### PR TITLE
Fixed many typos in all files with Antidote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,290 @@ output/
 *.png
 .idea/workspace.xml
 build/
+
+
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib
+

--- a/src/control/actuatorcontrol.tex
+++ b/src/control/actuatorcontrol.tex
@@ -7,7 +7,7 @@
 
 \section{Comportement des moteurs électriques}
 
-\section{Comportement des vérin pneumatiques}
+\section{Comportement des vérins pneumatiques}
 
 \section{Actionneur de type series-elastic}
 

--- a/src/control/control.tex
+++ b/src/control/control.tex
@@ -1,33 +1,33 @@
 \chapter{Introduction à la commande des systèmes robotisés}
 \label{sec:introcommanderobots}
 
-La science de "la commande" traite du développement d'algorithmes qui déterminent les actions qu'un système robotisé doit prendre en fonction de la situation pour atteindre un objectif (par exemple une position cible). Ces algorithmes sont généralement implémentés sur un micro-contrôleur, qui choisit les actions des actionneurs (par exemple le couple des moteurs électriques). Mathématiquement, le problème consiste à choisir les termes qui représentent les actions possible dans un système d'équations différentielles qui représentent le comportement du robot, afin d'obtenir le comportement désiré.
+La science de "la commande" traite du développement d'algorithmes qui déterminent les actions qu'un système robotisé doit prendre en fonction de la situation pour atteindre un objectif (par exemple une position cible). Ces algorithmes sont généralement implémentés sur un microcontrôleur, qui choisit les actions des actionneurs (par exemple le couple des moteurs électriques). Mathématiquement, le problème consiste à choisir les termes qui représentent les actions possibles dans un système d'équations différentielles qui représentent le comportement du robot, afin d'obtenir le comportement désiré.
 
-Lors de la conception des lois de commandes, plusieurs aspects (illustrés qualitativement à la Figure \ref{fig:controlgoal}) peuvent être analysés selon le contexte: 
+Lors de la conception des lois de commandes, plusieurs aspects (illustrés qualitativement à la Figure \ref{fig:controlgoal}) peuvent être analysés selon le contexte:
 
-\paragraph{La stabilité} 
+\paragraph{La stabilité}
 
-Lorsqu'une loi de commande est proposée, un critère essentiel dans la plupart des situations est la stabilité du système. La stabilité caractérise si les états du systèmes converge vers les états désirés ou bien si ils divergent. 
+Lorsqu'une loi de commande est proposée, un critère essentiel dans la plupart des situations est la stabilité du système. La stabilité caractérise si les états du système convergent vers les états désirés ou bien s’ils divergent.
 
-\paragraph{La faisabilité} 
+\paragraph{La faisabilité}
 
-Dans certain contextes, principalement ceux ou les actions possibles sont limités (ex. couple maximum des moteurs), on s'intéresse tout simplement à savoir si il existe une séquence d'actions possibles qui peuvent permettre au système d'atteindre l'objectif. 
+Dans certains contextes, principalement ceux où les actions possibles sont limitées (ex. couple maximum des moteurs), on s'intéresse tout simplement à savoir s’il existe une séquence d'actions possibles qui peuvent permettre au système d'atteindre l'objectif.
 
-\paragraph{Le temps de réponse} 
+\paragraph{Le temps de réponse}
 
-La stabilité et la faisabilité détermine si le système pourra atteindre l'objectif. Ensuite, on cherche généralement à atteindre l'objectif le plus rapidement possible ce qui est caractérisé par le temps de réponse. Un critère relié est la "bande passante" du système, la "vitesse" du système exprimée dans le domaine fréquentiel.
+La stabilité et la faisabilité déterminent si le système pourra atteindre l'objectif. Ensuite, on cherche généralement à atteindre l'objectif le plus rapidement possible ce qui est caractérisé par le temps de réponse. Un critère relié est la "bande passante" du système, la "vitesse" du système exprimée dans le domaine fréquentiel.
 
-\paragraph{L'optimalité} 
+\paragraph{L'optimalité}
 
-Il y a généralement un compromis à faire entre la vitesse (le temps de réponse) et l'utilisation agressive des actions possibles du système qui ont généralement un coût énergétique. Un objectif commun lors de la conception d'un asservissement est de maximiser la performance. La maximisation de la performance dans le domaine de la commande est généralement formulé comme la minimisation d'un coût qui combine les dépenses énergétiques et le temps passé loin de l'objectif.
+Il y a généralement un compromis à faire entre la vitesse (le temps de réponse) et l'utilisation agressive des actions possibles du système qui ont généralement un coût énergétique. Un objectif commun lors de la conception d'un asservissement est de maximiser la performance. La maximisation de la performance dans le domaine de la commande est généralement formulée comme la minimisation d'un coût qui combine les dépenses énergétiques et le temps passé loin de l'objectif.
 
-\paragraph{La robustesse} Finalement, dans plusieurs situations il faut considérer l'incertitude dans le système lors de la conception des lois de commande. L'incertitude peut être due à des perturbations externes inconnues (ex.: rafales de vent pour un avion) ou bien à des paramètres incertains du système robotique (ex.: poids de la charge transportée pour un bras manipulateur). L'analyse de robustesse consiste à vérifier si les lois de commandes vont fonctionner dans divers scénarios possibles. Des méthodes existe pour garantir le fonctionnement d'un contrôleur malgré un certain niveau d'incertitude (commande robuste ou commande adaptative).
+\paragraph{La robustesse} Finalement, dans plusieurs situations il faut considérer l'incertitude dans le système lors de la conception des lois de commande. L'incertitude peut être due à des perturbations externes inconnues (ex.: rafales de vent pour un avion) ou bien à des paramètres incertains du système robotique (ex.: poids de la charge transportée pour un bras manipulateur). L'analyse de robustesse consiste à vérifier si les lois de commandes vont fonctionner dans divers scénarios possibles. Des méthodes existent pour garantir le fonctionnement d'un contrôleur malgré un certain niveau d'incertitude (commande robuste ou commande adaptative).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.9\textwidth]{fig/controlgoal.jpg}
-	\caption{Différents aspects qui sont peuvent être considéré lors de la conception de loi de commandes}
+	\includegraphics[width=0.9\textwidth]{fig/controlgoal.jpg}
+	\caption{Différents aspects qui sont peuvent être considérés lors de la conception de loi de commandes}
 	\label{fig:controlgoal}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -35,41 +35,41 @@ Il y a généralement un compromis à faire entre la vitesse (le temps de répon
 
 \section{Architectures}
 
-Cette section introduits aux grandes catégories d'architecture de commande pour les systèmes robotisées. 
+Cette section introduit les grandes catégories d'architecture de commande pour les systèmes robotisés.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Boucle ouverte vs. boucle fermée}
 
-La méthode de commande la plus simple est appelée boucle ouverte, voir Figure \ref{fig:openloop}. Par exemple, on détermine une séquence d'action pour les actionneurs (plan) qui va théoriquement faire bouger un système robotisé d'un point A au point B (objectif). Dans ce cas, la loi de commande est seulement une fonction du temps qui envoi les consignes pré-déterminés aux actionneurs. 
+La méthode de commande la plus simple est appelée boucle ouverte, voir Figure \ref{fig:openloop}. Par exemple, on détermine une séquence d'action pour les actionneurs (plan) qui va théoriquement faire bouger un système robotisé d'un point $A$ au point $B$ (objectif). Dans ce cas, la loi de commande est seulement une fonction du temps qui envoie les consignes prédéterminées aux actionneurs.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.7\textwidth]{fig/openloop.jpg}
+	\includegraphics[width=0.7\textwidth]{fig/openloop.jpg}
 	\caption{Boucle ouverte}
 	\label{fig:openloop}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-En général, cette méthode que l'on pourrait qualifier "d'aveugle" fonctionne seulement lorsque les systèmes ont très peu d'incertitude. Par exemple, une machine outil qui lit un code-G et traduit directement les instructions en consignes pour ses moteurs pas à pas est une approche purement boucle ouverte. Par contre, on peut facilement s'imaginer que cette approche ne fonctionnerait pas pour une voiture autonome qui doit aller d'une ville à une autre. Un voiture automne qui utiliserait un contrôleur basé sur une séquence d'angle de volant pré-déterminée divergerait rapidement de la trajectoire désirée du aux incertitudes. 
+En général, cette méthode que l'on pourrait qualifier "d'aveugle" fonctionne seulement lorsque les systèmes ont très peu d'incertitude. Par exemple, une machine-outil qui lit un code-G et traduit directement les instructions en consignes pour ses moteurs pas à pas est une approche purement boucle ouverte. Par contre, on peut facilement s'imaginer que cette approche ne fonctionnerait pas pour une voiture autonome qui doit aller d'une ville à une autre. Une voiture automne qui utiliserait un contrôleur basé sur une séquence d'angles de volant prédéterminés divergerait rapidement de la trajectoire désirée due aux incertitudes.
 
-La plupart des contrôleurs utilisent une rétroaction continue basé sur des capteurs pour vérifier si le système évolue de façon approprié. C'est ce qu'on appelle l'approche boucle fermée,  illustré à la Figure \ref{fig:closedloop}. Dans ce cas, la loi de commande est une généralement fonction d'une erreur qui résulte de la comparaison de la position cible et la position réelle mesurée par des capteurs. 
+La plupart des contrôleurs utilisent une rétroaction continue basée sur des capteurs pour vérifier si le système évolue de façon appropriée. C'est ce qu'on appelle l'approche boucle fermée,  illustré à la Figure \ref{fig:closedloop}. Dans ce cas, la loi de commande est une généralement fonction d'une erreur qui résulte de la comparaison de la position cible et la position réelle mesurée par des capteurs.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.7\textwidth]{fig/closedloop.jpg}
+	\includegraphics[width=0.7\textwidth]{fig/closedloop.jpg}
 	\caption{Boucle fermée}
 	\label{fig:closedloop}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Le principe de base d'une telle loi de commande peut se résumer à: si le système est trop à gauche pousse vers la droite et si le système est trop à droite pousse vers la gauche. Cette approche fonctionne bien pour des systèmes simples. Par exemple, pour contrôler la position d'un vérin électrique une loi de commande de type "pousse dans le sens inverse de l'erreur" est suffisante. Toutefois pour une voiture autonome, si la direction et la vitesse à prendre serait basée sur l'erreur totale, par exemple 150 km NW par rapport à la ville que l'on désire aller, la voiture tenterais de traverser des champs en ligne droite! Pour les systèmes plus compliqués, particulièrement avec des limites comme des obstacles, des saturations d'actionneurs, etc, le contrôleur n'est pas simplement une fonction de l'erreur.
+Le principe de base d'une telle loi de commande peut se résumer à: si le système est trop à gauche, pousse vers la droite, et si le système est trop à droite, pousse vers la gauche. Cette approche fonctionne bien pour des systèmes simples. Par exemple, pour contrôler la position d'un vérin électrique une loi de commande de type "pousse dans le sens inverse de l'erreur" est suffisante. Toutefois pour une voiture autonome, si la direction et la vitesse à prendre serait basée sur l'erreur totale, par exemple 150 km NW par rapport à la ville que l'on désire aller, la voiture tenterait de traverser des champs en ligne droite! Pour les systèmes plus compliqués, particulièrement avec des limites comme des obstacles, des saturations d'actionneurs, etc., le contrôleur n'est pas simplement une fonction de l'erreur.
 
-Pour plusieurs systèmes robotiques, une loi de commande hybride est utilisée comme illustré à la Figure \ref{fig:trajectoryfollowingcontroller}. Un plan est déterminé comme avec l'approche en boucle ouverte, toutefois un contrôleur en boucle fermée qui agit sur l'erreur par rapport à la trajectoire cible est ensuite utilisé. La loi de commande dans ce cas, ne dépend pas seulement de la position actuel et de la position désirée, mais aussi du temps car elle compare la position actuelle à celle ou le robot doit théorique être rendu à ce moment. 
+Pour plusieurs systèmes robotiques, une loi de commande hybride est utilisée comme illustré à la Figure \ref{fig:trajectoryfollowingcontroller}. Un plan est déterminé comme avec l'approche en boucle ouverte, toutefois un contrôleur en boucle fermée qui agit sur l'erreur par rapport à la trajectoire cible est ensuite utilisé. La loi de commande dans ce cas, ne dépend pas seulement de la position actuelle et de la position désirée, mais aussi du temps, car elle compare la position actuelle à celle ou le robot doit théorique être rendu à ce moment.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.8\textwidth]{fig/trajectoryfollowingcontroller.jpg}
+	\includegraphics[width=0.8\textwidth]{fig/trajectoryfollowingcontroller.jpg}
 	\caption{Contrôleur de suivi de trajectoire}
 	\label{fig:trajectoryfollowingcontroller}
 \end{figure}
@@ -80,62 +80,63 @@ Pour plusieurs systèmes robotiques, une loi de commande hybride est utilisée c
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Boucles imbriquées}
 
-La plupart des systèmes robotiques n'ont pas un seul gros contrôleur qui contrôle toutes les actions des actionneurs de façon centralisé, mais plutôt plusieurs sous-systèmes avec chacun des contrôleur locaux. Par exemple, lorsqu'un système robotisé utilise des servo-moteurs, l'électronique des moteurs inclus déjà un contrôleur qui effectue un asservissement en position ou en vitesse. 
+La plupart des systèmes robotiques n'ont pas un seul gros contrôleur qui contrôle toutes les actions des actionneurs de façon centralisée, mais plutôt plusieurs sous-systèmes avec chacun des contrôleurs locaux. Par exemple, lorsqu'un système robotisé utilise des servomoteurs, l'électronique des moteurs inclut déjà un contrôleur qui effectue un asservissement en position ou en vitesse.
 
-Une architecture qui est souvent utilisée pour les robots manipulateur est illustrée à la Figure \ref{fig:innerloop}. Chaque joint du robot du robot a sont propre contrôleur en vitesse qui recoit une consigne d'un contrôleur central. Les contrôleurs locaux comparent la vitesse du joint désirée à une mesure de vitesse et détermine un couple moteur selon l'erreur en vitesse. Le contrôleur central lui compare la position cible à la position mesurée du robot et détermine le mouvement (consignes de vitesse) que les joints devraient faire pour corriger la position.
+Une architecture qui est souvent utilisée pour les robots manipulateurs est illustrée à la Figure \ref{fig:innerloop}. Chaque joint du robot a son propre contrôleur en vitesse qui reçoit une consigne d'un contrôleur central. Les contrôleurs locaux comparent la vitesse du joint désirée à une mesure de vitesse et déterminent un couple moteur selon l'erreur en vitesse. Le contrôleur central lui compare la position cible à la position mesurée du robot et détermine le mouvement (consignes de vitesse) que les joints devraient faire pour corriger la position.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.9\textwidth]{fig/innerloop.jpg}
+	\includegraphics[width=0.9\textwidth]{fig/innerloop.jpg}
 	\caption{Boucles imbriquées}
 	\label{fig:innerloop}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Cette approche a comme avantage de découpler le problème en deux problèmes plus simples et rendre plus modulaires les loi de commande qui sont développée. Par exemple, le concepteur du contrôleur des moteurs pourrait effectuer sont travail sans ce soucier du modèle cinématique compliqué du bras manipulateur. Inversement, le concepteur du contrôleur central du robot pourrait travailler avec un modèle purement cinématique du robot (plutôt que les équations dynamiques qui relient les couples moteurs aux accélérations), en assumant que les boucles en vitesse des moteurs fonctionnent et sont rapide. Dans ces conditions, comme illustré à la Figure \ref{fig:innerloop2}, le concepteur du contrôleur central aurait un problème classique avec une seule boucle fermée, mais sont modèle du système considère les contrôleurs de moteurs. 
+Cette approche a comme avantage de découpler le problème en deux problèmes plus simples et rendre plus modulaires les lois de commande qui sont développées. Par exemple, le concepteur du contrôleur des moteurs pourrait effectuer son travail sans se soucier du modèle cinématique compliqué du bras manipulateur. Inversement, le concepteur du contrôleur central du robot pourrait travailler avec un modèle purement cinématique du robot (plutôt que les équations dynamiques qui relient les couples moteurs aux accélérations), en assumant que les boucles en vitesse des moteurs fonctionnent et sont rapides. Dans ces conditions, comme illustré à la Figure \ref{fig:innerloop2}, le concepteur du contrôleur central aurait un problème classique avec une seule boucle fermée, mais son modèle du système considère les contrôleurs de moteurs.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.7\textwidth]{fig/innerloop2.jpg}
+	\includegraphics[width=0.7\textwidth]{fig/innerloop2.jpg}
 	\caption{Boucle fermée du contrôleur central}
 	\label{fig:innerloop2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Il est donc important de noté que le modèle utilisé pour la conception du ou des contrôleurs d'un système robotisé doit être adapté au contexte et à l'architecture utilisée. 
+Il est donc important de noter que le modèle utilisé pour la conception du ou des contrôleurs d'un système robotisé doit être adapté au contexte et à l'architecture utilisée.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Synthétisation d'un plan hors-ligne ou en-ligne}
 
-Un autre aspect pour les méthodes de commandes avancées qui utilise beaucoup de calculs numériques, est qu'est-ce qui est calculé d'avance vs. en temps réel durant l'exécution du contrôleur. 
+Un autre aspect pour les méthodes de commandes avancées qui utilisent beaucoup de calculs numériques, est qu'est-ce qui est calculé d'avance vs. en temps réel durant l'exécution du contrôleur.
 
 Une architecture souvent utilisée avec les algorithmes de planification/optimisation de trajectoire (ex. RRT) est illustrée à la Figure \ref{fig:offlinetrajectorygeneration}. Les calculs lourds de rechercher et/ou optimisation sont effectués d'avance, et lors de l'exécution la loi de commande utilise seulement la trajectoire cible qui a été synthétisée hors-ligne.
+%% TODO: Les calculs lourds de quoi? %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.9\textwidth]{fig/offlinetrajectorygeneration.jpg}
+	\includegraphics[width=0.9\textwidth]{fig/offlinetrajectorygeneration.jpg}
 	\caption{Générateur de trajectoire hors-ligne}
 	\label{fig:offlinetrajectorygeneration}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-De façon similaire, les méthodes comme \textit{LQR} ou bien \textit{value-iteration} effectue des calculs généralement hors-ligne pour synthétisé une loi de commande sous forme de carte $\col{u} = c(\col{x})$ de quelles actions $\col{u}$ prendre en fonction des états mesurés $\col{x}$ du robot. C'est donc ici une fonction qui est synthétisée hors-ligne et utilisée en-ligne, voir Figure \ref{fig:offlinecontrollergeneration}. La fonction synthétisée peut-être analytique, par exemple pour la méthode \textit{LQR} avec un format $\col{u} = K \col{x}$, ou bien numérique, comme par exemple pour un contrôleur synthétisé avec la méthode \textit{value-iteration}. 
+De façon similaire, les méthodes comme \textit{LQR} ou bien \textit{value-iteration} effectue des calculs généralement hors-ligne pour synthétiser une loi de commande sous forme de carte $\col{u} = c(\col{x})$ de quelles actions $\col{u}$ prendre en fonction des états mesurés $\col{x}$ du robot. C'est donc ici une fonction qui est synthétisée hors-ligne et utilisée en-ligne, voir Figure \ref{fig:offlinecontrollergeneration}. La fonction synthétisée peut -être analytique, par exemple pour la méthode \textit{LQR} avec un format $\col{u} = K \col{x}$, ou bien numérique, par exemple pour un contrôleur synthétisé avec la méthode \textit{value-iteration}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.9\textwidth]{fig/offlinecontrollergeneration.jpg}
+	\includegraphics[width=0.9\textwidth]{fig/offlinecontrollergeneration.jpg}
 	\caption{Génération de contrôleur hors-ligne}
 	\label{fig:offlinecontrollergeneration}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Ensuite, certain type de contrôleurs de systèmes robotiques vont avoir une certaine forme de synthétisation de trajectoire ou de contrôleur mais en ligne, voir un exemple à la Figure \ref{fig:onlinetrajectorygeneration}. Typiquement, du au lourd calcul numérique qui doivent être fait en ligne, les architectures vont aussi utilisée des boucles imbriquée avec une boucle interne plus rapide et une boucle externe plus lente qui met à jour la trajectoire cible. L'approche de commande prédictive (MPC Model Predictive Control), est un exemple ou on optimise des trajectoire cible constament en ligne dans la boucle. 
+Ensuite, certains types de contrôleurs de systèmes robotiques vont avoir une certaine forme de synthétisation de trajectoire ou de contrôleur, mais en ligne, voir un exemple à la Figure \ref{fig:onlinetrajectorygeneration}. Typiquement, dû au lourd calcul numérique qui doit être fait en ligne, les architectures vont aussi utiliser des boucles imbriquées avec une boucle interne plus rapide et une boucle externe plus lente qui met à jour la trajectoire cible. L'approche de commande prédictive (MPC Model Predictive Control) est un exemple où l'on optimise des trajectoires cibles constamment en ligne dans la boucle.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.9\textwidth]{fig/onlinetrajectorygeneration.jpg}
+	\includegraphics[width=0.9\textwidth]{fig/onlinetrajectorygeneration.jpg}
 	\caption{Génération de trajectoire en ligne}
 	\label{fig:onlinetrajectorygeneration}
 \end{figure}
@@ -149,8 +150,9 @@ Ensuite, certain type de contrôleurs de systèmes robotiques vont avoir une cer
 
 
 % \begin{figure}[htbp]
-% 	\centering
-% 		\includegraphics[width=1.00\textwidth]{boucleouverte.png}
-% 	\caption{Boucle ouverte}
-% 	\label{fig:boucleouverte}
+%  \centering
+%     \includegraphics[width=1.00\textwidth]{boucleouverte.png}
+%  \caption{Boucle ouverte}
+%  \label{fig:boucleouverte}
 % \end{figure}
+

--- a/src/control/robotcontrolstatic.tex
+++ b/src/control/robotcontrolstatic.tex
@@ -1,14 +1,14 @@
 \chapter{Commande des robots manipulateurs I: quasi-statique}
 \label{sec:staticcontrol}
 
+%% TODO: à la fin du paragraphe, on parle des section 4.5 et XXX %%
+Les objectifs en termes de mouvement désiré d'un robot sont généralement plus naturellement spécifiés en termes de variables dans l'espace de la tâche d'un robot, alors qu’ à bas niveau les consignes des actionneurs sont reliées à des variables dans l'espace des joints. Ce chapitre présente des méthodes de commande qui permettent de calculer les consignes pour les actionneurs basés sur des objectifs directement spécifiés dans l'espace de la tâche, malgré la relation géométrique hautement non linéaire. Les méthodes présentées ici utilisent grandement les notions de cinématique différentielle et de statique présentés dans les sections \ref{sec:differentialkinematicmanipulators} et XXX.
 
-Les objectifs en termes de mouvement désiré d'un robot sont généralement plus naturellement spécifiés en termes de variables dans l'espace de la tâche d'un robot, alors que à bas niveau les consignes des actionneurs sont reliés à des variables dans l'espace des joints. Ce chapitre présente des méthodes de commande qui permettent de calculer les consignes pour les actionneurs basé sur des objectifs directement spécifié dans l'espace de la tâche, malgré la relation géométrique hautement non-linéaire. Les méthodes ici présenté utilisent grandement les notions de cinématique différentiel et de statique présentés dans les sections \ref{sec:differentialkinematicmanipulators} et XXX.
+Les méthodes présentées dans ce chapitre négligent les effets dynamiques (inerties, frottement, etc.) et considèrent juste un comportement simplifié des robots: la relation statique non linéaire entre le mouvement/force des actionneurs et le mouvement/force à l'effecteur. Ces méthodes sont généralement performantes lorsque les mouvements du robot sont relativement lents, c'est pourquoi ils sont regroupés ici sous la caractéristique "quasi-statique". Ensuite, selon la nature des actionneurs des systèmes robotiques, différentes variantes peuvent être utilisées:
 
-Les méthodes présentés dans ce chapitre négligent les effets dynamiques (inerties, frottement, etc.) et considèrent juste un comportement simplifié des robots: la relation statique non-linéaire entre le mouvement/force des actionneurs et le mouvement/force à l'effecteur. Ces méthodes sont généralement performante lorsque les mouvements du robot sont relativement lents, c'est pourquoi ils sont ici regroupé sous la caractéristique "quasi-statique". Ensuite, selon la nature des actionneurs des systèmes robotiques, différentes variantes peuvent être utilisée:
+\paragraph{Actionneurs commandés en vitesse:} Pour les méthodes de commande du mouvement de l'effecteur présentées aux sections \ref{sec:speedcontrol}, \ref{sec:positioncontrol} et \ref{sec:admcontrol}, il est considéré que le robot a des asservissements bas-niveau en vitesse à chacun des joints. Ces méthodes calculent les consignes en vitesse à envoyer aux joints pour contrôler le mouvement de l'effecteur. Ces méthodes fonctionnent bien dans des situations ou le suivi de consigne en vitesse des joints est très performant, c'est généralement le cas des manipulateurs industriels qui ont de très grands ratios de réduction.
 
-\paragraph{Actionneurs commandés en vitesse:} Pour les méthodes de commande du mouvement de l'effecteur présentées aux sections \ref{sec:speedcontrol}, \ref{sec:positioncontrol} et \ref{sec:admcontrol}, il est considéré que le robot a des asservissements bas-niveau en vitesse à chacun des joints. Ces méthodes calculent les consignes en vitesse à envoyer aux joints pour contrôler le mouvement de l'effecteur. Ces méthodes fonctionnent bien dans des situations ou le suivi de consigne en vitesse des joints est très performant, c'est généralement le cas des manipulateurs industriels qui ont de très grand ratios de réduction. 
-
-\paragraph{Actionneurs commandés en force:} Pour les méthodes de commande présentées aux section \ref{sec:forcecontrol} et \ref{sec:impcontrol}, on considère seulement la relation géométrique entre les forces des actionneurs et ceux à l'effecteur. Les deux méthodes calculent des forces à appliquer au niveau des actionneurs/joint, pour contrôler la force au niveau de l'effecteur. Ces méthodes fonctionnent donc bien pour des systèmes robotisées à basse impédance (peu d'inertie, peu d'effets dissipatifs, transmission réversibles, etc.), comme les systèmes haptiques où les forces des actionneurs sont pratiquement proportionnelles au courant dans les moteurs du à des très petits ratio de transmissions.
+\paragraph{Actionneurs commandés en force:} Pour les méthodes de commande présentées aux sections \ref{sec:forcecontrol} et \ref{sec:impcontrol}, on considère seulement la relation géométrique entre les forces des actionneurs et ceux à l'effecteur. Les deux méthodes calculent des forces à appliquer au niveau des actionneurs/joints, pour contrôler la force au niveau de l'effecteur. Ces méthodes fonctionnent donc bien pour des systèmes robotisés à basse impédance (peu d'inertie, peu d'effets dissipatifs, transmissions réversibles, etc.), comme les systèmes haptiques où les forces des actionneurs sont pratiquement proportionnelles au courant dans les moteurs dus à de très petits ratios de transmissions.
 
 
 
@@ -18,38 +18,38 @@ Les méthodes présentés dans ce chapitre négligent les effets dynamiques (ine
 \label{sec:speedcontrol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Si un robot a des actionneurs contrôlés en vitesse à bas niveau, contrôler la vitesse de l'effecteur se résume à mettre en oeuvre la relation de cinématique différentielle inverse (voir section \ref{sec:differentialkinematicmanipulators}).  Comme illustré par un schéma bloc à la Figure \ref{fig:robotspeedcontrol}, les consignes en vitesse pour les actionneurs sont déterminées en multipliant le vecteur-colonne de vitesses désirés dans l'espace des tâches, par l'inverse du Jacobien qui relie l'espace des joints à l'espace des tâches du systèmes. Le Jacobien est généralement dépendent de la position des joints du robot ce qui nécessite une boucle de rétroaction basé sur les capteurs de position des actionneurs pour effectuer le calcul de $J$ en continu basé sur la position actuelle des joints. Finalement, comme mis en évidence à la Figure \ref{fig:robotspeedcontrol}, cette méthode s'intègre comme une boucle haut-niveau pour coordonner les différents joints d'un système robotisé où chacun des actionneurs est asservis en vitesse, souvent avec des asservissements bas-niveaux implémentées directement dans l'électronique de contrôle des moteurs. 
+Si un robot a des actionneurs contrôlés en vitesse à bas niveau, contrôler la vitesse de l'effecteur se résume à mettre en œuvre la relation de cinématique différentielle inverse (voir section \ref{sec:differentialkinematicmanipulators}).  Comme illustré par un schéma bloc à la Figure \ref{fig:robotspeedcontrol}, les consignes en vitesse pour les actionneurs sont déterminées en multipliant le vecteur-colonne de vitesses désirées dans l'espace des tâches, par l'inverse du Jacobien qui relie l'espace des joints à l'espace des tâches du système. Le Jacobien est généralement dépendent de la position des joints du robot ce qui nécessite une boucle de rétroaction basée sur les capteurs de position des actionneurs pour effectuer le calcul de $J$ en continu basé sur la position actuelle des joints. Finalement, comme mis en évidence à la Figure \ref{fig:robotspeedcontrol}, cette méthode s'intègre comme une boucle haut-niveau pour coordonner les différents joints d'un système robotisé où chacun des actionneurs est asservi en vitesse, souvent avec des asservissements bas-niveaux implémentés directement dans l'électronique de contrôle des moteurs.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.7\textwidth]{fig/robotspeedcontrol.jpg}
+	\includegraphics[width=0.7\textwidth]{fig/robotspeedcontrol.jpg}
 	\caption{Commande de la vitesse de l'effecteur d'un robot : schéma bloc}
 	\label{fig:robotspeedcontrol}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Si le nombre de joints $n$ est égale au nombre de DDL de l'espace de la tâche $m$, alors la matrice Jacobien est carrée et peut être inversée (sauf sur les singularités). Si le nombre de joint $n$ est supérieur au nombre de DDL de l'espace de la tâche $m$, alors on peut utiliser une matrice pseudo-inverse droite $J^{\#} = J^T (J J^T)^{-1}$ (voir section \ref{sec:pseudoinverse}). La loi de commande en équation peut donc être exprimée comme:
+Si le nombre de joints $n$ est égal au nombre de DDL de l'espace de la tâche $m$, alors la matrice Jacobienne est carrée et peut être inversée (sauf sur les singularités). Si le nombre de joints $n$ est supérieur au nombre de DDL de l'espace de la tâche $m$, alors on peut utiliser une matrice pseudo-inverse droite $J^{\#} = J^T (J J^T)^{-1}$ (voir section \ref{sec:pseudoinverse}). La loi de commande en équation peut donc être exprimée comme:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{q}} = \left\{ \begin{array}{c}
- J(\col{q})^{-1} \dot{\col{r}_d}   \quad\quad \text{if $n=m$}
- \\ \\
- J(\col{q})^{\#} \, \dot{\col{r}_d}   \quad\quad \text{if $n>m$}
-\end{array}
-\right.
+	\dot{\col{q}} = \left\{ \begin{array}{c}
+								J(\col{q})^{-1} \dot{\col{r}_d}   \quad\quad \text{if $n=m$}
+								\\ \\
+								J(\col{q})^{\#} \, \dot{\col{r}_d}   \quad\quad \text{if $n>m$}
+	\end{array}
+	\right.
 \end{align}
 %%%%%%%%%%%%%%%%%
 
 En substituant la loi de commande dans la relation de cinématique différentielle, on confirme que la vitesse de l'effecteur sera exactement la vitesse désirée:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{r}} &= J(\col{q}) \, \dot{\col{q}} \\
-\dot{\col{r}} &= J(\col{q}) \, J(\col{q})^{\#} \, \dot{\col{r}_d} \\
-\dot{\col{r}} &= J J^T (J J^T)^{-1} \, \dot{\col{r}_d} \\
-\dot{\col{r}} &=  \col{\dot{r}_d} 
+	\dot{\col{r}} &= J(\col{q}) \, \dot{\col{q}} \\
+	\dot{\col{r}} &= J(\col{q}) \, J(\col{q})^{\#} \, \dot{\col{r}_d} \\
+	\dot{\col{r}} &= J J^T (J J^T)^{-1} \, \dot{\col{r}_d} \\
+	\dot{\col{r}} &=  \col{\dot{r}_d}
 \end{align}
 %%%%%%%%%%%%%%%%%
-sous les hypothèses que: 1) le Jacobien utilisé par le contrôleur est exacte, 2) le Jacobien est inversible (i.e. le robot n'est pas sur une singularité) et 3) la vitesse des joints est parfaitement asservis par les boucles bas-niveaux. 
+sous les hypothèses que: 1) le Jacobien utilisé par le contrôleur est exacte, 2) le Jacobien est inversible (c.-à-d. le robot n'est pas sur une singularité) et 3) la vitesse des joints est parfaitement asservie par les boucles bas-niveau.
 
 
 
@@ -60,11 +60,13 @@ sous les hypothèses que: 1) le Jacobien utilisé par le contrôleur est exacte,
 \label{sec:positioncontrol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Pour commander la position de l'effecteur d'un robot, tenter de trouver une solution directement au problème de cinématique inverse (voir section \ref{sec:invkin}) n'est généralement pas la méthode la plus appropriée car la cinématique directe des manipulateurs est hautement non-linéaire. La méthode ici présentée utilise plutôt la méthode de commande en vitesse de l'effecteur (section \ref{sec:speedcontrol}) pour indirectement résoudre la cinématique inverse du robot. Le principe ce résume au fait que pour contrôler la position de l'effecteur de façon, il suffit de diriger le vecteur vitesse de l'effecteur vers la position cible. La méthode est illustrée graphiquement à la Figure \ref{fig:robotspeedcontrolgeo}: 1) Un vecteur d'erreur $\col{r}_e$ est calculé en comparant la position désirée $\col{r}_d$ à la position actuelle $\col{r}$. 2) Le vecteur d'erreur $\col{r}_e$ est multiplié par un paramètre scalaire $\lambda$ pour déterminer la vitesse cible instantanée pour l'effecteur notée $\dot{\col{r}}_r$, qui pointe en direction de la cible. 3) L'inverse du Jacobien est utilisé pour convertir la vitesse instantanée désirée de l'effecteur en consigne de vitesse pour les joints. 
+Pour commander la position de l'effecteur d'un robot, tenter de trouver une solution directement au problème de cinématique inverse (voir section \ref{sec:invkin}) n'est généralement pas la méthode la plus appropriée, car la cinématique directe des manipulateurs est hautement non-linéaire. La méthode ici présentée utilise plutôt la méthode de commande en vitesse de l'effecteur (section \ref{sec:speedcontrol}) pour indirectement résoudre la cinématique inverse du robot. Le principe se résume au fait que pour contrôler la position de l'effecteur de façon,
+%%TODO: de façon quoi?%%
+il suffit de diriger le vecteur vitesse de l'effecteur vers la position cible. La méthode est illustrée graphiquement à la Figure \ref{fig:robotspeedcontrolgeo}: 1) Un vecteur d'erreur $\col{r}_e$ est calculé en comparant la position désirée $\col{r}_d$ à la position actuelle $\col{r}$. 2) Le vecteur d'erreur $\col{r}_e$ est multiplié par un paramètre scalaire $\lambda$ pour déterminer la vitesse cible instantanée pour l'effecteur noté $\dot{\col{r}}_r$, qui pointe en direction de la cible. 3) L'inverse du Jacobien est utilisé pour convertir la vitesse instantanée désirée de l'effecteur en consigne de vitesse pour les joints.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.4\textwidth]{fig/robotspeedcontrolgeo.jpg}
+	\includegraphics[width=0.4\textwidth]{fig/robotspeedcontrolgeo.jpg}
 	\caption{Commande de la trajectoire de l'effecteur d'un robot : interprétation géométrique}
 	\label{fig:robotspeedcontrolgeo}
 \end{figure}
@@ -72,21 +74,21 @@ Pour commander la position de l'effecteur d'un robot, tenter de trouver une solu
 Formellement, la loi de commande est exprimée par l'expression mathématique:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{q}} = \left\{ \begin{array}{c}
- J(\col{q})^{-1} \lambda 
- \underbrace{ \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right) }_{\col{r}_e} 
- \quad\quad \text{if $n=m$}
- \\ \\
- J(\col{q})^{\#} \, \lambda  \underbrace{ \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right) }_{\col{r}_e}    \quad\quad \text{if $n>m$}
-\end{array}
-\right.
+	\dot{\col{q}} = \left\{ \begin{array}{c}
+								J(\col{q})^{-1} \lambda
+								\underbrace{ \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right) }_{\col{r}_e}
+								\quad\quad \text{if $n=m$}
+								\\ \\
+								J(\col{q})^{\#} \, \lambda  \underbrace{ \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right) }_{\col{r}_e}    \quad\quad \text{if $n>m$}
+	\end{array}
+	\right.
 \end{align}
 %%%%%%%%%%%%%%%%%
-ou $\lambda$ est un paramètre scalaire de gain du contrôleur, $J$ est le Jacobien, la matrice $n \times m$, qui relie l'espace des joints à l'espace de la tâche du manipulateur, et $f(\col{q})$ la fonction de cinématique directe du manipulateur. La Figure \ref{fig:robotspeedcontrolpos} illustre cette méthode de commande sous la forme d'un schéma bloc. 
+où $\lambda$ est un paramètre scalaire de gain du contrôleur, $J$ est le Jacobien, la matrice $n \times m$, qui relie l'espace des joints à l'espace de la tâche du manipulateur, et $f(\col{q})$ la fonction de cinématique directe du manipulateur. La Figure \ref{fig:robotspeedcontrolpos} illustre cette méthode de commande sous la forme d'un schéma bloc.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.7\textwidth]{fig/robotspeedcontrolpos.jpg}
+	\includegraphics[width=0.7\textwidth]{fig/robotspeedcontrolpos.jpg}
 	\caption{Commande de la position de l'effecteur d'un robot : schéma bloc}
 	\label{fig:robotspeedcontrolpos}
 \end{figure}
@@ -108,19 +110,19 @@ ou $\lambda$ est un paramètre scalaire de gain du contrôleur, $J$ est le Jacob
 Lorsque le robot doit suivre une position cible de l'effecteur qui varie dans le temps, il est préférable de calculer la dérivée temporelle de la trajectoire et d'utiliser cette information directement dans la loi de commande comme indiqué dans l'équation suivante:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{q}} = \left\{ \begin{array}{c}
- J(\col{q})^{-1} \left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}} \right) \right] \quad\quad \text{if $n=m$}
- \\ \\
- J(\col{q})^{\#} \, \left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}} \right) \right]   \quad\quad \text{if $n>m$}
-\end{array}
-\right.
+	\dot{\col{q}} = \left\{ \begin{array}{c}
+								J(\col{q})^{-1} \left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}} \right) \right] \quad\quad \text{if $n=m$}
+								\\ \\
+								J(\col{q})^{\#} \, \left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}} \right) \right]   \quad\quad \text{if $n>m$}
+	\end{array}
+	\right.
 \end{align}
 %%%%%%%%%%%%%%%%%
-En terme de schéma bloc, la vitesse de la trajectoire doit être utilisée avec un feedfoward dans la loi de commande comme illustré à la Figure \ref{fig:robotspeedcontroltraj}, pour garantir la convergence sur la trajectoire.
+En termes de schéma bloc, la vitesse de la trajectoire doit être utilisée avec un feedfoward dans la loi de commande comme illustré à la Figure \ref{fig:robotspeedcontroltraj}, pour garantir la convergence sur la trajectoire.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.95\textwidth]{fig/robotspeedcontroltraj.jpg}
+	\includegraphics[width=0.95\textwidth]{fig/robotspeedcontroltraj.jpg}
 	\caption{Commande de la trajectoire de l'effecteur d'un robot : schéma bloc}
 	\label{fig:robotspeedcontroltraj}
 \end{figure}
@@ -129,119 +131,119 @@ En terme de schéma bloc, la vitesse de la trajectoire doit être utilisée avec
 
 \subsection{Convergence}
 
-Les méthodes de commande en position de l'effecteur converge sous certaines conditions. L'objectif peut être mathématiquement exprimé comme:
+Les méthodes de commande en position de l'effecteur convergent sous certaines conditions. L'objectif peut être mathématiquement exprimé comme:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\lim_{t \rightarrow \infty } \col{r}_e(t) = 0 
+	\lim_{t \rightarrow \infty } \col{r}_e(t) = 0
 \end{align}
 %%%%%%%%%%%%%%%%%
-c'est-à-dire l'erreur (sur la position de l'effecteur) doit converger vers zéro. L'erreur est une fonction de la trajectoire et de la positon réelle du robot:
+c'est-à-dire l'erreur (sur la position de l'effecteur) doit converger vers zéro. L'erreur est une fonction de la trajectoire et de la position réelle du robot:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_e = \col{r}_d - \col{r}
+	\col{r}_e = \col{r}_d - \col{r}
 \end{align}
 %%%%%%%%%%%%%%%%%
-Si on dérive cette équation dans le temps, on obtient une relation différentielle. On peut alors substituer le modèle de cinématique différentiel et les lois de commandes pour obtenir:
+Si l'on dérive cette équation dans le temps, on obtient une relation différentielle. On peut alors substituer le modèle de cinématique différentiel et les lois de commandes pour obtenir:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{r}}_e  &= \dot{\col{r}}_d - \dot{\col{r}} \\
-\dot{\col{r}}_e  &= \dot{\col{r}}_d - J(\col{q}) \dot{\col{q}} \\
-\dot{\col{r}}_e  &= \dot{\col{r}}_d - \underbrace{J(\col{q}) J(\col{q})^{\#} }_{1} \dot{\col{r}}_r \\
-\dot{\col{r}}_e  &= \dot{\col{r}}_d - \underbrace{J(\col{q}) J(\col{q})^{\#} }_{1}  \left( \dot{\col{r}}_d + \lambda \, \col{r}_e \right) \\
-\dot{\col{r}}_e  &= - \lambda \, \col{r}_e  
+	\dot{\col{r}}_e  &= \dot{\col{r}}_d - \dot{\col{r}} \\
+	\dot{\col{r}}_e  &= \dot{\col{r}}_d - J(\col{q}) \dot{\col{q}} \\
+	\dot{\col{r}}_e  &= \dot{\col{r}}_d - \underbrace{J(\col{q}) J(\col{q})^{\#} }_{1} \dot{\col{r}}_r \\
+	\dot{\col{r}}_e  &= \dot{\col{r}}_d - \underbrace{J(\col{q}) J(\col{q})^{\#} }_{1}  \left( \dot{\col{r}}_d + \lambda \, \col{r}_e \right) \\
+	\dot{\col{r}}_e  &= - \lambda \, \col{r}_e
 \end{align}
 %%%%%%%%%%%%%%%%
 La dynamique de l'erreur est donc stable et converge exponentiellement vers zéro si $\lambda>0$, avec une constante de temps égale à $\lambda$:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{r}}_e = - \lambda \, \col{r}_e 
-\quad\quad \Rightarrow \quad\quad 
-\col{r}_e(t) = \col{r}_e(t=0) \, e^{- \lambda t} 
-\quad\quad \Rightarrow \quad\quad 
-\col{r}_e(t=\infty) = 0
+	\dot{\col{r}}_e = - \lambda \, \col{r}_e
+	\quad\quad \Rightarrow \quad\quad
+	\col{r}_e(t) = \col{r}_e(t=0) \, e^{- \lambda t}
+	\quad\quad \Rightarrow \quad\quad
+	\col{r}_e(t=\infty) = 0
 \end{align}
 %%%%%%%%%%%%%%%%%
-Notez ici que cette analyse assume un contrôle parfait et instantané de la vitesse des moteurs. Une autre limite est que la convergence cesse si le robot passe sur une singularité, i.e. mathématiquement l'inverse (ou pseudo-inverse) du Jacobien n'excisera pas. Finalement, comme démontré dans la démarche, pour garantir la convergence exponentielle sur une trajectoire (position cible qui varie dans le temps), le feedforward illustré à la Figure \ref{fig:robotspeedcontroltraj} est nécessaire.
+Notez ici que cette analyse suppose un contrôle parfait et instantané de la vitesse des moteurs. Une autre limite est que la convergence cesse si le robot passe sur une singularité, c.-à-d. mathématiquement l'inverse (ou pseudo-inverse) du Jacobien n'existera pas. Finalement, comme démontré dans la démarche, pour garantir la convergence exponentielle sur une trajectoire (position cible qui varie dans le temps), le feedforward illustré à la Figure \ref{fig:robotspeedcontroltraj} est nécessaire.
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Utilisation du Nullspace pour un objectif secondaire}
 
-Comme il a été vu à la section \ref{sec:invdiffkinredondant}, lorsque le nombre de DDL du robot ($dim(\col{q})$) est supérieur à celui de l'espace de la tâche qu'on désire contrôler ($dim(\col{r})$), il y a plusieurs solutions $\col{\dot{q}}$ pour lesquels la vitesse cible pour l'effecteur est parfaitement atteinte. Lorsque la consigne de vitesse de l'effecteur $\col{\dot{r}}_r$ est fixée par la loi de commande qui la fait converger vers $\col{r}_d$,  l'ensemble des solutions pour $\dot{\col{q}}$ peuvent être décrite par l'équation suivante:
+Comme il a été vu à la section \ref{sec:invdiffkinredondant}, lorsque le nombre de DDL du robot ($dim(\col{q})$) est supérieur à celui de l'espace de la tâche qu'on désire contrôler ($dim(\col{r})$), il y a plusieurs solutions $\col{\dot{q}}$ pour lesquels la vitesse cible pour l'effecteur est parfaitement atteinte. Lorsque la consigne de vitesse de l'effecteur $\col{\dot{r}}_r$ est fixée par la loi de commande qui la fait converger vers $\col{r}_d$,  l'ensemble des solutions pour $\dot{\col{q}}$ peuvent être décrites par l'équation suivante:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{q}} = J^{\#} \, 
-\underbrace{
-\left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right)\right] 
-}_{\col{\dot{r}}_r}
-+ \left[ I - J^{\#}J  \right] \col{v}
+	\dot{\col{q}} = J^{\#} \,
+	\underbrace{
+		\left[ \dot{\col{r}_d} + \lambda \left( \col{r}_d  - \underbrace{f(\col{q})}_{\col{r}}  \right)\right]
+	}_{\col{\dot{r}}_r}
+	+ \left[ I - J^{\#}J  \right] \col{v}
 \end{align}
 %%%%%%%%%%%%%%%%%
-où le vecteur-colonne $\col{v}$ contient les variables libres. On peut donc considérer le vecteur $\col{v}$ comme une entrée de contrôle secondaire, qu'il est possible d'utiliser pour faire autre chose avec le robot sans effectuer la convergence de l'effecteur. Par exemple, les bras humains: on peut les utiliser pour attraper un objet avec notre main (objectif principal), tout en utilisant notre bras pour tenir un cahier contre notre corps (objectif secondaire). On peut aussi utiliser l'espace nul pour tenter de garder la configuration du robot le plus loin possible des configurations singulières. La Figure \ref{fig:nullspacecontrol} illustre graphiquement l'effet de divers options de vecteur $\col{v}$ sur les mouvements internes des joints d'un robot manipulateur. 
+où le vecteur-colonne $\col{v}$ contient les variables libres. On peut donc considérer le vecteur $\col{v}$ comme une entrée de contrôle secondaire, qu'il est possible d'utiliser pour faire autre chose avec le robot sans effectuer la convergence de l'effecteur. Par exemple, les bras humains: on peut les utiliser pour attraper un objet avec notre main (objectif principal), tout en utilisant notre bras pour tenir un cahier contre notre corps (objectif secondaire). On peut aussi utiliser l'espace nul pour tenter de garder la configuration du robot le plus loin possible des configurations singulières. La Figure \ref{fig:nullspacecontrol} illustre graphiquement l'effet de diverses options de vecteur $\col{v}$ sur les mouvements internes des joints d'un robot manipulateur.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.70\textwidth]{fig/nullspacecontrol.jpg}
+	\includegraphics[width=0.70\textwidth]{fig/nullspacecontrol.jpg}
 	\caption{Utilisation de l'espace nul d'un robot redondant pour effectuer un objectif secondaire}
 	\label{fig:nullspacecontrol}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-De façon général, on peut formuler l'objectif secondaire comme une fonction potentielle scalaire $G$ qui dépend de la configuration (un scalaire qui est le plus grand possible le plus on est sur l'objectif). La commande secondaire $\col{v}$ peut alors être déterminée par le gradient de cette fonction évalué à la configuration actuelle du robot:
+De façon générale, on peut formuler l'objectif secondaire comme une fonction potentielle scalaire $G$ qui dépend de la configuration (un scalaire qui est le plus grand possible le plus on est sur l'objectif). La commande secondaire $\col{v}$ peut alors être déterminée par le gradient de cette fonction évalué à la configuration actuelle du robot:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-G( \col{q} ) \; \Rightarrow \; \col{v} = \frac{\partial G }{\partial \col{q} }
+	G( \col{q} ) \; \Rightarrow \; \col{v} = \frac{\partial G }{\partial \col{q} }
 \end{align}
 %%%%%%%%%%%%%%%%%
 
 Si l'objectif secondaire est une position cible $\col{q}_d$ dans l'espace des joints. La fonction objectif $G$ pourrait être la norme de l'erreur, et on obtiendrait:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-G( \col{q} ) &= - \frac{1}{2} \lambda \col{q}_e^T \col{q}_e
-\quad \text{avec: } \; \col{q}_e = \col{q}_d - \col{q} \\
-\col{v} &= \frac{\partial G }{\partial \col{q} } = \lambda \huge( \col{q}_d - \col{q} \huge)
+	G( \col{q} ) &= - \frac{1}{2} \lambda \col{q}_e^T \col{q}_e
+	\quad \text{avec: } \; \col{q}_e = \col{q}_d - \col{q} \\
+	\col{v} &= \frac{\partial G }{\partial \col{q} } = \lambda \huge( \col{q}_d - \col{q} \huge)
 \end{align}
 %%%%%%%%%%%%%%%%%
-où $\lambda$ est un paramètre de gain de convergence pour cette boucle de commande secondaire avec une cible de configuration $\col{q}_d$ dans l'espace des joints. Notez que la boucle principale a toujours la priorité absolue avec cette formulation, la convergence de l'objectif principal est garantie mais pas celle de l'objectif secondaire. 
+où $\lambda$ est un paramètre de gain de convergence pour cette boucle de commande secondaire avec une cible de configuration $\col{q}_d$ dans l'espace des joints. Notez que la boucle principale a toujours la priorité absolue avec cette formulation, la convergence de l'objectif principal est garantie, mais pas celle de l'objectif secondaire.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Formulation avec régulation de la norme du vecteur vitesse}
 
-Dans certaines situation, par exemple lorsque le robot passe proche d'une singularité, les lois de commande présentées dans les sections précédentes peuvent demander des très grande vitesses irréalistes aux joints. Plutôt que d'inverser directement la matrice Jacobienne, il est possible de plutôt trouver une solution au système d'équation suivant qui pénalise aussi la norme du vecteur $\col{\dot{q}}$:
+Dans certaines situations, par exemple lorsque le robot passe proche d'une singularité, les lois de commande présentées dans les sections précédentes peuvent demander de très grandes vitesses irréalistes aux joints. Plutôt que d'inverser directement la matrice Jacobienne, il est possible de plutôt trouver une solution au système d'équations suivant qui pénalise aussi la norme du vecteur $\col{\dot{q}}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}  \\ \dot{\col{r}}_r \\ \\ \col{0} \\ \\ 
-\end{array} \right]_{(m+n) \times 1}
-&= 
-\left[ \begin{array}{c c c} 
-&&\\
-& J(\col{q}) &\\
-&&\\
-&\lambda I &\\
-&&
-\end{array} \right]_{(m + n)  \times n}
-\left[ \begin{array}{c} 
-\\ \dot{\col{q}} \\ \\
-\end{array} \right]_{n \times 1}
-\end{align} 
+	\left[ \begin{array}{c}  \\ \dot{\col{r}}_r \\ \\ \col{0} \\ \\
+	\end{array} \right]_{(m+n) \times 1}
+	&=
+	\left[ \begin{array}{c c c}
+			   &&\\
+			   & J(\col{q}) &\\
+			   &&\\
+			   &\lambda I &\\
+			   &&
+	\end{array} \right]_{(m + n)  \times n}
+	\left[ \begin{array}{c}
+			   \\ \dot{\col{q}} \\ \\
+	\end{array} \right]_{n \times 1}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-où $\lambda$ est un paramètre de poids sur la pénalité d'utiliser des grandes vitesses de joints. Ce système a donc $m+n$ équations et $n$ variables, il est donc sur-contraint. Une méthode standard est d'utiliser la solution des moindres-carrés (voir section \ref{sec:moindrecarre}) pour trouver une solution non-exacte pour $\dot{\col{q}}$ qui minimise la norme de l'erreur au carré, ce qui correspond ici à minimiser:
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-\| \col{e} \|^2 = \| \col{\dot{r}}_r - J \col{\dot{q}}   \|^2 + \lambda^2 \| \col{\dot{q}} \|^2
-\end{align} 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-La solution des moindres carrés a une solution explicite qui correspond à 
+où $\lambda$ est un paramètre de poids sur la pénalité d'utiliser de grandes vitesses de joints. Ce système a donc $m+n$ équations et $n$ variables, il est donc sur-contraint. Une méthode standard est d'utiliser la solution des moindres carrés (voir section \ref{sec:moindrecarre}) pour trouver une solution non-exacte pour $\dot{\col{q}}$ qui minimise la norme de l'erreur au carré, ce qui correspond ici à minimiser:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\hat{\dot{q}}} &= \operatornamewithlimits{argmin}\limits_{\col{\dot{q}}} \| \col{e} \|^2 \\
-\col{\hat{\dot{q}}} &= \huge( J^T J + \lambda^2 I \huge)^{-1} J^T  \col{\dot{r}}_r 
-\end{align} 
+	\| \col{e} \|^2 = \| \col{\dot{r}}_r - J \col{\dot{q}}   \|^2 + \lambda^2 \| \col{\dot{q}} \|^2
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-La convergence de cette méthode n'est toutefois pas garantie, le robot peut dériver de la trajectoire désirée surtout si $\lambda$ est trop grand. Une méthode pour palier à ce problème est d'ajuster dynamiquement $\lambda$ pour lui assigner de grandes valeurs seulement proche des configurations problématiques, i.e. proche des singularités. Dans la littérature, la méthode présentée dans cette section est appelée \textit{damped least-square}.
+La solution des moindres carrés a une solution explicite qui correspond à
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{align}
+	\col{\hat{\dot{q}}} &= \operatornamewithlimits{argmin}\limits_{\col{\dot{q}}} \| \col{e} \|^2 \\
+	\col{\hat{\dot{q}}} &= \huge( J^T J + \lambda^2 I \huge)^{-1} J^T  \col{\dot{r}}_r
+\end{align}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+La convergence de cette méthode n'est toutefois pas garantie, le robot peut dériver de la trajectoire désirée surtout si $\lambda$ est trop grand. Une méthode pour pallier à ce problème est d'ajuster dynamiquement $\lambda$ pour lui assigner de grandes valeurs seulement proche des configurations problématiques, c.-à-d. proche des singularités. Dans la littérature, la méthode présentée dans cette section est appelée \textit{damped least-square}.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -250,27 +252,27 @@ La convergence de cette méthode n'est toutefois pas garantie, le robot peut dé
 \label{sec:forcecontrol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Pour certaines tâches, ce n'est pas la position de l'outil que l'on désire contrôler, mais plutôt la force qu'il applique sur l'environnement. Si un systèmes robotisé a des actionneurs qui sont contrôlable en force ou couple, il suffit d'une transformation géométrique avec le Jacobien pour calculer les consignes en force des actionneurs basé sur une force désirée à l'effecteur, comme illustré à la Figure \ref{fig:forcecontroleffectorgeo}. 
+Pour certaines tâches, ce n'est pas la position de l'outil que l'on désire contrôler, mais plutôt la force qu'il applique sur l'environnement. Si un système robotisé a des actionneurs qui sont contrôlables en force ou en couple, il suffit d'une transformation géométrique avec le Jacobien pour calculer les consignes en force des actionneurs basés sur une force désirée à l'effecteur, comme illustré à la Figure \ref{fig:forcecontroleffectorgeo}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.4\textwidth]{fig/forcecontroleffectorgeo.jpg}
+	\includegraphics[width=0.4\textwidth]{fig/forcecontroleffectorgeo.jpg}
 	\caption{Commande en force de l'effecteur d'un robot : interprétation géométrique}
 	\label{fig:forcecontroleffectorgeo}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La Figure \ref{fig:forcecontroleffectorbloc} montre cette méthode de commande avec un schéma bloc. À l'exception du calcul du Jacobien qui nécessite de connaître la position des joints actuelle, la méthode peut être peut être considérée comme une boucle ouverte.  Par exemple dans le cas des robots à entraînement direct, i.e. utilisant des gros moteurs électrique qui n'ont pas de ratio de réduction, il suffit de traduire la force désirée en couples moteurs à l'aide du Jacobien et ensuite de traduire les couples moteurs en consigne de courant des les moteurs en divisant par la constante des moteurs. Selon le type d'actionneur, des boucles de rétroaction en force à bas niveau peuvent être utilisées, par exemple un asservissement de la pression dans un actionneur pneumatique. La loi de commande présentée ici spécifie les consigne en force pour les actionneurs.
+La Figure \ref{fig:forcecontroleffectorbloc} montre cette méthode de commande avec un schéma bloc. À l'exception du calcul du Jacobien qui nécessite de connaître la position des joints actuelle, la méthode peut être considérée comme une boucle ouverte. Par exemple dans le cas des robots à entraînement direct, c.-à-d. utilisant des gros moteurs électriques qui n'ont pas de ratio de réduction, il suffit de traduire la force désirée en couples moteurs à l'aide du Jacobien et ensuite de traduire les couples moteurs en consigne de courant des les moteurs en divisant par la constante des moteurs. Selon le type d'actionneur, des boucles de rétroaction en force à bas niveau peuvent être utilisées, par exemple un asservissement de la pression dans un actionneur pneumatique. La loi de commande présentée ici spécifie les consignes en force pour les actionneurs.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.70\textwidth]{fig/forcecontroleffectorbloc.jpg}
+	\includegraphics[width=0.70\textwidth]{fig/forcecontroleffectorbloc.jpg}
 	\caption{Commande en force de l'effecteur d'un robot : schéma bloc}
 	\label{fig:forcecontroleffectorbloc}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Il est à noter que pour produire une force, le principe action-réaction nous rappel qu'il faut avoir une résistance. Donc si l'effecteur n'est pas en contact avec un objet le comportement de cette loi de commande de donnera pas nécessairement le résultat attendu, les forces des actionneurs vont alors ce balancer avec la résistance interne du robot: forces dissipatrices et inertielles. Le robot va donc accélérer s'il n'y a pas de contact ou de résistance. Comme le mentionne le titre du chapitre, cette loi de commande \textbf{quasi-statique} fonctionne bien lorsque le robot est bloqué ou bien bouge très lentement, sinon les forces dissipatives et inertielles interne au robot vont influencer la force de contact. 
+Il est à noter que pour produire une force, le principe d'action-réaction nous rappelle qu'il faut avoir une résistance. Donc si l'effecteur n'est pas en contact avec un objet le comportement de cette loi de commande de donnera pas nécessairement le résultat attendu, les forces des actionneurs vont alors ce balancer avec la résistance interne du robot: forces dissipatrices et inertielles. Le robot va donc accélérer s'il n'y a pas de contact ou de résistance. Comme le mentionne le titre du chapitre, cette loi de commande \textbf{quasi-statique} fonctionne bien lorsque le robot est bloqué ou bien bouge très lentement, sinon les forces dissipatives et inertielles internes au robot vont influencer la force de contact.
 
 
 
@@ -280,109 +282,109 @@ Il est à noter que pour produire une force, le principe action-réaction nous r
 \label{sec:impcontrol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Jusqu'à maintenant, à la section \ref{sec:positioncontrol} une technique a été discutée pour contrôler la position d'un robot et à la section \ref{sec:forcecontrol} une technique a été discuté pour contrôler la force transmise par un robot. La dernière grande catégorie de type de commande est de contrôler la relation entre la positon et la force du robot. L'idée est d'imposer une loi de comportement qui relie la force au déplacement du système. Cette approche est particulièrement utile pour les situations ou un robot va entrer en contact avec un objet ou un humain. Un des inconvénients d'un contrôle en position pur est que si le robot rencontre un obstacle qui bloque son chemin, le robot va soudainement appliquer une très grande force pour tenter de continuer, ce qui peut risquer de briser soit l'objet rencontré ou le robot lui-même. À l'opposé, le problème avec une approche de contrôle en force pur est que si le robot n'a pas d'obstacle pour créer une résistance et établir la force désirée, le robot va plutôt accélérer jusqu'à se qu'il atteindre la limite de son espace de travail. La commande en impédance ou en admittance est une approche hybride qui vise plutôt à imposer une relation entre la force et le déplacement. Par exemple, on pourrait désirer que le robot se déplace de façon proportionnelle à une force appliqué sur celui-ci, en imposant ce comportement le robot émulerait le comportement d'un ressort. 
+Jusqu'à maintenant, à la section \ref{sec:positioncontrol} une technique a été discutée pour contrôler la position d'un robot et à la section \ref{sec:forcecontrol} une technique a été discutée pour contrôler la force transmise par un robot. La dernière grande catégorie de type de commande est de contrôler la relation entre la position et la force du robot. L'idée est d'imposer une loi de comportement qui relie la force au déplacement du système. Cette approche est particulièrement utile pour les situations ou un robot va entrer en contact avec un objet ou un humain. Un des inconvénients d'un contrôle en position pur est que si le robot rencontre un obstacle qui bloque son chemin, le robot va soudainement appliquer une très grande force pour tenter de continuer, ce qui peut risquer de briser soit l'objet rencontré ou le robot lui-même. À l'opposé, le problème avec une approche de contrôle en force pur est que si le robot n'a pas d'obstacle pour créer une résistance et établir la force désirée, le robot va plutôt accélérer jusqu'à se qu'il atteindre la limite de son espace de travail. La commande en impédance ou en admittance est une approche hybride qui vise plutôt à imposer une relation entre la force et le déplacement. Par exemple, on pourrait désirer que le robot se déplace de façon proportionnelle à une force appliquée sur celui-ci, en imposant ce comportement le robot émulerait le comportement d'un ressort.
 
-Deux approches permettre d'imposer une relation entre la force et la vitesse: la commande en impédance et en admittance. D'un point de vu théorique les approches sont pratiquement équivalent, comme illustré à la Figure \ref{fig:impedanceadmitancecontrolbloc}, la différence est la causalité. Un contrôleur en impédance mesure le déplacement et impose une force pour l'impédance, et un contrôleur en admittance mesure la force pour imposer un déplacement dans le cas de l'admittance. Dans un monde idéal ou les mesures et le contrôle de la force/déplacement serait parfait, pour la même loi de comportement les deux approches donneraient un résultat identique. Toutefois, en pratique il y a des grandes différences d'implémentation et de performance entre ces approches. 
+Deux approches permettent d'imposer une relation entre la force et la vitesse: la commande en impédance et en admittance. D'un point de vue théorique, les deux approches sont pratiquement équivalentes, comme illustré à la Figure \ref{fig:impedanceadmitancecontrolbloc}, la différence est la causalité. Un contrôleur en impédance mesure le déplacement et impose une force pour l'impédance, et un contrôleur en admittance mesure la force pour imposer un déplacement dans le cas de l'admittance. Dans un monde idéal où les mesures et le contrôle de la force/déplacement seraient parfaits, pour la même loi de comportement les deux approches donneraient un résultat identique. Toutefois, en pratique il y a des grandes différences d'implémentation et de performance entre ces approches.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Commande en \textbf{impédance}]{
-				\includegraphics[width=0.40\textwidth]{fig/impedancecontrolbloc.jpg}
-				\label{fig:impedancecontrolbloc}}
-				%%%%
-				\hspace{30pt}
-				%%%%
-				\subfloat[Commande en \textbf{admittance}]{
-				\includegraphics[width=0.40\textwidth]{fig/admitancecontrolbloc.jpg}
-				\label{fig:admitancecontrolbloc}}
-        \caption{Deux façon d'imposer une loi de comportement qui relie la force au déplacement.}
-				\label{fig:impedanceadmitancecontrolbloc}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Commande en \textbf{impédance}]{
+		\includegraphics[width=0.40\textwidth]{fig/impedancecontrolbloc.jpg}
+		\label{fig:impedancecontrolbloc}}
+	%%%%
+	\hspace{30pt}
+	%%%%
+	\subfloat[Commande en \textbf{admittance}]{
+		\includegraphics[width=0.40\textwidth]{fig/admitancecontrolbloc.jpg}
+		\label{fig:admitancecontrolbloc}}
+	\caption{Deux façons d'imposer une loi de comportement qui relie la force au déplacement.}
+	\label{fig:impedanceadmitancecontrolbloc}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les lois de comportements mécaniques sont souvent décrit avec des fonctions de transfert dans le domaine de Laplace pour une notation compacte. La fonction $Z(s)$ est utilisée pour décrire l'impédance: le signal de force $f(s)$ divisé par le signal de déplacement $x(s)$ dans le domaine de Laplace. L'admittance $Y(s)$ est l'inverse de la fonction d'impédance. 
+Les lois de comportements mécaniques sont souvent décrites avec des fonctions de transfert dans le domaine de Laplace pour une notation compacte. La fonction $Z(s)$ est utilisée pour décrire l'impédance: le signal de force $f(s)$ divisé par le signal de déplacement $x(s)$ dans le domaine de Laplace. L'admittance $Y(s)$ est l'inverse de la fonction d'impédance.
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Impédance:} \quad Z(s) = \frac{f(s)}{x(s)} \quad\quad \text{Admittance:} \quad Y(s) =  \frac{1}{Z(s)} = \frac{x(s)}{f(s)}
+	\text{Impédance:} \quad Z(s) = \frac{f(s)}{x(s)} \quad\quad \text{Admittance:} \quad Y(s) =  \frac{1}{Z(s)} = \frac{x(s)}{f(s)}
 \end{align}
 %%%%%%%%%%%%%%%%%
 
-\paragraph{Note:} Dans certains ouvrage le concept d'impédance est définie comme la force divisée par la vitesse (contrairement à la position). La définition relative au déplacement sera toutefois utilisée ici car elle s'intègre plus naturellement au contexte de commande des robots. 
+\paragraph{Note:} Dans certains ouvrages le concept d'impédance est défini comme la force divisée par la vitesse (contrairement à la position). La définition relative au déplacement sera toutefois utilisée ici, car elle s'intègre plus naturellement au contexte de commande des robots.
 
 Un système mécanique avec une inertie $m$, un amortissement linéaire $b$ et une rigidité $k$ a une impédance égale à:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-Z(s) = m s^2 + b s + k 
+	Z(s) = m s^2 + b s + k
 \end{align}
 %%%%%%%%%%%%%%%%%
-L'opération de multiplié le signal de déplacement par l'impédance $Z(s)$ est équivalent dans le domaine temporel à :
+L'opération de multiplier le signal de déplacement par l'impédance $Z(s)$ est équivalent dans le domaine temporel à :
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-f(s) = Z(s) x(s) = \left( m s^2 + b s + k \right) x(s) \quad \Longleftrightarrow \quad 
-f(t) = m \frac{d^2}{dt^2} x(t) + b \frac{d}{dt} x(t) + k x(t) 
+	f(s) = Z(s) x(s) = \left( m s^2 + b s + k \right) x(s) \quad \Longleftrightarrow \quad
+	f(t) = m \frac{d^2}{dt^2} x(t) + b \frac{d}{dt} x(t) + k x(t)
 \end{align}
 %%%%%%%%%%%%%%%%%
 
 
-\paragraph{Exemple} Une loi de comportement qui est souvent désirable d'implémenter est la loi de \textit{Hooke}, i.e. un ressort. Comme illustré à la Figure \ref{fig:impedanceadmitancespring}, l'approche impédance se résume à mesurer un signal de position $x$ et le multiplier par une constante de rigidité $k$ pour obtenir la force à appliquer. L'approche en admittance se résume à mesurer un signal de force $f$ et le diviser par la constante de rigidité $k$ pour obtenir le déplacement $x$ à imposer. On utilise parfois la notion de compliance $C=1/k$ qui est l'inverse de la rigidité. 
+\paragraph{Exemple} Une loi de comportement qui est souvent désirable d'implémenter est la loi de \textit{Hooke}, c.-à-d. un ressort. Comme illustré à la Figure \ref{fig:impedanceadmitancespring}, l'approche impédance se résume à mesurer un signal de position $x$ et le multiplier par une constante de rigidité $k$ pour obtenir la force à appliquer. L'approche en admittance se résume à mesurer un signal de force $f$ et le diviser par la constante de rigidité $k$ pour obtenir le déplacement $x$ à imposer. On utilise parfois la notion de compliance $C=1/k$ qui est l'inverse de la rigidité.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				\vspace{-10pt}
-        \centering
-				\subfloat[Commande en \textbf{impédance}]{
-				\includegraphics[width=0.35\textwidth]{fig/impedancecontrolspring.jpg}
-				\label{fig:impedancecontrolspring}}
-				%%%%
-				\hspace{5pt}
-				%%%%
-				\subfloat[Commande en \textbf{admittance}]{
-				\includegraphics[width=0.35\textwidth]{fig/admitancecontrolspring.jpg}
-				\label{fig:admitancecontrolspring}}
-        \caption{Imposition d'une loi de comportement $f=kx$ (ressort)}
-				\label{fig:impedanceadmitancespring}
+	\vspace{-10pt}
+	\centering
+	\subfloat[Commande en \textbf{impédance}]{
+		\includegraphics[width=0.35\textwidth]{fig/impedancecontrolspring.jpg}
+		\label{fig:impedancecontrolspring}}
+	%%%%
+	\hspace{5pt}
+	%%%%
+	\subfloat[Commande en \textbf{admittance}]{
+		\includegraphics[width=0.35\textwidth]{fig/admitancecontrolspring.jpg}
+		\label{fig:admitancecontrolspring}}
+	\caption{Imposition d'une loi de comportement $f=kx$ (ressort)}
+	\label{fig:impedanceadmitancespring}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-En pratique, se qui va guider le choix d'une approche ou d'une autre est principalement le type d'actionneur utilisé dans le système robotisé. L'approche par impédance est plus naturelle pour un système avec des actionneurs qui sont des sources de forces (moteur électrique sans réducteur, cylindre pneumatique, etc.), tandis que l'approche par admittance est plus naturelle pour les systèmes avec des actionneurs qui sont des sources de déplacement, i.e. plus facilement contrôlable en position ou vitesse comme la plupart des moteurs électriques jumelés à des grandes réductions utilisés dans les robots industriels. La Figure \ref{fig:impedanceadmitancesex} illustre deux implémentations possibles pour émuler la loi de \textit{Hooke}.
+En pratique, ce qui va guider le choix d'une approche ou d'une autre est principalement le type d'actionneur utilisé dans le système robotisé. L'approche par impédance est plus naturelle pour un système avec des actionneurs qui sont des sources de forces (moteur électrique sans réducteur, cylindre pneumatique, etc.), tandis que l'approche par admittance est plus naturelle pour les systèmes avec des actionneurs qui sont des sources de déplacement, c.-à-d. plus facilement contrôlable en position ou vitesse comme la plupart des moteurs électriques jumelés à des grandes réductions utilisés dans les robots industriels. La Figure \ref{fig:impedanceadmitancesex} illustre deux implémentations possibles pour émuler la loi de \textit{Hooke}.
 %
-Généralement, l'approche en impédance jumelée à des actionneurs à faible résistance hautement réversible (le plus proche possible d'une source de force pure) est idéale pour bien émuler des loi de comportement pour des petites impédances. La performance est toutefois limitée pour émuler des rigidités très élevée. Cette approche est généralement utilisée par les systèmes haptiques. À l'inverse, l'approche en admittance avec des actionneurs irréversibles (le plus proche possible d'une source de position), est idéale pour émuler de très grandes impédances. La performance est toutefois limitée pour émuler un comportement très compliant (peu de résistance) car l'accélération et la vitesse des actionneurs sont limités en pratique. Cette approche est généralement utilisée par les robots collaboratifs industriels. 
+Généralement, l'approche en impédance jumelée à des actionneurs à faible résistance hautement réversible (le plus proche possible d'une source de force pure) est idéale pour bien émuler des lois de comportement pour des petites impédances. La performance est toutefois limitée pour émuler des rigidités très élevées. Cette approche est généralement utilisée par les systèmes haptiques. À l'inverse, l'approche en admittance avec des actionneurs irréversibles (le plus proche possible d'une source de position), est idéale pour émuler de très grandes impédances. La performance est toutefois limitée pour émuler un comportement très compliant (peu de résistance), car l'accélération et la vitesse des actionneurs sont limitées en pratique. Cette approche est généralement utilisée par les robots collaboratifs industriels.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				\vspace{-10pt}
-        \centering
-				\subfloat[Commande en \textbf{impédance}]{
-				\includegraphics[width=0.45\textwidth]{fig/impedancecontrolpiston.jpg}
-				\label{fig:impedancecontrolpiston}}
-				%%%%
-				\hspace{5pt}
-				%%%%
-				\subfloat[Commande en \textbf{admittance}]{
-				\includegraphics[width=0.45\textwidth]{fig/admitancecontrolservo.jpg}
-				\label{fig:admitancecontrolservo}}
-        \caption{Deux exemples d'implémentation de commande pour une loi de comportement $f=kx$ (ressort). L'approche en impédance est adaptée à aux actionneurs qui sont des sources de force avec peu de résistance interne. L'approche en admittance est adaptée aux actionneurs qui sont irréversibles et donc des sources de déplacements idéales qui sont peu influencées par la résistance externe.}
-				\label{fig:impedanceadmitancesex}
+	\vspace{-10pt}
+	\centering
+	\subfloat[Commande en \textbf{impédance}]{
+		\includegraphics[width=0.45\textwidth]{fig/impedancecontrolpiston.jpg}
+		\label{fig:impedancecontrolpiston}}
+	%%%%
+	\hspace{5pt}
+	%%%%
+	\subfloat[Commande en \textbf{admittance}]{
+		\includegraphics[width=0.45\textwidth]{fig/admitancecontrolservo.jpg}
+		\label{fig:admitancecontrolservo}}
+	\caption{Deux exemples d'implémentation de commande pour une loi de comportement $f=kx$ (ressort). L'approche en impédance est adaptée aux actionneurs qui sont des sources de force avec peu de résistance interne. L'approche en admittance est adaptée aux actionneurs qui sont irréversibles et donc des sources de déplacements idéales qui sont peu influencées par la résistance externe.}
+	\label{fig:impedanceadmitancesex}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les sections suivantes présentent des approches de commande haut-niveau, i.e. la coordination spatiale de plusieurs joints pour obtenir des lois de comportement, soit exprimées dans l'espace des joints ou de la tâche comme illustré à la Figure \ref{fig:stiffnesscontrol}. Dans ces sections il est considéré que les actionneurs sont soit des sources parfaites de force ou des sources parfaites de déplacement. La performance des boucles en forces/impédance/admittance implique une analyse de la dynamique bas-niveau des actionneurs qui est plutôt traité au chapitre \ref{sec:actuatorcontrol}. 
+Les sections suivantes présentent des approches de commande haut-niveau, c.-à-d. la coordination spatiale de plusieurs joints pour obtenir des lois de comportement, soit exprimées dans l'espace des joints ou de la tâche comme illustré à la Figure \ref{fig:stiffnesscontrol}. Dans ces sections il est considéré que les actionneurs sont soit des sources parfaites de force ou des sources parfaites de déplacement. La performance des boucles en forces/impédance/admittance implique une analyse de la dynamique bas-niveau des actionneurs qui est plutôt traitée au chapitre \ref{sec:actuatorcontrol}.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Dans l'espace des joints]{
-				\includegraphics[width=0.30\textwidth]{fig/jointspacestiffness.jpg}
-				\label{fig:jointspacestiffness}}
-				%%%%
-				\hspace{5pt}
-				%%%%
-				\subfloat[Dans l'espace de la tâche]{
-				\includegraphics[width=0.30\textwidth]{fig/taskspacestiffness.jpg}
-				\label{fig:taskspacestiffness}}
-        \caption{Commande de la rigidité/compliance d'un robot}
-			\label{fig:stiffnesscontrol}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Dans l'espace des joints]{
+		\includegraphics[width=0.30\textwidth]{fig/jointspacestiffness.jpg}
+		\label{fig:jointspacestiffness}}
+	%%%%
+	\hspace{5pt}
+	%%%%
+	\subfloat[Dans l'espace de la tâche]{
+		\includegraphics[width=0.30\textwidth]{fig/taskspacestiffness.jpg}
+		\label{fig:taskspacestiffness}}
+	\caption{Commande de la rigidité/compliance d'un robot}
+	\label{fig:stiffnesscontrol}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -391,33 +393,33 @@ Les sections suivantes présentent des approches de commande haut-niveau, i.e. l
 \subsection{Commande en impédance aux joints}
 \label{sec:jointimpcontrol}
 
-Pour des robots avec des actionneurs contrôlés en force ou couple, la commande en impédance aux joints se résume à relié le déplacement mesuré aux joints aux efforts à chaque joint. Dans le cas le plus simple, comme illustré à la Figure \ref{fig:jointspacestiffness}, on peut commander des couples moteurs proportionnel aux déplacement angulaire des joints, ce qui est équivalent à émuler des ressorts angulaires sur chaque joint. De façon général on pourrait émuler des ressorts-amortisseurs sur chaque joint avec la loi de commande:
+Pour des robots avec des actionneurs contrôlés en force ou en couple, la commande en impédance aux joints se résume à relier le déplacement mesuré aux joints aux efforts à chaque joint. Dans le cas le plus simple, comme illustré à la Figure \ref{fig:jointspacestiffness}, on peut commander des couples moteurs proportionnels aux déplacements angulaires des joints, ce qui est équivalent à émuler des ressorts angulaires sur chaque joint. De façon générale, on pourrait émuler des ressorts-amortisseurs sur chaque joint avec la loi de commande:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} = K \col{q}_e + B \col{\dot{q}}_e
-\label{eq:jointspaceimpe}
+	\col{\tau} = K \col{q}_e + B \col{\dot{q}}_e
+	\label{eq:jointspaceimpe}
 \end{align}
 %%%%%%%%%%%%%%%%%
-ou $\col{q}_e = \col{q}_d - \col{q}$ est une erreur par rapport à la configuration de référence ou les ressorts sont "au repos". Les matrices $K$ et $B$ sont respectivement une matrice de coefficients de rigidité et une matrice de coefficients d'amortissement. Les matrice sont diagonales pour un comportement de chaque joint indépendant. Dans ce cas diagonal, la loi de commande est équivalente à plusieurs boucle d'asservissement indépendantes de type Proportionnel-Dérivé sur la position des joints. La loi de commande est illustrée sous forme de schéma bloc à la Figure \ref{fig:impedancecontroljoint}.
+où $\col{q}_e = \col{q}_d - \col{q}$ est une erreur par rapport à la configuration de référence où les ressorts sont "au repos". Les matrices $K$ et $B$ sont respectivement une matrice de coefficients de rigidité et une matrice de coefficients d'amortissement. Les matrices sont diagonales pour un comportement de chaque joint indépendant. Dans ce cas diagonal, la loi de commande est équivalente à plusieurs boucles d'asservissement indépendantes de type Proportionnel-Dérivé sur la position des joints. La loi de commande est illustrée sous forme de schéma bloc à la Figure \ref{fig:impedancecontroljoint}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.6\textwidth]{fig/impedancecontroljoint.jpg}
-	\caption{Commande de l'impédance au joints d'un robot: schéma bloc}
+	\includegraphics[width=0.6\textwidth]{fig/impedancecontroljoint.jpg}
+	\caption{Commande de l'impédance aux joints d'un robot: schéma bloc}
 	\label{fig:impedancecontroljoint}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Comme ici on programme des lois de comportement, il est possible de programmer des impédances non-linéaires arbitraires. 
+Comme ici on programme des lois de comportement, il est possible de programmer des impédances non-linéaires arbitraires.
 
-\textbf{Compensation de friction: } Les systèmes robotiques vont normalement avoir de la dissipation naturelle présente dans les joints (roulements, engrenage, etc.). Si la friction naturelle est significative et plus grande que l'amortissement qu'on désire émuler, les coefficients de friction dans $B$ pourraient être négatif pour appliquer une force opposée à la friction naturelle. La matrice $B$ pourrait être définie par:
+\textbf{Compensation de friction: } Les systèmes robotiques vont normalement avoir de la dissipation naturelle présente dans les joints (roulements, engrenage, etc.). Si la friction naturelle est significative et plus grande que l'amortissement qu'on désire émuler, les coefficients de friction dans $B$ pourraient être négatifs pour appliquer une force opposée à la friction naturelle. La matrice $B$ pourrait être définie par:
 %%%%%%%%%%%%%%%%
 \begin{align}
-B = B_{d} - B_{sys}
+	B = B_{d} - B_{sys}
 \end{align}
 %%%%%%%%%%%%%%%%%
-ou $B_{d}$ contient les coefficients d'amortissement que l'on désire émuler et $B_{sys}$ contient les coefficients d'amortissement naturel du robot. Il est toutefois risqué en pratique de tenter de totalement compenser la friction dans les joints d'un robot, car si la compensation est légèrement plus forte que la friction naturelle le système se retrouve instable. De plus le comportement de la friction autour de zéro vitesse est généralement très non-linéaire et avec de l'hystérésis, donc dur à modéliser avec précision. 
+où $B_{d}$ contient les coefficients d'amortissement que l'on désire émuler et $B_{sys}$ contient les coefficients d'amortissement naturel du robot. Il est toutefois risqué en pratique de tenter de totalement compenser la friction dans les joints d'un robot, car si la compensation est légèrement plus forte que la friction naturelle le système se retrouve instable. De plus, le comportement de la friction autour de zéro vitesse est généralement très non-linéaire et avec de l'hystérésis, donc dur à modéliser avec précision.
 
-\note{Note sur l'émulation de l'inertie: }{ On pourrait être tenté de rajouter un terme de type $M \col{\ddot{q}}_e$ à l'équation \eqref{eq:jointspaceimpe} pour rajouter l'option d'émuler un effet inertiel sur chaque joint. Toutefois il y a un problème de causalité à une telle opération. L'accélération n'est pas un état du système mais résulte de l'application de forces sur le système incluant $\col{\tau}$. Donc les couples dépendraient de l'accélération, qui dépend des couples, qui dépendraient de l'accélération, qui dépend des couples etc. c'est la poule ou bien l'oeuf qui vient en premier? En pratique, l'accélération mesurée serait celle d'un instant passé dû au délai de calcul dans le contrôleur et aux filtres dans les capteurs, et la rétroaction de la mesure de l'accélération risque de déstabiliser le système.}
+\note{Note sur l'émulation de l'inertie: }{ On pourrait être tenté de rajouter un terme de type $M \col{\ddot{q}}_e$ à l'équation \eqref{eq:jointspaceimpe} pour rajouter l'option d'émuler un effet inertiel sur chaque joint. Toutefois, il y a un problème de causalité à une telle opération. L'accélération n'est pas un état du système, mais résulte de l'application des forces sur le système incluant $\col{\tau}$. Donc les couples dépendraient de l'accélération, qui dépend des couples, qui dépendraient de l'accélération, qui dépend des couples, etc. c'est la poule ou bien l'œuf qui vient en premier? En pratique, l'accélération mesurée serait celle d'un instant passé dû au délai de calcul dans le contrôleur et aux filtres dans les capteurs, et la rétroaction de la mesure de l'accélération risque de déstabiliser le système.}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -427,14 +429,14 @@ ou $B_{d}$ contient les coefficients d'amortissement que l'on désire émuler et
 Pour la commande en impédance de l'effecteur d'un robot, c'est la relation force-déplacement à l'effecteur qu'on impose au robot:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{f}_e  =  K \col{r}_e + B \col{\dot{r}}_e 
+	\col{f}_e  =  K \col{r}_e + B \col{\dot{r}}_e
 \end{align}
 %%%%%%%%%%%%%%%%%
-ou $\col{r}_e = \col{r}_d - \col{r} $ est le vecteur position qui de la position désirée de l'effecteur du robot par rapport à la position actuelle. On peut interpréter l'effet de la loi de commande comme un ressort-amortisseur virtuel qui relit l'effecteur du robot à sa position cible comme illustré à la Figure \ref{fig:impedanceeffectorgeo}.
+où $\col{r}_e = \col{r}_d - \col{r} $ est le vecteur position de la position désirée de l'effecteur du robot par rapport à la position actuelle. On peut interpréter l'effet de la loi de commande comme un ressort-amortisseur virtuel qui relit l'effecteur du robot à sa position cible comme illustré à la Figure \ref{fig:impedanceeffectorgeo}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.4\textwidth]{fig/impedancecontroleffectorgeo.jpg}
+	\includegraphics[width=0.4\textwidth]{fig/impedancecontroleffectorgeo.jpg}
 	\caption{Commande de l'impédance de l'effecteur d'un robot : interprétation géométrique}
 	\label{fig:impedanceeffectorgeo}
 \end{figure}
@@ -442,205 +444,207 @@ ou $\col{r}_e = \col{r}_d - \col{r} $ est le vecteur position qui de la position
 Le ressort-amortisseur virtuel produit une force virtuelle $\col{f}_e$ désirée à l'effecteur qui est traduite en commande de couple grâce à la relation statique d'un manipulateur:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J(\col{q})^T \col{f}_e
+	\col{\tau} &= J(\col{q})^T \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%%%
-La Figure \ref{fig:impedanceeffectorbloc} illustre cette loi de commande avec un schéma bloc. La première étape du contrôleur est de calculer la position et la vitesse de l'effecteur à partir des capteurs qui mesurent la position et la vitesse des joints. Il faut donc ici utiliser la cinématique directe et la cinématique-différentielle directe pour calculer la position et la vitesse de l'effecteur. Ensuite la position et la vitesse de l'effecteur sont comparées à la position et la vitesse désirée (qui peut varier dans le temps, i.e. une trajectoire). L'erreur en termes de position et vitesse est convertie en force cartésienne basé sur la loi de comportement désirée (l'impédance è l'effecteur). Finalement cette force cartésienne est convertie en couple aux joints grâce au Jacobien du robot manipulateur. On peut aussi ajouter une compensation de gravité, voir la section \ref{sec:impcontrolconvergence}. L'équation de la loi de commande est égale à:
+La Figure \ref{fig:impedanceeffectorbloc} illustre cette loi de commande avec un schéma bloc. La première étape du contrôleur est de calculer la position et la vitesse de l'effecteur à partir des capteurs qui mesurent la position et la vitesse des joints. Il faut donc ici utiliser la cinématique directe et la cinématique-différentielle directe pour calculer la position et la vitesse de l'effecteur. Ensuite, la position et la vitesse de l'effecteur sont comparées à la position et la vitesse désirée (qui peut varier dans le temps, c.-à-d. une trajectoire). L'erreur en termes de position et vitesse est convertie en force cartésienne basée sur la loi de comportement désirée (l'impédance à l'effecteur). Finalement, cette force cartésienne est convertie en couple aux joints grâce au Jacobien du robot manipulateur. On peut aussi ajouter une compensation de gravité, voir la section \ref{sec:impcontrolconvergence}. L'équation de la loi de commande est égale à:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J(\col{q})^T \col{f}_e \\
-\col{\tau} &= J(\col{q})^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] \\
-\col{\tau} &= J(\col{q})^T  \left[ K  \left( \col{r}_d- \col{r} \right) + B  \left( \col{\dot{r}}_d - \col{\dot{r}} \right)  \right] \\
-\col{\tau} &= J(\col{q})^T  \left[ K  \left( \col{r}_d- f(\col{q}) \right) + B  \left( \col{\dot{r}}_d - J(\col{q}) \col{\dot{q}} \right)  \right] 
+	\col{\tau} &= J(\col{q})^T \col{f}_e \\
+	\col{\tau} &= J(\col{q})^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] \\
+	\col{\tau} &= J(\col{q})^T  \left[ K  \left( \col{r}_d- \col{r} \right) + B  \left( \col{\dot{r}}_d - \col{\dot{r}} \right)  \right] \\
+	\col{\tau} &= J(\col{q})^T  \left[ K  \left( \col{r}_d- f(\col{q}) \right) + B  \left( \col{\dot{r}}_d - J(\col{q}) \col{\dot{q}} \right)  \right]
 \end{align}
 %%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[th]
 	\centering
-		\includegraphics[width=0.99\textwidth]{fig/impedanceeffectorbloc.jpg}
+	\includegraphics[width=0.99\textwidth]{fig/impedanceeffectorbloc.jpg}
 	\caption{Commande de l'impédance de l'effecteur d'un robot : schéma bloc}
 	\label{fig:impedanceeffectorbloc}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Il y a une certaine équivalence locale entre une loi de commande en impédance à l'effecteur et une loi de commande en impédance dans l'espace des joints. Si on définie une configuration d'origine (point d'équilibre des ressorts) comme la position zéro pour $\col{q}$ et $\col{r}$ alors les lois pour le domaine des joints et de la tâche sont des expressions simplifiés puisque les positions désirée sont égale à zéro: 
+Il y a une certaine équivalence locale entre une loi de commande en impédance à l'effecteur et une loi de commande en impédance dans l'espace des joints. Si l'on définit une configuration d'origine (point d'équilibre des ressorts) comme la position zéro pour $\col{q}$ et $\col{r}$, alors les lois pour le domaine des joints et de la tâche sont des expressions simplifiées puisque les positions désirées sont égales à zéro:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Joints: }
-\col{\tau} = - K_q \col{q} - B_q \col{\dot{q}}
-\quad\quad
-\text{Effecteur: }
-\col{\tau} = - J(\col{q})^T   \left[ K_e \col{r} + B_e \col{\dot{r}} \right] 
+	\text{Joints: }
+	\col{\tau} = - K_q \col{q} - B_q \col{\dot{q}}
+	\quad\quad
+	\text{Effecteur: }
+	\col{\tau} = - J(\col{q})^T   \left[ K_e \col{r} + B_e \col{\dot{r}} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%
-où on a rajouté les indices $q$ ou $e$ aux matrices pour spécifier l'espace, joint ou effecteur, dans lesquelles est sont définies. Ensuite si on distribue et utilise la relation de cinématique différentielle, on observe que la matrice d'amortissement $B_e$ à l'effecteur a exactement le même effet qu'une matrice d'amortissement dans l'espace des joints égale à $B_q = J^T B_e J$:
+où l'on a rajouté les indices $q$ ou $e$ aux matrices pour spécifier l'espace, joint ou effecteur, dans lesquelles
+%% TODO: quoi est définie? %%
+sont définies. Ensuite si l'on distribue et utilise la relation de cinématique différentielle, on observe que la matrice d'amortissement $B_e$ à l'effecteur a exactement le même effet qu'une matrice d'amortissement dans l'espace des joints égale à $B_q = J^T B_e J$:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= - J(\col{q})^T   K_e \col{r} - J(\col{q})^T B_e \col{\dot{r}} \\
-\col{\tau} &= - J(\col{q})^T   K_e \col{r} - \underbrace{ [ J(\col{q})^T   B_e  J(\col{q}) ] }_{ B_q } \col{\dot{q}}
+	\col{\tau} &= - J(\col{q})^T   K_e \col{r} - J(\col{q})^T B_e \col{\dot{r}} \\
+	\col{\tau} &= - J(\col{q})^T   K_e \col{r} - \underbrace{ [ J(\col{q})^T   B_e  J(\col{q}) ] }_{ B_q } \col{\dot{q}}
 \end{align}
 %%%%%%%%%%%%%%%%%
 Pour des petites variations autour de la position zéro (celle pour laquelle la force nette est nulle), on peut aussi retrouver une équivalence similaire pour la rigidité $K_q = J^T K_e J$:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\delta \col{\tau} &= - \underbrace{ [ J(\col{q})^T   K_e  J(\col{q}) ] }_{ K_q }
-\delta \col{q} - \underbrace{ [ J(\col{q})^T   B_e  J(\col{q}) ] }_{ B_q }\delta \col{\dot{r}}
+	\delta \col{\tau} &= - \underbrace{ [ J(\col{q})^T   K_e  J(\col{q}) ] }_{ K_q }
+	\delta \col{q} - \underbrace{ [ J(\col{q})^T   B_e  J(\col{q}) ] }_{ B_q }\delta \col{\dot{r}}
 \end{align}
 %%%%%%%%%%%%%%%%%
-Il est à bien noter que ces équivalences sont locales et seulement valides pour dans les environ d'une configuration précise du robot. 
+Il est à bien noter que ces équivalences sont locales et seulement valides pour dans les environs d'une configuration précise du robot.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Convergence des lois de commande en impédance}
 \label{sec:impcontrolconvergence}
 
-Pour les robots avec des actionneurs contrôlés en force, une bonne façon de contrôler la position de l'effecteur est d'utiliser l'approche en impédance à l'effecteur avec une matrice $K$ très rigide. C'est l'équivalent de prendre un gros ressort très rigide, attacher une extrémité sur la position cible et l'autre sur l'effecteur du robot. Le robot va être attiré vers la position cible. D'un point de vu énergétique, le robot va converger vers le point ou l'énergie potentielle du système est minimum, ce qui est la position cible si le ressort est la seule source d'énergie potentielle, à condition qu'il y ait une certaine forme de dissipation dans le système (qui peut venir des coefficients du ressort virtuel dans $B$ ou bien de phénomènes physique dans les joints du robot). 
+Pour les robots avec des actionneurs contrôlés en force, une bonne façon de contrôler la position de l'effecteur est d'utiliser l'approche en impédance à l'effecteur avec une matrice $K$ très rigide. C'est l'équivalent de prendre un gros ressort très rigide, attacher une extrémité sur la position cible et l'autre sur l'effecteur du robot. Le robot va être attiré vers la position cible. D'un point de vue énergétique, le robot va converger vers le point ou l'énergie potentielle du système est minimum, ce qui est la position cible si le ressort est la seule source d'énergie potentielle, à condition qu'il y ait une certaine forme de dissipation dans le système (qui peut venir des coefficients du ressort virtuel dans $B$ ou bien de phénomènes physiques dans les joints du robot).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.5\textwidth]{fig/impedancecontroltaskconvergencegeo.jpg}
+	\includegraphics[width=0.5\textwidth]{fig/impedancecontroltaskconvergencegeo.jpg}
 	\caption{Convergence d'un contrôleur en impédance à l'effecteur}
 	\label{fig:impedancecontroltaskconvergencegeo}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Comme illustré à la Figure \ref{fig:impedancecontroltaskconvergencegeo}, si considère d'abord le robot comme seulement une chaîne de corps rigide avec leurs propriétés inertielles, on peut bien visualiser qu'un ressort à l'effecteur va attirer le robot sur la cible. Les propriétés inertielles du bras et la géométrie non-linéaire vont influencer la trajectoire, mais dans ce cas le point d'équilibre dépend seulement des forces conservatrice. Si le ressort virtuel de la loi d'impédance est le seul élément qui produit une force conservatrice, alors le point d'équilibre sera la configuration ou l'effecteur est exactement sur la cible. Si le robot est influencé par des forces gravitationnelles, le point d'équilibre sera le point minimum de l'énergie potentielle totale. Le robot aura donc une erreur finale avec une amplitude qui dépend de la force relative du ressort virtuel et de la gravité. Comme illustré à la Figure \ref{fig:impedanceeffectorbloc}, il est toutefois possible d'inclure une \textbf{compensation de gravité} $\col{\hat{g}}$ à une loi de commande en impédance pour éliminer cet erreur finale:
+Comme illustré à la Figure \ref{fig:impedancecontroltaskconvergencegeo}, si considère d'abord le robot comme seulement une chaîne de corps rigide avec leurs propriétés inertielles, on peut bien visualiser qu'un ressort à l'effecteur va attirer le robot sur la cible. Les propriétés inertielles du bras et la géométrie non linéaire vont influencer la trajectoire, mais dans ce cas le point d'équilibre dépend seulement des forces conservatrices. Si le ressort virtuel de la loi d'impédance est le seul élément qui produit une force conservatrice, alors le point d'équilibre sera la configuration ou l'effecteur est exactement sur la cible. Si le robot est influencé par des forces gravitationnelles, le point d'équilibre sera le point minimum de l'énergie potentielle totale. Le robot aura donc une erreur finale avec une amplitude qui dépend de la force relative du ressort virtuel et de la gravité. Comme illustré à la Figure \ref{fig:impedanceeffectorbloc}, il est toutefois possible d'inclure une \textbf{compensation de gravité} $\col{\hat{g}}$ à une loi de commande en impédance pour éliminer cette erreur finale:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} = J(\col{q})^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}(\col{q})
-\end{align} 
+	\col{\tau} = J(\col{q})^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}(\col{q})
+\end{align}
 %%%%%%%%%%%%%%%%%
-où $\col{\hat{g}}$ est l'estimation par le contrôleur (basé sur un modèle) du vecteur des forces gravitationnelles dans l'espace des joints. Finalement, un autre phénomène courant qui pourrait causer une erreur final serait s'il y a de la friction sèche dans les joints du robot. Le robot pourrait rester pris à un point ou la force commandée est égale à la friction sèche dans le système.
+où $\col{\hat{g}}$ est l'estimation par le contrôleur (basé sur un modèle) du vecteur des forces gravitationnelles dans l'espace des joints. Finalement, un autre phénomène courant qui pourrait causer une erreur finale serait s'il y a de la friction sèche dans les joints du robot. Le robot pourrait rester pris à un point ou la force commandée est égale à la friction sèche dans le système.
 
-Cette analyse qualitative basée sur des principes énergétiques peut être formalisé avec une analyse de la stabilité avec la méthode de \textit{Lyapunov}. Si on considère les équations génériques de la dynamique du robot manipulateur avec des actionneurs contrôlés en forces:
+Cette analyse qualitative basée sur des principes énergétiques peut être formalisée avec une analyse de la stabilité avec la méthode de \textit{Lyapunov}. Si l'on considère les équations génériques de la dynamique du robot manipulateur avec des actionneurs contrôlés en force:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{
-H \ddot{\col{q}} + C \dot{\col{q}} 
-}_{\text{Forces inertielles }}
-+ 
-\underbrace{
-\col{d}
-}_{\text{Forces dissipatives }}
-+ 
-\underbrace{
-\col{g} 
-}_{\text{Forces conservatrices }}
-= \col{\tau}
+	\underbrace{
+		H \ddot{\col{q}} + C \dot{\col{q}}
+	}_{\text{Forces inertielles }}
+	+
+	\underbrace{
+		\col{d}
+	}_{\text{Forces dissipatives }}
+	+
+	\underbrace{
+		\col{g}
+	}_{\text{Forces conservatrices }}
+	= \col{\tau}
 \end{align}
 %%%%%%%%%%%%%%%%%
 avec comme loi de commande, une impédance à l'effecteur incluant une compensation de gravité:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} = J^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}
+	\col{\tau} = J^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}
 \end{align}
 %%%%%%%%%%%%%%%%%
 En utilisant comme fonction candidate de \textit{Lyapunov} l'énergie mécanique réelle plus l'énergie potentielle virtuelle dans le ressort du contrôleur:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-V = 
-\underbrace{
-1/2 \, \dot{\col{q}}^T H \dot{\col{q}} 
-}_{\text{ Énergie cinétique réelle du robot }}
-+
-\underbrace{
-1/2 \, \col{r}_e^T K \col{r}_e
-}_{\text{ Énergie potentielle virtuelle du ressort }}
+	V =
+	\underbrace{
+		1/2 \, \dot{\col{q}}^T H \dot{\col{q}}
+	}_{\text{ Énergie cinétique réelle du robot }}
+	+
+	\underbrace{
+		1/2 \, \col{r}_e^T K \col{r}_e
+	}_{\text{ Énergie potentielle virtuelle du ressort }}
 \end{align}
 %%%%%%%%%%%%%%%%%
-Il est possible de démontré que cette fonction est toujours décroissante dans le temps sous certaines conditions:
+Il est possible de démontrer que cette fonction est toujours décroissante dans le temps sous certaines conditions:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{V} &= \frac{d}{dt} \left[ 1/2 \,  \dot{\col{q}}^T H \dot{\col{q}}  + 1/2 \, \col{r}_e^T K \col{r}_e \right]  \\
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-H \ddot{\col{q}} + 2 \dot{H} \dot{\col{q}}
-\right] +
-\col{r}_e^T K \col{\dot{r}}_e
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-\col{\tau} - \col{g} - \col{d}
-\right] -
-\col{\dot{r}}^T K \col{r}_e
-\quad \quad
-\text{pour une position désirée fixe: }  \col{\dot{r}}_e = \col{\dot{r}}_d - \col{\dot{r}} = - \col{\dot{r}}
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-\col{\tau} - \col{g} - \col{d}
-\right] -
-\col{\dot{q}}^T J^T K \col{r}_e
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-\col{\tau} - \col{g} - \col{d}
-\right] -
-\col{\dot{q}}^T J^T K \col{r}_e
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-\col{\tau} - \col{g} - \col{d}
-- J^T K \col{r}_e
-\right]
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-J^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}
-- \col{g} - \col{d}
-- J^T K \col{r}_e
-\right]
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-J^T  K \col{r}_e 
-- J^T B \col{\dot{r}}
-+ \col{\hat{g}}
-- \col{g} - \col{d}
-- J^T K \col{r}_e
-\right]
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-- J^T B J \col{\dot{q}}
-+ \col{\hat{g}}
-- \col{g} - \col{d}
-\right]
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-- J^T B J \col{\dot{q}} - \col{d}
-\right]
-\quad \quad
-\text{si la compensation de gravité est parfaite}
-\\%%%%%%%%%%%%%
-\dot{V} &= \dot{\col{q}}^T 
-\left[ 
-- J^T B J \col{\dot{q}} - D \col{\dot{q}}
-\right]
-\quad \quad
-\text{si on considère la friction dans les joints du robot comme linéaire}
-\\%%%%%%%%%%%%%
-\dot{V} &= - \dot{\col{q}}^T 
-\left[ 
-J^T B J + D 
-\right] \col{\dot{q}}
-\\%%%%%%%%%%%%%
-\dot{V} &< 0 \quad  
-\forall \col{\dot{q}} \neq \col{0} \quad 
-\text{si} \left[ J^T B J + D \right]  > 0
-\quad\quad \Rightarrow \quad\quad
-\lim_{t \rightarrow \infty} \col{r}_e(t) = \col{0} \quad \& \quad
-\lim_{t \rightarrow \infty} \col{\dot{q}}(t) = \col{0}
-\end{align} 
+	\dot{V} &= \frac{d}{dt} \left[ 1/2 \,  \dot{\col{q}}^T H \dot{\col{q}}  + 1/2 \, \col{r}_e^T K \col{r}_e \right]  \\
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		H \ddot{\col{q}} + 2 \dot{H} \dot{\col{q}}
+		\right] +
+	\col{r}_e^T K \col{\dot{r}}_e
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		\col{\tau} - \col{g} - \col{d}
+		\right] -
+	\col{\dot{r}}^T K \col{r}_e
+	\quad \quad
+	\text{pour une position désirée fixe: }  \col{\dot{r}}_e = \col{\dot{r}}_d - \col{\dot{r}} = - \col{\dot{r}}
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		\col{\tau} - \col{g} - \col{d}
+		\right] -
+	\col{\dot{q}}^T J^T K \col{r}_e
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		\col{\tau} - \col{g} - \col{d}
+		\right] -
+	\col{\dot{q}}^T J^T K \col{r}_e
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		\col{\tau} - \col{g} - \col{d}
+		- J^T K \col{r}_e
+		\right]
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		J^T   \left[ K \col{r}_e + B \col{\dot{r}}_e \right] + \col{\hat{g}}
+		- \col{g} - \col{d}
+		- J^T K \col{r}_e
+		\right]
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		J^T  K \col{r}_e
+		- J^T B \col{\dot{r}}
+		+ \col{\hat{g}}
+		- \col{g} - \col{d}
+		- J^T K \col{r}_e
+		\right]
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		- J^T B J \col{\dot{q}}
+		+ \col{\hat{g}}
+		- \col{g} - \col{d}
+		\right]
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		- J^T B J \col{\dot{q}} - \col{d}
+		\right]
+	\quad \quad
+	\text{si la compensation de gravité est parfaite}
+	\\%%%%%%%%%%%%%
+	\dot{V} &= \dot{\col{q}}^T
+	\left[
+		- J^T B J \col{\dot{q}} - D \col{\dot{q}}
+		\right]
+	\quad \quad
+	\text{si on considère la friction dans les joints du robot comme linéaire}
+	\\%%%%%%%%%%%%%
+	\dot{V} &= - \dot{\col{q}}^T
+	\left[
+		J^T B J + D
+		\right] \col{\dot{q}}
+	\\%%%%%%%%%%%%%
+	\dot{V} &< 0 \quad
+	\forall \col{\dot{q}} \neq \col{0} \quad
+	\text{si} \left[ J^T B J + D \right]  > 0
+	\quad\quad \Rightarrow \quad\quad
+	\lim_{t \rightarrow \infty} \col{r}_e(t) = \col{0} \quad \& \quad
+	\lim_{t \rightarrow \infty} \col{\dot{q}}(t) = \col{0}
+\end{align}
 %%%%%%%%%%%%%%%%%
-Ce qui démontre que le système va nécessairement converger vers le point minimum de la fonction $V$, ce qui correspond à $\col{q} = \col{0}$ et $\col{r}_e = \col{0}$. Avec comme condition que les termes d'amortissement total du système (contrôleur + friction naturelle) sont positifs, i.e. l'énergie nette du système est dissipée. Cette analyse peut aussi être faites pour une impédance dans le domaine des joints, et une combinaison des deux, pour obtenir des conclusions équivalentes. 
+Ce qui démontre que le système va nécessairement converger vers le point minimum de la fonction $V$, ce qui correspond à $\col{q} = \col{0}$ et $\col{r}_e = \col{0}$. Avec comme condition que les termes d'amortissement total du système (contrôleur + friction naturelle) sont positifs, c.-à-d. l'énergie nette du système est dissipée. Cette analyse peut aussi être faite pour une impédance dans le domaine des joints, et une combinaison des deux, pour obtenir des conclusions équivalentes.
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{figure}[th]
-% 	\centering
-% 		\includegraphics[width=0.70\textwidth]{fig/impedancecontroltaskconvergencemath.jpg}
-% 	\caption{Contrôleur en impédance à l'effecteur: analyse de convergence}
-% 	\label{fig:impedancecontroltaskconvergencemath}
+%  \centering
+%     \includegraphics[width=0.70\textwidth]{fig/impedancecontroltaskconvergencemath.jpg}
+%  \caption{Contrôleur en impédance à l'effecteur: analyse de convergence}
+%  \label{fig:impedancecontroltaskconvergencemath}
 % \end{figure}
 % ¢
 
@@ -652,60 +656,60 @@ Ce qui démontre que le système va nécessairement converger vers le point mini
 Pour un contrôle en admittance, dans l'espace des joints ou de la tâche, des capteurs mesurent des forces et le déplacement du robot est contrôlé à bas niveau, soit en position ou en vitesse. Si les actionneurs sont asservis en position, la relation générique est:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-q_i = \frac{1}{Z_i(s)} \tau_i
-\label{eq:admipos}
+	q_i = \frac{1}{Z_i(s)} \tau_i
+	\label{eq:admipos}
 \end{align}
 %%%%%%%%%%%%%%%%%
 où $q_i$ est une consigne de position pour le joint $i$, $Z_i$ est une impédance désirée pour le joint $i$ et $\tau_i$ est la force mesurée au joint $i$.
 Si les actionneurs sont asservis en vitesse à bas niveau, la relation générique est:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{q}_i = \frac{s}{Z_i(s)} \tau_i
-\label{eq:admispeed}
+	\dot{q}_i = \frac{s}{Z_i(s)} \tau_i
+	\label{eq:admispeed}
 \end{align}
 %%%%%%%%%%%%%%%%%
 
-Lorsqu'on implémente une loi de commande il est préférable d'éviter de dériver des signaux, donc certaines combinaison de type de consigne bas-niveau (position vs. vitesse) avec un type d'impédance sont préférable. Par exemple, pour émuler une force proportionnelle à une vitesse $Z_i(s) = b_i s$ avec des actionneurs contrôlés en vitesse, l'équation \eqref{eq:admispeed} se réduit à 
+Lorsqu'on implémente une loi de commande il est préférable d'éviter de dériver des signaux, donc certaines combinaisons de type de consigne bas-niveau (position vs. vitesse) avec un type d'impédance sont préférables. Par exemple, pour émuler une force proportionnelle à une vitesse $Z_i(s) = b_i s$ avec des actionneurs contrôlés en vitesse, l'équation \eqref{eq:admispeed} se réduit à
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{q}_i = \frac{1}{b} \tau_i
+	\dot{q}_i = \frac{1}{b} \tau_i
 \end{align}
 %%%%%%%%%%%%%%%%%
-donc simplement une relation algébrique entre les signaux. Avec des actionneurs contrôlés en position l'équation \eqref{eq:admipos} se réduit à 
+donc simplement une relation algébrique entre les signaux. Avec des actionneurs contrôlés en position l'équation \eqref{eq:admipos} se réduit à
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-q_i = \frac{1}{b s} \tau_i = \frac{1}{b} \int \tau_i
+	q_i = \frac{1}{b s} \tau_i = \frac{1}{b} \int \tau_i
 \end{align}
 %%%%%%%%%%%%%%%%%
-ce qui implique d'intégrer le signal de force. Par contre, si on désire émuler un système masse-ressort-amortisseur c'est l'approche avec des actionneurs en position qui est préférable. Avec des actionneurs contrôlés en position l'équation \eqref{eq:admipos} se réduit à  
+ce qui implique d'intégrer le signal de force. Par contre, si l'on désire émuler un système masse-ressort-amortisseur c'est l'approche avec des actionneurs en position qui est préférable. Avec des actionneurs contrôlés en position l'équation \eqref{eq:admipos} se réduit à
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{q}_i = \frac{1}{ms^2+bs+k} \tau_i
+	\dot{q}_i = \frac{1}{ms^2+bs+k} \tau_i
 \end{align}
 %%%%%%%%%%%%%%%%%
-La fonction de transfert a deux pôles donc l'implémentation inclurait deux intégrales. Avec des actionneurs contrôlés en vitesse l'équation \eqref{eq:admispeed} se réduit à 
+La fonction de transfert a deux pôles donc l'implémentation inclurait deux intégrales. Avec des actionneurs contrôlés en vitesse l'équation \eqref{eq:admispeed} se réduit à
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{q}_i = \frac{s}{ms^2+bs+k} \tau_i
+	\dot{q}_i = \frac{s}{ms^2+bs+k} \tau_i
 \end{align}
 %%%%%%%%%%%%%%%%%
-une fonction de transfert qui a en plus un zéro, donc demanderait de dériver un signal en plus des deux intégrales. Pour l'implémentation d'une loi de commande, l'idéal lorsque possible est une relation algébrique. Si on doit avoir une relation différentielle il est préférable d'avoir seulement des intégrales. Les opérations de dérivations sont à éviter. 
+une fonction de transfert qui a en plus un zéro, donc demanderait de dériver un signal en plus des deux intégrales. Pour l'implémentation d'une loi de commande, l'idéal lorsque possible est une relation algébrique. Si on doit avoir une relation différentielle, il est préférable d'avoir seulement des intégrales. Les opérations de dérivations sont à éviter.
 
 \subsection{Commande en admittance aux joints}
 \label{sec:jointadmcontrol}
 
-Pour un contrôle en admittance dans l'espace des joints, des capteurs de forces vont mesurée la force actuelle à chaque joint et commander un déplacement à l'actionneur relié. Les lois en admittance peuvent aussi être exprimées en format matricielle pour décrire le comportement de tous les joints en une seule équation. La Figure \ref{fig:admitancecontroljointspace1} présente un contrôleur en admittance de type amortisseurs avec comme comportement cible la relation:
+Pour un contrôle en admittance dans l'espace des joints, des capteurs de forces vont mesurer la force actuelle à chaque joint et commander un déplacement à l'actionneur relié. Les lois en admittance peuvent aussi être exprimées en format matriciel pour décrire le comportement de tous les joints en une seule équation. La Figure \ref{fig:admitancecontroljointspace1} présente un contrôleur en admittance de type amortisseur avec comme comportement cible la relation:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-B \col{\dot{q}} = \col{\tau}
+	B \col{\dot{q}} = \col{\tau}
 \end{align}
 %%%%%%%%%%%%%%%%%
-pour un robot contrôlé en vitesse à bas niveau dans l'espace des joints, avec des capteurs qui mesure le couple de chaque joint. 
+pour un robot contrôlé en vitesse à bas niveau dans l'espace des joints, avec des capteurs qui mesurent le couple de chaque joint.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[th]
 	\centering
-		\includegraphics[width=0.70\textwidth]{fig/admitancecontroljointspace1.jpg}
-	\caption{Commande de l'admittance au joints d'un robot : schéma bloc}
+	\includegraphics[width=0.70\textwidth]{fig/admitancecontroljointspace1.jpg}
+	\caption{Commande de l'admittance aux joints d'un robot : schéma bloc}
 	\label{fig:admitancecontroljointspace1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -713,15 +717,15 @@ pour un robot contrôlé en vitesse à bas niveau dans l'espace des joints, avec
 La Figure \ref{fig:admitancecontroljointspace} présente le schéma bloc d'un contrôleur en admittance avec comme comportement cible la relation:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-M \col{\ddot{q}} + B \col{\dot{q}} + K \col{q} = \col{\tau}
+	M \col{\ddot{q}} + B \col{\dot{q}} + K \col{q} = \col{\tau}
 \end{align}
 %%%%%%%%%%%%%%%%%
-pour un robot contrôlé en position à bas niveau dans l'espace des joints, avec des capteurs qui mesure le couple de chaque joint. Pour ce cas il y a deux intégrale dans la loi de commande. On peut interpréter le bloc "loi de comportement" à la Figure \ref{fig:admitancecontroljointspace} qui est tout simplement la simulation d'un système masse-ressort-amortisseur qui reçoit en entrée une force réelle lue par un capteur. Le résultat de la simulation est ensuite envoyer à un contrôleur en déplacement. Le robot va donc émuler le système virtuel simulé. 
+pour un robot contrôlé en position à bas niveau dans l'espace des joints, avec des capteurs qui mesurent le couple de chaque joint. Pour ce cas, il y a deux intégrales dans la loi de commande. On peut interpréter le bloc "loi de comportement" à la Figure \ref{fig:admitancecontroljointspace} qui est tout simplement la simulation d'un système masse-ressort-amortisseur qui reçoit en entrée une force réelle lue par un capteur. Le résultat de la simulation est ensuite envoyé à un contrôleur en déplacement. Le robot va donc émuler le système virtuel simulé.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.85\textwidth]{fig/admitancecontroljointspace.jpg}
-	\caption{Commande de l'admittance au joints d'un robot : schéma bloc}
+	\includegraphics[width=0.85\textwidth]{fig/admitancecontroljointspace.jpg}
+	\caption{Commande de l'admittance aux joints d'un robot : schéma bloc}
 	\label{fig:admitancecontroljointspace}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -733,14 +737,14 @@ pour un robot contrôlé en position à bas niveau dans l'espace des joints, ave
 
 L'approche en admittance dans l'espace de l'effecteur est basée sur une mesure de la force à l'effecteur (généralement avec une cellule de charge) et le contrôle du déplacement de l'effecteur à bas niveau. La Figure \ref{fig:admittancecontroltaskspace1} présente un schéma bloc d'une loi de commande en admittance pour imposer un comportement: %%%%%%%%%%%%%%%%%%
 \begin{align}
-B \col{\dot{r}} = \col{f}_e
+	B \col{\dot{r}} = \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%%%
-Une chose à noter est que généralement la cellule de charge va mesurer les composantes du vecteur force $\Vec{f}_e$ dans une base vectorielle mobile $t$ attachée à l'outil. Il faut donc faire un changement de base avec la matrice de rotation ${}^{w}R^t$ pour avoir les composantes dans la base vectorielle fixe $w$ dans laquelle le reste des autres vecteurs sont exprimés. La matrice de rotation ${}^{w}R^t$ doit donc être obtenue basé sur la positon des joints actuels en utilisant la relation de cinématique directe pour l'orientation. La loi de commande de la Figure \ref{fig:admittancecontroltaskspace1} est utilisée pour les "teach mode" des robots manipulateur, i.e. le mode ou un opérateur peut déplacer le robot manuellement dans l'espace. Avec cette loi de commande, un humain peut pousser sur l'effecteur du robot et le robot se déplacera alors dans le sens de la poussée avec une vitesse proportionnelle à l'amplitude de la poussée. Si il n'y a aucune poussée le robot reste en place. 
+Une chose à noter est que généralement la cellule de charge va mesurer les composantes du vecteur force $\Vec{f}_e$ dans une base vectorielle mobile $t$ attachée à l'outil. Il faut donc faire un changement de base avec la matrice de rotation ${}^{w}R^t$ pour avoir les composantes dans la base vectorielle fixe $w$ dans laquelle le reste des autres vecteurs sont exprimés. La matrice de rotation ${}^{w}R^t$ doit donc être obtenue basé sur la position des joints actuels en utilisant la relation de cinématique directe pour l'orientation. La loi de commande de la Figure \ref{fig:admittancecontroltaskspace1} est utilisée pour les "teach mode" des robots manipulateurs, c.-à-d. le mode où un opérateur peut déplacer le robot manuellement dans l'espace. Avec cette loi de commande, un humain peut pousser sur l'effecteur du robot et le robot se déplacera alors dans le sens de la poussée avec une vitesse proportionnelle à l'amplitude de la poussée. S’il n'y a aucune poussée, le robot reste en place.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/admittancecontroltaskspace1.jpg}
+	\includegraphics[width=0.80\textwidth]{fig/admittancecontroltaskspace1.jpg}
 	\caption{Commande de l'admittance à l'effecteur d'un robot avec une loi de comportement de type amortisseur: schéma bloc}
 	\label{fig:admittancecontroltaskspace1}
 \end{figure}
@@ -749,17 +753,16 @@ Une chose à noter est que généralement la cellule de charge va mesurer les co
 La Figure \ref{fig:admittancecontroltaskspace1} montre le schéma bloc d'une loi de commande plus générique pour une loi de comportement égale à une masse-ressort-amortisseur à l'effecteur:
 %%%%%%%%%%%%%%%%%%
 \begin{align}
-M \col{\ddot{r}} + B \col{\dot{r}} + K \col{r}= \col{f}_e
+	M \col{\ddot{r}} + B \col{\dot{r}} + K \col{r}= \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[h]
 	\centering
-		\includegraphics[width=0.99\textwidth]{fig/admittancecontroltaskspace.jpg}
+	\includegraphics[width=0.99\textwidth]{fig/admittancecontroltaskspace.jpg}
 	\caption{Commande de l'admittance à l'effecteur d'un robot avec une loi de comportement de type masse-ressort-amortisseur: schéma bloc}
 	\label{fig:admittancecontroltaskspace}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est à noté que les Figures \ref{fig:admittancecontroltaskspace1} et \ref{fig:admittancecontroltaskspace} ne montre pas le détail de la boucle interne du contrôleur en vitesse ou position de l'effecteur. Les méthodes présentées aux sections \ref{sec:speedcontrol} et \ref{sec:positioncontrol} peuvent être utilisée. Une différence à noter pour l'approche en admittance basée sur l'utilisation d'une cellule de charge à l'effecteur du robot, par rapport aux autres approches présentés est que seul les forces qui sont appliquées à l'effecteur (en aval de la cellule de charge) vont influencer la position du robot. Si une force est appliqué sur les liens du robot en amont de la cellule de charge, le contrôleur n'aura pas connaissance de cette force externe qui ne sera donc pas pris en compte dans le calcul du déplacement du robot basée sur la loi de comportement désirée.
-
+Il est à noter que les Figures \ref{fig:admittancecontroltaskspace1} et \ref{fig:admittancecontroltaskspace} ne montre pas le détail de la boucle interne du contrôleur en vitesse ou position de l'effecteur. Les méthodes présentées aux sections \ref{sec:speedcontrol} et \ref{sec:positioncontrol} peuvent être utilisée. Une différence à noter pour l'approche en admittance basée sur l'utilisation d'une cellule de charge à l'effecteur du robot par rapport aux autres approches présentées est que seules les forces qui sont appliquées à l'effecteur (en aval de la cellule de charge) vont influencer la position du robot. Si une force est appliquée sur les liens du robot en amont de la cellule de charge, le contrôleur n'aura pas connaissance de cette force externe qui ne sera donc pas prise en compte dans le calcul du déplacement du robot basé sur la loi de comportement désirée.
 

--- a/src/exer.tex
+++ b/src/exer.tex
@@ -29,29 +29,29 @@
 \subsection{Traduire des énoncés en équations vectorielles}
 \label{sec:exerposmaison}
 
-Convertissez les énoncés suivant en équations vectorielles avec des scalaires qui représentent des distances et des vecteur unitaires qui représentent des directions. 
+Convertissez les énoncés suivants en équations vectorielles avec des scalaires qui représentent des distances et des vecteurs unitaires qui représentent des directions.
 
-\paragraph{A)} 
+\paragraph{A)}
 
 À partir d'un point A, on avance de 100m vers le nord, 15m vers l'ouest et 50m vers le sud-est, pour arriver sur le point B.
 
-\paragraph{B)} 
+\paragraph{B)}
 
-À partir d'un point A, on avance de 50m vers le sud, dévie de 30 degrés vers la gauche (bâbord) et avance de 100m, pour arriver sur le point B. 
+À partir d'un point A, on avance de 50m vers le sud, dévie de 30 degrés vers la gauche (bâbord) et avance de 100m, pour arriver sur le point B.
 
 
-\paragraph{C)} 
+\paragraph{C)}
 
 À partir d'un point A, on avance de 200m vers le l'est, dévie de 60 degrés vers la droite (tribord) et avance de 50 m. Ensuite, on s'oriente à l'opposé de la direction du point A et on double la distance par rapport au point A pour arriver sur le point B.
- 
+
 
 \subsection{Substitution de vecteurs unitaires}
 
 Convertissez les équations vectorielles obtenues à l’exercice \ref{sec:exerposmaison} pour seulement contenir les deux vecteurs unitaires suivants:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{n} : Nord \quad\quad   \hat{o} : Ouest
-\end{align} 
+	\hat{n} : Nord \quad\quad   \hat{o} : Ouest
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -59,19 +59,19 @@ Convertissez les équations vectorielles obtenues à l’exercice \ref{sec:exerp
 
 \subsection{Obtenir les composantes avec un produit scalaire}
 
-Le vecteur $\vec{v}$ est définie dans une base vectorielle orthogonale $a$:
+Le vecteur $\vec{v}$ est défini dans une base vectorielle orthogonale $a$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{v} = v_1 \hat{a}_1 + v_2 \hat{a}_2 + v_3 \hat{a}_3
-\end{align} 
+	\vec{v} = v_1 \hat{a}_1 + v_2 \hat{a}_2 + v_3 \hat{a}_3
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-démontrez que 
+démontrez que
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-v_1 = \vec{v} \bullet \hat{a}_1 \\
-v_2 = \vec{v} \bullet \hat{a}_2 \\
-v_3 = \vec{v} \bullet \hat{a}_3 
-\end{align} 
+	v_1 = \vec{v} \bullet \hat{a}_1 \\
+	v_2 = \vec{v} \bullet \hat{a}_2 \\
+	v_3 = \vec{v} \bullet \hat{a}_3
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 en se basant sur les définitions.
 
@@ -82,75 +82,75 @@ en se basant sur les définitions.
 
 Effectuer le calcul de la matrice $R_3$ discutée à la section \ref{sec:rot3}:
 
-\paragraph{A)} À partir de la définition basée sur les produit scalaires:
+\paragraph{A)} À partir de la définition basée sur les produits scalaires:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_b^a &= 
-\left[ \begin{array}{c c c} 
-\hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 \\
-\hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 \\
-\hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 
-\end{array} \right] 
-\end{align} 
+	R_b^a &=
+	\left[ \begin{array}{c c c}
+			   \hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 \\
+			   \hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 \\
+			   \hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{B)} À partir de la définition basée sur l'angle entre les vecteurs unitaires:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_b^a &= 
-\left[ \begin{array}{c c c} 
-\cos \angle (\hat{a}_1 , \hat{b}_1)  &  \cos \angle (\hat{a}_1 , \hat{b}_2)  &  \cos \angle (\hat{a}_1 , \hat{b}_3) \\
-\cos \angle (\hat{a}_2 , \hat{b}_1)  &  \cos \angle (\hat{a}_2 , \hat{b}_2)  &  \cos \angle (\hat{a}_2 , \hat{b}_3) \\
-\cos \angle (\hat{a}_3 , \hat{b}_1)  &  \cos \angle (\hat{a}_3 , \hat{b}_2)  &  \cos \angle (\hat{a}_3 , \hat{b}_3) 
-\end{array} \right] 
-\end{align} 
+	R_b^a &=
+	\left[ \begin{array}{c c c}
+			   \cos \angle (\hat{a}_1 , \hat{b}_1)  &  \cos \angle (\hat{a}_1 , \hat{b}_2)  &  \cos \angle (\hat{a}_1 , \hat{b}_3) \\
+			   \cos \angle (\hat{a}_2 , \hat{b}_1)  &  \cos \angle (\hat{a}_2 , \hat{b}_2)  &  \cos \angle (\hat{a}_2 , \hat{b}_3) \\
+			   \cos \angle (\hat{a}_3 , \hat{b}_1)  &  \cos \angle (\hat{a}_3 , \hat{b}_2)  &  \cos \angle (\hat{a}_3 , \hat{b}_3)
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{C)} À partir de la définition basée sur les composants des vecteurs unitaires $\hat{b}_i$ dans la base $a$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_b^a &= 
-\left[ \begin{array}{c c c} 
-\col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
-\end{array} \right] 
-\end{align} 
+	R_b^a &=
+	\left[ \begin{array}{c c c}
+			   \col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{D)} À partir de la définition basée sur les composants des vecteurs unitaires $\hat{a}_i$ dans la base $b$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_b^a &= 
-\left[ \begin{array}{c} 
-(\col{a}_1^b)^T \\
-(\col{a}_2^b)^T \\
-(\col{a}_3^b)^T
-\end{array} \right] 
-\end{align} 
+	R_b^a &=
+	\left[ \begin{array}{c}
+			   (\col{a}_1^b)^T \\
+			   (\col{a}_2^b)^T \\
+			   (\col{a}_3^b)^T
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{E)} À partir de la définition basée sur les angles de Euler:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_b^a &= 
-\left[ \begin{array}{c c c}
-	 + c\phi \, c\psi - s\phi\,c\theta\,c\psi  & - c\phi \, s\psi - s\phi \, c\theta c\psi  & + s\phi \, s\theta  \\
-	 + s\phi \, c\psi + c\phi\,c\theta\,c\psi  & - s\phi \, s\psi + c\phi \, c\theta c\psi  & - c\phi \, s\theta  \\
-	 + s\theta \, s\psi                        & + s\theta \, c\psi                          & + c\theta 
-\end{array}  \right]
-\end{align} 
+	R_b^a &=
+	\left[ \begin{array}{c c c}
+			   + c\phi \, c\psi - s\phi\,c\theta\,c\psi  & - c\phi \, s\psi - s\phi \, c\theta c\psi  & + s\phi \, s\theta  \\
+			   + s\phi \, c\psi + c\phi\,c\theta\,c\psi  & - s\phi \, s\psi + c\phi \, c\theta c\psi  & - c\phi \, s\theta  \\
+			   + s\theta \, s\psi                        & + s\theta \, c\psi                          & + c\theta
+	\end{array}  \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 
 \subsection{Axe de rotation à partir d'une matrice de rotation}
 
-La figure \ref{fig:exer_mat_axe_1} illustre deux base vectorielle avec une orientation relative décrite par la matrice ${}^aR^b$. 
+La figure \ref{fig:exer_mat_axe_1} illustre deux bases vectorielles avec une orientation relative décrite par la matrice ${}^aR^b$.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.40\textwidth]{exer_mat_axe_1.png}
+	\includegraphics[width=0.40\textwidth]{exer_mat_axe_1.png}
 	\caption{Calcul d'un axe de rotation à partir d'une matrice}
 	\label{fig:exer_mat_axe_1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
 
-\paragraph{A)} Vérifiez que la matrice de rotation illustrée ci-dessus a une valeur propre réel $\lambda=1$.
+\paragraph{A)} Vérifiez que la matrice de rotation illustrée ci-dessus a une valeur propre réelle $\lambda=1$.
 \paragraph{B)} Calculez le vecteur propre associé.
 \paragraph{C)} Vérifiez graphiquement que le vecteur propre calculé correspond à l’axe de rotation.
 
@@ -161,13 +161,13 @@ La figure \ref{fig:exer_mat_axe_1} illustre deux base vectorielle avec une orien
 Un avion détecte un ovni et sa position dans son repère $\{ V_o, \hat{v}_1, \hat{v}_2, \hat{v}_2\}$, il doit transmettre les coordonnées de cet ovni par rapport au repère $\{ B_o, \hat{b}_1, \hat{b}_2, \hat{b}_2\}$ de la base, voir figure \ref{fig:exrep}. Écrivez une fonction, dans votre langage de programmation préféré, pour effectuer le calcul:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^b_{Ovni/B_o} = f\left( \col{r}^v_{Ovni/V_o}, \theta, h, d\right)
-\end{align} 
+	\col{r}^b_{Ovni/B_o} = f\left( \col{r}^v_{Ovni/V_o}, \theta, h, d\right)
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.70\textwidth]{exrep.png}
+	\includegraphics[width=0.70\textwidth]{exrep.png}
 	\caption{Calcul d'un changement de repère}
 	\label{fig:exrep}
 \end{figure}
@@ -177,32 +177,32 @@ Un avion détecte un ovni et sa position dans son repère $\{ V_o, \hat{v}_1, \h
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Calcul de la cinématique d'un robot à deux joints}
 
-La figure \ref{fig:exrobot2} illustre un robot planaire à deux joints. 
+La figure \ref{fig:exrobot2} illustre un robot planaire à deux joints.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.50\textwidth]{exrobot2.png}
+	\includegraphics[width=0.50\textwidth]{exrobot2.png}
 	\caption{Calcul de la cinématique d'un robot à deux joints}
 	\label{fig:exrobot2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{A)}
-Tracez le robot (ligne reliant les points $A_o$, $B_o$, $C_o$ et $D_o$) lorsque la configuration des joints est (en Radians):
+Tracez le robot (ligne reliant les points $A_o$, $B_o$, $C_o$ et $D_o$) lorsque la configuration des joints est (en radians):
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\theta_1 &= 0.3 \\
-\theta_2 &= -1.6
-\end{align} 
+	\theta_1 &= 0.3 \\
+	\theta_2 &= -1.6
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\paragraph{B)} 
-Tracez la trajectoire de l'effecteur (point $D_o$) lorsque les joints bougent selon les fonctions temporelles (en Radians):
+\paragraph{B)}
+Tracez la trajectoire de l'effecteur (point $D_o$) lorsque les joints bougent selon les fonctions temporelles (en radians):
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\theta_1(t) &= 0.5 \sin(t) + 0.3 \\
-\theta_2(t) &= 0.3 \sin(2t) - 1.6
-\end{align} 
+	\theta_1(t) &= 0.5 \sin(t) + 0.3 \\
+	\theta_2(t) &= 0.3 \sin(2t) - 1.6
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -211,40 +211,40 @@ Tracez la trajectoire de l'effecteur (point $D_o$) lorsque les joints bougent se
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Calcul de la position de l'effecteur d'un robot}
 
-La figure \ref{fig:exer_robot3D} illustre un robot avec quatre joints rotatifs. 
+La figure \ref{fig:exer_robot3D} illustre un robot avec quatre joints rotatifs.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.65\textwidth]{exer_robot3D.png}
+	\includegraphics[width=0.65\textwidth]{exer_robot3D.png}
 	\caption{Calcul de la cinématique d'un robot en 3D}
 	\label{fig:exer_robot3D}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{A)}
-Identifier des points et bases vectorielles intermédiaires à utiliser. 
+Identifier des points et bases vectorielles intermédiaires à utiliser.
 
-\paragraph{B)} 
+\paragraph{B)}
 Trouver le vecteur position de l'effecteur par rapport à l'origine $O$, exprimé dans la base vectorielle $a$.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Calcul de la cinématique d'une grue}
 
-La figure \ref{fig:exer_grue3D} illustre une grue. 
+La figure \ref{fig:exer_grue3D} illustre une grue.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.75\textwidth]{exer_grue3D.png}
+	\includegraphics[width=0.75\textwidth]{exer_grue3D.png}
 	\caption{Calcul de la cinématique d'un robot en 3D}
 	\label{fig:exer_grue3D}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{A)}
-Identifier des points et bases vectorielles intermédiaires à utiliser. 
+Identifier des points et bases vectorielles intermédiaires à utiliser.
 
-\paragraph{B)} 
+\paragraph{B)}
 Trouver le vecteur position du point $B$ par rapport à l'origine $A_o$, exprimé dans la base vectorielle $a$.
 
 
@@ -256,7 +256,7 @@ Trouver le vecteur position du point $B$ par rapport à l'origine $A_o$, exprim�
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.75\textwidth]{exer_jambe.png}
+	\includegraphics[width=0.75\textwidth]{exer_jambe.png}
 	\caption{Calcul de la cinématique d'une jambe}
 	\label{fig:exer_jambe}
 \end{figure}
@@ -269,8 +269,9 @@ Trouver le vecteur position du point $B$ par rapport à l'origine $A_o$, exprim�
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.75\textwidth]{exer_robot2D.png}
+	\includegraphics[width=0.75\textwidth]{exer_robot2D.png}
 	\caption{Calcul de la cinématique d'un robot à trois joints}
 	\label{fig:exer_exer_robot2D}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
+

--- a/src/manip/cinematique.tex
+++ b/src/manip/cinematique.tex
@@ -1,7 +1,7 @@
 \chapter{Cinématique I: La position}
 \label{sec:cine1}
 
-Ce chapitre présente des méthodes pour modéliser et analyser la position de systèmes à plusieurs degrés de liberté, donc bien adaptés aux robots manipulateurs. Dans un contexte de robotique, les problèmes de cinématique consistent premièrement à bien choisir et définir des systèmes de coordonnées pertinents. Par exemple, des coordonnées généralisées pour décrire la configuration des joints, des coordonnées cartésiennes pour décrire la tâche d'un robot en terme de trajectoire de l'effecteur, des coordonnées sphériques pour décrire les mesures d'un système de vision, etc. Ensuite, le défi est de \textbf{calculer les fonctions de transformations pour passer d'un système de coordonnées à un autre}. Par exemple, pour les robots manipulateurs, le principal défi est le calcul de la fonction de la cinématique directe et son inverse, i.e. une fonction avec comme entrées les coordonnées généralisées qui représentent la configuration des joints et comme sortie la pose de l'effecteur. Le calcul de ces transformations dans un contexte de robotique est le sujet principal de ce chapitre. La section \ref{sec:syscoord} introduit aux différents systèmes de coordonnées. Les sections \ref{sec:vecgeopos} et \ref{sec:basevecpos} introduisent les notions de vecteurs de position géométriques, bases vectorielles et vecteur-colonnes de composantes. Les sections \ref{sec:changematrice} et \ref{sec:repere} présentent les changements de base et les changements des repères. Ensuite, la section \ref{sec:corps} présente les méthodes pour représenter mathématiquement la pose d'un corps rigide. Finalement, les sections \ref{sec:fwdkin} et \ref{sec:invkin} traitent de la cinématique des robots manipulateurs, i.e. le calcul des transformations pour passer de l'espace des joints à la pose de l'effecteur et vice-versa. 
+Ce chapitre présente des méthodes pour modéliser et analyser la position de systèmes à plusieurs degrés de liberté, donc bien adaptés aux robots manipulateurs. Dans un contexte de robotique, les problèmes de cinématique consistent premièrement à bien choisir et définir des systèmes de coordonnées pertinents. Par exemple, des coordonnées généralisées pour décrire la configuration des joints, des coordonnées cartésiennes pour décrire la tâche d'un robot en termes de trajectoire de l'effecteur, des coordonnées sphériques pour décrire les mesures d'un système de vision, etc. Ensuite, le défi est de \textbf{calculer les fonctions de transformations pour passer d'un système de coordonnées à un autre}. Par exemple, pour les robots manipulateurs, le principal défi est le calcul de la fonction de la cinématique directe et son inverse, c.-à-d. une fonction avec comme entrée les coordonnées généralisées qui représentent la configuration des joints et comme sortie la pose de l'effecteur. Le calcul de ces transformations dans un contexte de robotique est le sujet principal de ce chapitre. La section \ref{sec:syscoord} introduit aux différents systèmes de coordonnées. Les sections \ref{sec:vecgeopos} et \ref{sec:basevecpos} introduisent les notions de vecteurs de position géométriques, bases vectorielles et vecteurs-colonne de composantes. Les sections \ref{sec:changematrice} et \ref{sec:repere} présentent les changements de base et les changements des repères. Ensuite, la section \ref{sec:corps} présente les méthodes pour représenter mathématiquement la pose d'un corps rigide. Finalement, les sections \ref{sec:fwdkin} et \ref{sec:invkin} traitent de la cinématique des robots manipulateurs, c.-à-d. le calcul des transformations pour passer de l'espace des joints à la pose de l'effecteur et vice-versa.
 
 
 
@@ -11,108 +11,108 @@ Ce chapitre présente des méthodes pour modéliser et analyser la position de s
 \section{Systèmes de coordonnées}
 \label{sec:syscoord}
 
-Un système de coordonnées c'est un ensemble de scalaires, généralement des distances et des angles, qui décrivent la position d'un système. 
+Un système de coordonnées c'est un ensemble de scalaires, généralement des distances et des angles, qui décrivent la position d'un système.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Position d'une particule}
 \label{sec:syscoordparticule}
 
-Une particule (un point) dans l'espace tri-dimensionnel possède trois DDL et sa position peut donc être complètement déterminée par trois scalaires qui forment un système de coordonnées. Trois types de systèmes de coordonnées sont généralement utilisés pour décrire la position d'une particule par rapport à des axes: \textbf{cartésien} $( x, y, z)$, \textbf{cylindrique} $( r, \theta, z)$ ou \textbf{sphérique} $( \rho, \theta, \phi)$, voir la figure \ref{fig:coorsys}. 
+Une particule (un point) dans l'espace tridimensionnel possède trois DDL et sa position peut donc être complètement déterminée par trois scalaires qui forment un système de coordonnées. Trois types de systèmes de coordonnées sont généralement utilisés pour décrire la position d'une particule par rapport à des axes: \textbf{cartésien} $( x, y, z)$, \textbf{cylindrique} $( r, \theta, z)$ ou \textbf{sphérique} $( \rho, \theta, \phi)$, voir la figure \ref{fig:coorsys}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Cartésien]{
-				\includegraphics[width=0.28\textwidth]{carsys}
-				\label{fig:carsys}}
-				\subfloat[Cylindrique]{
-				\includegraphics[width=0.28\textwidth]{cylsys}
-				\label{fig:cylsys}}
-				\subfloat[Sphérique]{
-				\includegraphics[width=0.28\textwidth]{sphsys}
-				\label{fig:sphsys}}
-        \caption{Trois systèmes de coordonnées standards pour représenter la position d'un point en 3D}
-				\label{fig:coorsys}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Cartésien]{
+		\includegraphics[width=0.28\textwidth]{carsys}
+		\label{fig:carsys}}
+	\subfloat[Cylindrique]{
+		\includegraphics[width=0.28\textwidth]{cylsys}
+		\label{fig:cylsys}}
+	\subfloat[Sphérique]{
+		\includegraphics[width=0.28\textwidth]{sphsys}
+		\label{fig:sphsys}}
+	\caption{Trois systèmes de coordonnées standards pour représenter la position d'un point en 3D}
+	\label{fig:coorsys}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Selon la situation, l'utilisation d'un système de coordonnées particulier peut simplifier l'analyse d'un problème. Par exemple, pour localiser un point géographique sur la Terre, des coordonnées sphériques (ex.: longitude et latitude) sont plus pratiques que des coordonnées cartésiennes ($x$,$y$,$z$) par rapport au centre de la Terre. Parfois l'utilisation d'un type de système de coordonnées est nécessaire car un capteur mesure une coordonnée particulière. Par exemple, le \textit{LIDAR} sur une voiture autonome mesure des distances dans plusieurs directions grâce à un laser pivotant, les données brute sont des coordonnées sphériques. Il est donc parfois inévitable de faire la conversion d'un système de coordonnées à un autre. Le tableau \ref{tab:convcoord} donne les conversions entre des coordonnées cartésiennes, cylindriques et sphériques, qui sont basées sur la même origine et le même système d'axes.
+Selon la situation, l'utilisation d'un système de coordonnées particulier peut simplifier l'analyse d'un problème. Par exemple, pour localiser un point géographique sur la Terre, des coordonnées sphériques (ex.: longitude et latitude) sont plus pratiques que des coordonnées cartésiennes ($x$,$y$,$z$) par rapport au centre de la Terre. Parfois l'utilisation d'un type de système de coordonnées est nécessaire, car un capteur mesure une coordonnée particulière. Par exemple, le \textit{LIDAR} sur une voiture autonome mesure des distances dans plusieurs directions grâce à un laser pivotant, les données brutes sont des coordonnées sphériques. Il est donc parfois inévitable de faire la conversion d'un système de coordonnées à un autre. Le tableau \ref{tab:convcoord} donne les conversions entre des coordonnées cartésiennes, cylindriques et sphériques, qui sont basées sur la même origine et le même système d'axes.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{table}[htbp]
 	\centering
-		\begin{tabular}{|p{3cm}|p{3cm}|p{3cm}|p{3cm}|}
+	\begin{tabular}{|p{3cm}|p{3cm}|p{3cm}|p{3cm}|}
 		\hline
-		 & De cartésien & De cylindrique & De sphérique \\
-		\hline 
-		 Vers cartésien &
-			\vbox{\begin{align*}
-			x &= x \\
-			y &= y \\
-			z &= z
-			\end{align*}} 
-			& 
-			% Polaire vers xyz
-			\vbox{\begin{align*}
-			x &= r \cos \theta \\
-			y &= r \sin \theta \\
-			z &= z
-			\end{align*}}
-			& 
-			% Spherical vers xyz
-			\vbox{\begin{align*}
-			x &= \rho \sin \phi \cos \theta \\
-			y &= \rho \sin \phi \sin \theta \\
-			z &= \rho \cos \phi
-			\end{align*}}
-			\\
+		& De cartésien & De cylindrique & De sphérique \\
 		\hline
-		  Vers cylindrique &
-			% xyz vers cylindrique
-			\vbox{\begin{align*}
-			r &= \sqrt{x^2+y^2} \\
-			\theta &= \arctan \frac{y}{x} \\
-			z &= z
-			\end{align*}}
-			&  %cylindrique vers cylindrique
-			\vbox{\begin{align*}
-			r &= r \\
-			\theta &= \theta \\
-			z &= z
-			\end{align*}}
-			& %spherique vers cylindrique
-			\vbox{\begin{align*}
-			r &= \rho \sin \phi \\
-			\theta &= \theta \\
-			z &= \rho \cos \phi
-			\end{align*}}
-			\\
+		Vers cartésien &
+		\vbox{\begin{align*}
+				  x &= x \\
+				  y &= y \\
+				  z &= z
+		\end{align*}}
+		&
+		% Polaire vers xyz
+		\vbox{\begin{align*}
+				  x &= r \cos \theta \\
+				  y &= r \sin \theta \\
+				  z &= z
+		\end{align*}}
+		&
+		% Spherical vers xyz
+		\vbox{\begin{align*}
+				  x &= \rho \sin \phi \cos \theta \\
+				  y &= \rho \sin \phi \sin \theta \\
+				  z &= \rho \cos \phi
+		\end{align*}}
+		\\
 		\hline
-		  Vers sphérique &
-			% xyz vers Spherical 
-			\vbox{\begin{align*}
-			\rho &= \sqrt{x^2+y^2+z^2} \\
-			\theta &= \arctan \frac{y}{x} \\
-			\phi &= \arctan \frac{\sqrt{x^2+y^2}}{z}
-			\end{align*}}
-			& 
-			% cylindrical vers Spherical 
-			\vbox{\begin{align*}
-			\rho &= \sqrt{r^2+z^2} \\
-			\theta &= \theta \\
-			\phi &= \arctan \frac{r}{z}
-			\end{align*}}
-			& 
-			%  Spherical 
-			\vbox{\begin{align*}
-			\rho &= \rho \\
-			\theta &= \theta \\
-			\phi &= \phi
-			\end{align*}}
-			\\
+		Vers cylindrique &
+		% xyz vers cylindrique
+		\vbox{\begin{align*}
+				  r &= \sqrt{x^2+y^2} \\
+				  \theta &= \arctan \frac{y}{x} \\
+				  z &= z
+		\end{align*}}
+		&  %cylindrique vers cylindrique
+		\vbox{\begin{align*}
+				  r &= r \\
+				  \theta &= \theta \\
+				  z &= z
+		\end{align*}}
+		& %spherique vers cylindrique
+		\vbox{\begin{align*}
+				  r &= \rho \sin \phi \\
+				  \theta &= \theta \\
+				  z &= \rho \cos \phi
+		\end{align*}}
+		\\
 		\hline
-		\end{tabular}
-	\caption{Conversions entre les systèmes de coordonnées cartésiennes, polaires et sphériques qui font référence aux même axes et à la même origine.}
+		Vers sphérique &
+		% xyz vers Spherical
+		\vbox{\begin{align*}
+				  \rho &= \sqrt{x^2+y^2+z^2} \\
+				  \theta &= \arctan \frac{y}{x} \\
+				  \phi &= \arctan \frac{\sqrt{x^2+y^2}}{z}
+		\end{align*}}
+		&
+		% cylindrical vers Spherical
+		\vbox{\begin{align*}
+				  \rho &= \sqrt{r^2+z^2} \\
+				  \theta &= \theta \\
+				  \phi &= \arctan \frac{r}{z}
+		\end{align*}}
+		&
+		%  Spherical
+		\vbox{\begin{align*}
+				  \rho &= \rho \\
+				  \theta &= \theta \\
+				  \phi &= \phi
+		\end{align*}}
+		\\
+		\hline
+	\end{tabular}
+	\caption{Conversions entre les systèmes de coordonnées cartésiennes, polaires et sphériques qui font référence aux mêmes axes et à la même origine.}
 	\label{tab:convcoord}
 \end{table}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -124,44 +124,44 @@ Selon la situation, l'utilisation d'un système de coordonnées particulier peut
 Pour décrire la position d'un corps rigide, trois scalaires qui représentent l'orientation sont nécessaires en plus des trois coordonnées qui spécifient la translation, pour un total de six DDL. La combinaison de la translation et de l'orientation est souvent appelée \textbf{la pose} d'un objet. La translation est typiquement spécifiée par la position d'un point sur le corps rigide (ex.: son centre) avec les différentes représentations discutées à la section \ref{sec:syscoordparticule} (cartésienne, cylindrique ou sphérique) et l'orientation est typiquement spécifiée par trois angles. Comme illustré à la figure \ref{fig:pose}, les six coordonnées suivantes pourraient être utilisées pour spécifier la pose d'un objet:
 %%%%%%%%%%%%%
 \begin{align}
-\text{La translation (3 DDL), ex.:} \quad &\left[ x, y, z \right] \\
-\text{L'orientation (3 DDL), ex.:} \quad &\left[ \theta_{tangage}, \theta_{roulis}, \theta_{lacet} \right]
+	\text{La translation (3 DDL), ex.:} \quad &\left[ x, y, z \right] \\
+	\text{L'orientation (3 DDL), ex.:} \quad &\left[ \theta_{tangage}, \theta_{roulis}, \theta_{lacet} \right]
 \end{align}
 %%%%%%%%%%%%%
-Il est à noter que \textbf{la représentation de l'orientation d'un corps rigide est un problème complexe} et qu'il existe plusieurs méthodes alternatives pour représenter l'orientation (matrices de rotations, angles de Euler, représentation axe-angle, quaternions, etc.) qui seront discutées à la section \ref{sec:corps}. Selon les domaines (robotique, aérospatiale, engins graphiques des jeux vidéos, vision par ordinateur, astronomie, etc.), différents standards et conventions existent en terme de coordonnées utilisées pour décrire l'orientation. Le point à retenir pour le moment est que trois coordonnées indépendantes sont nécessaires pour représenter une orientation arbitraire, donc six totales sont nécessaires pour représenter une pose arbitraire. Par exemple, un minimum de six coordonnées doivent être utilisées pour: spécifier la position de l'effecteur d'un robot, décrire la position d'un avion dans le ciel, décrire la position de la terre par rapport au soleil, etc. 
+Il est à noter que \textbf{la représentation de l'orientation d'un corps rigide est un problème complexe} et qu'il existe plusieurs méthodes alternatives pour représenter l'orientation (matrices de rotations, angles de Euler, représentation axe-angle, quaternions, etc.) qui seront discutées à la section \ref{sec:corps}. Selon les domaines (robotique, aérospatiale, engins graphiques des jeux vidéos, vision par ordinateur, astronomie, etc.), différents standards et conventions existent en termes de coordonnées utilisées pour décrire l'orientation. Le point à retenir pour le moment est que trois coordonnées indépendantes sont nécessaires pour représenter une orientation arbitraire, donc six au total sont nécessaires pour représenter une pose arbitraire. Par exemple, un minimum de six coordonnées doit être utilisé pour: spécifier la position de l'effecteur d'un robot, décrire la position d'un avion dans le ciel, décrire la position de la terre par rapport au soleil, etc.
 
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.50\textwidth]{pose.png}
-	\caption{Six coordonnées sont nécessaire pour représenter la pose d'un corps rigide, trois pour décrire la translation et trois pour décrire son orientation.}
+	\includegraphics[width=0.50\textwidth]{pose.png}
+	\caption{Six coordonnées sont nécessaires pour représenter la pose d'un corps rigide: trois pour décrire la translation et trois pour décrire son orientation.}
 	\label{fig:pose}
 \end{figure}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Configuration d'un robot manipulateur}
-Pour représenter la configuration d'un robot manipulateur il faut suffisamment de variables pour décrire la position relative de chacun des liens rigides qui le compose. Le choix des coordonnées doit être adapté à la géométrie du robot étudié. Un ensemble de variables indépendantes, généralement des angles et des distances, qui permet de déterminer la configuration d'un robot est appelé \textbf{coordonnées généralisées}. L'adjectif \textit{généralisées} est historique et a ici le sens de \textit{pas nécessairement cartésiennes}. Le nombre de coordonnées généralisées nécessaire correspond au nombre de \textbf{degrés-de-liberté} (DDL) du robot.
+Pour représenter la configuration d'un robot manipulateur, il faut suffisamment de variables pour décrire la position relative de chacun des liens rigides qui le compose. Le choix des coordonnées doit être adapté à la géométrie du robot étudié. Un ensemble de variables indépendantes, généralement des angles et des distances, qui permet de déterminer la configuration d'un robot est appelé \textbf{coordonnées généralisées}. L'adjectif \textit{généralisées} est historique et a ici le sens de \textit{pas nécessairement cartésiennes}. Le nombre de coordonnées généralisées nécessaire correspond au nombre de \textbf{degrés de liberté} (DDL) du robot.
 %\paragraph{Exemples de coordonnées généralisées}
 La figure \ref{fig:coor} montre trois exemples de deux coordonnées indépendantes qui peuvent être utilisées comme coordonnées généralisées pour décrire la configuration d'un robot à deux joints rotatifs.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Deux angles relatifs]{
-				\includegraphics[width=0.24\textwidth]{coor_theta}
-				\label{fig:coor_theta}}
-				\vspace{10pt}
-				\subfloat[Deux angles absolus]{
-				\includegraphics[width=0.22\textwidth]{coor_phi}
-				\label{fig:coor_phi}}
-				\vspace{10pt}
-				\subfloat[Deux distances]{
-				\includegraphics[width=0.18\textwidth]{coor_xy}
-				\label{fig:coor_xy}}
-				\vspace{-10pt}
-        \caption{Trois possibilités de coordonnées indépendantes pour spécifier la position d'un robot à 2 DDL}
-				\label{fig:coor}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Deux angles relatifs]{
+		\includegraphics[width=0.24\textwidth]{coor_theta}
+		\label{fig:coor_theta}}
+	\vspace{10pt}
+	\subfloat[Deux angles absolus]{
+		\includegraphics[width=0.22\textwidth]{coor_phi}
+		\label{fig:coor_phi}}
+	\vspace{10pt}
+	\subfloat[Deux distances]{
+		\includegraphics[width=0.18\textwidth]{coor_xy}
+		\label{fig:coor_xy}}
+	\vspace{-10pt}
+	\caption{Trois possibilités de coordonnées indépendantes pour spécifier la position d'un robot à 2 DDL}
+	\label{fig:coor}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -171,25 +171,25 @@ La figure \ref{fig:coor} montre trois exemples de deux coordonnées indépendant
 
 \paragraph{Espace des joints/actionneurs}
 
-Pour les robots manipulateurs, les algorithmes de contrôle utilisent généralement des coordonnées généralisées qui correspondent à des mesures du déplacement relatif de chaque joint comme illustré à la figure \ref{fig:jointspace}. Ces coordonnées sont généralement notées $\col{q} = \left[ \begin{array}{cccc} q_1 & q_2 & ... & q_n \end{array} \right]^T$ (où $n$ est le nombre de DDL) et on réfère aussi à ce système comme \textbf{l'espace des joints}. Chaque coordonnée $q_i$ représente alors une mesure locale du DDL qui relie deux liens rigides séquentiels. Pour les robots industriels par exemple, ce système de coordonnées est très utile car des encodeurs mesurent directement ces variables et les moteurs les contrôlent de façon indépendante. 
+Pour les robots manipulateurs, les algorithmes de contrôle utilisent généralement des coordonnées généralisées qui correspondent à des mesures du déplacement relatif de chaque joint comme illustré à la figure \ref{fig:jointspace}. Ces coordonnées sont généralement notées $\col{q} = \left[ \begin{array}{cccc} q_1 & q_2 & ... & q_n \end{array} \right]^T$ (où $n$ est le nombre de DDL) et on réfère aussi à ce système comme \textbf{l'espace des joints}. Chaque coordonnée $q_i$ représente alors une mesure locale du DDL qui relie deux liens rigides séquentiels. Pour les robots industriels par exemple, ce système de coordonnées est très utile, car des encodeurs mesurent directement ces variables et les moteurs les contrôlent de façon indépendante.
 
 \paragraph{Espace de la tâche}
 
-La tâche d'un robot peut rarement être spécifiée facilement dans l'espace des joints. Un système de coordonnées naturel pour la tâche doit donc généralement être utilisé et on réfère aussi à ce système comme \textbf{l'espace de la tâche}. La tâche d'un robot manipulateur est généralement spécifiée plus naturellement en termes de coordonnées cartésiennes de l'effecteur. Il est à noter que le nombre de coordonnées nécessaires pour l'espace de la tâche peut être différent du nombre de DDL total du robot. Comme illustré à la figure \ref{fig:taskspace}, pour un robot qui aurait comme tâche d'écrire sur une plaque, l'objectif serait naturellement exprimé par une trajectoire définie avec des coordonnées $(x,y)$ sur la plaque. 
+La tâche d'un robot peut rarement être spécifiée facilement dans l'espace des joints. Un système de coordonnées naturel pour la tâche doit donc généralement être utilisé et on réfère aussi à ce système comme \textbf{l'espace de la tâche}. La tâche d'un robot manipulateur est généralement spécifiée plus naturellement en termes de coordonnées cartésiennes de l'effecteur. Il est à noter que le nombre de coordonnées nécessaires pour l'espace de la tâche peut être différent du nombre de DDL total du robot. Comme illustré à la figure \ref{fig:taskspace}, pour un robot qui aurait comme tâche d'écrire sur une plaque, l'objectif serait naturellement exprimé par une trajectoire définie avec des coordonnées $(x,y)$ sur la plaque.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Espace des joints]{
-				\includegraphics[width=0.28\textwidth]{jointspace}
-				\label{fig:jointspace}}
-				\hspace{+20pt}
-				\subfloat[Espace de la tache]{
-				\includegraphics[width=0.28\textwidth]{taskspace}
-				\label{fig:taskspace}}
-        \caption{Exemple de coordonnées représentant l'espace des joints et l'espace tâche d'un robot manipulateur}
-				\label{fig:spaces}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Espace des joints]{
+		\includegraphics[width=0.28\textwidth]{jointspace}
+		\label{fig:jointspace}}
+	\hspace{+20pt}
+	\subfloat[Espace de la tache]{
+		\includegraphics[width=0.28\textwidth]{taskspace}
+		\label{fig:taskspace}}
+	\caption{Exemple de coordonnées représentant l'espace des joints et l'espace tâche d'un robot manipulateur}
+	\label{fig:spaces}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -198,43 +198,45 @@ La tâche d'un robot peut rarement être spécifiée facilement dans l'espace de
 %\subsection{Transformation des coordonnées}
 %
 
-  
+
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newpage
-\section{Vecteurs géométriques de positions}
+\section{Vecteurs géométriques de position}
 \label{sec:vecgeopos}
 
-La notion de vecteur géométrique permet de travailler avec des \textbf{vecteurs de position} qui sont indépendants d'un choix de système de coordonnées. Pour les problèmes de cinématique de robots, il est particulièrement adapté de travailler d'abord avec les vecteurs géométrique, plutôt que directement avec des coordonnées. Cette approche \textbf{1)} simplifie les calculs en 3D et \textbf{2)} permet de faire le saut facilement entre plusieurs systèmes de coordonnées. Un vecteur géométrique est une quantité définie dans l’espace et possédant une grandeur et une direction. Dans ces notes, les vecteurs géométriques, notés $\vec{v}$, seront explicitement distingués des vecteur-colonnes (groupe de plusieurs scalaires) qui seront notés $\col{v}=\left[  \begin{array}{ccc} v_{1} & v_{2} & v_{3} \end{array} \right]^T$, voir chapitre \ref{sec:calcvec}.
+La notion de vecteur géométrique permet de travailler avec des \textbf{vecteurs de position} qui sont indépendants d'un choix de système de coordonnées. Pour les problèmes de cinématique de robots, il est particulièrement adapté de travailler d'abord avec les vecteurs géométriques, plutôt que directement avec des coordonnées. Cette approche \textbf{1)} simplifie les calculs en 3D et \textbf{2)} permet de faire le saut facilement entre plusieurs systèmes de coordonnées. Un vecteur géométrique est une quantité définie dans l’espace et possédant une grandeur et une direction. Dans ces notes, les vecteurs géométriques, notés $\vec{v}$, seront explicitement distingués des vecteurs-colonne (groupe de plusieurs scalaires) qui seront notés $\col{v}=\left[  \begin{array}{ccc} v_{1} & v_{2} & v_{3} \end{array} \right]^T$, voir chapitre \ref{sec:calcvec}.
 
-%La section XXXX présente un rappel sur les propriétés et les opérations possible avec les vecteurs. 
+%La section XXXX présente un rappel sur les propriétés et les opérations possible avec les vecteurs.
 
 %\subsubsection{Vecteurs de positions}
 
-\textbf{Un vecteur position nécessite deux points pour être défini}, une origine et une destination. Notez que c'est particulier des vecteurs positions, la plupart des autres vecteurs utilisés en physique (vitesse, accélération, force, champ électrique, etc.) ont un point d'application mais sont indépendants d'un choix d’origine. Dans ces notes, les vecteurs positions seront notés:
+\textbf{Un vecteur position nécessite deux points pour être défini}, une origine et une destination. Notez que c'est particulier des vecteurs positions, la plupart des autres vecteurs utilisés en physique (vitesse, accélération, force, champ électrique, etc.) ont un point d'application, mais sont indépendants d'un choix d’origine. Dans ces notes, les vecteurs positions seront notés:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{B/A}  \quad =  \quad \text{Vecteur position du point $B$ par rapport au point $A$}
-\end{equation} 
+	\vec{r}_{B/A}  \quad =  \quad \text{Vecteur position du point $B$ par rapport au point $A$}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-où $A$ est le point d'origine et $B$ le point de destination, tel qu'illustré à la figure \ref{fig:vecpos}. Parfois, la notation équivalente $\vec{AB}$ est utilisée dans la littérature. Ces vecteurs  peuvent être utilisés pour faire des constructions géométriques indépendamment d'un choix de système de coordonnées. 
+où $A$ est le point d'origine et $B$ le point de destination, tel qu'illustré à la figure \ref{fig:vecpos}. Parfois, la notation équivalente $\vec{AB}$ est utilisée dans la littérature.
+%%TODO La fleche de AB est pas allongée  $\vec{AB}$  %%
+Ces vecteurs  peuvent être utilisés pour faire des constructions géométriques indépendamment d'un choix de système de coordonnées.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htb]
-				%\vspace{-10pt}
-        \centering
-				\includegraphics[width=0.30\textwidth]{vecpos}
-				\caption{Un vecteur position}
-        %\subfloat[Un Vecteur Positions]{
-				%\includegraphics[width=0.30\textwidth]{vecpos}
-				%\label{fig:vecpos}}
-				%\subfloat[Construction géométrique]{
-				%\includegraphics[width=0.30\textwidth]{vecposcons}
-				%\label{fig:vecposcons}}
-        %\caption{Example de vecteurs de position}
-				\label{fig:vecpos}
+	%\vspace{-10pt}
+	\centering
+	\includegraphics[width=0.30\textwidth]{vecpos}
+	\caption{Un vecteur position}
+	%\subfloat[Un Vecteur Positions]{
+	%\includegraphics[width=0.30\textwidth]{vecpos}
+	%\label{fig:vecpos}}
+	%\subfloat[Construction géométrique]{
+	%\includegraphics[width=0.30\textwidth]{vecposcons}
+	%\label{fig:vecposcons}}
+	%\caption{Example de vecteurs de position}
+	\label{fig:vecpos}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -247,22 +249,22 @@ La figure \ref{fig:vecposprop} illustre les propriétés de base des vecteurs de
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Inversion]{
-				\includegraphics[width=0.28\textwidth]{vecposinv}
-				\label{fig:vecposinv}}
-				\hspace{5pt}
-				\subfloat[Vecteur unitaire et distance]{
-				\includegraphics[width=0.28\textwidth]{vecposvecuni}
-				\label{fig:vecposinv}}
-				\hspace{5pt}
-				\subfloat[Addition]{
-				\includegraphics[width=0.35\textwidth]{vecposadd}
-				\label{fig:vecposinv}}
-				%\vspace{-10pt}
-        \caption{Propiétés des vecteurs de position}
-				\label{fig:vecposprop}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Inversion]{
+		\includegraphics[width=0.28\textwidth]{vecposinv}
+		\label{fig:vecposinv}}
+	\hspace{5pt}
+	\subfloat[Vecteur unitaire et distance]{
+		\includegraphics[width=0.28\textwidth]{vecposvecuni}
+		\label{fig:vecposinv}}
+	\hspace{5pt}
+	\subfloat[Addition]{
+		\includegraphics[width=0.35\textwidth]{vecposadd}
+		\label{fig:vecposinv}}
+	%\vspace{-10pt}
+	\caption{Propriétés des vecteurs de position}
+	\label{fig:vecposprop}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -271,8 +273,8 @@ La figure \ref{fig:vecposprop} illustre les propriétés de base des vecteurs de
 Par définition, un vecteur position peut être décomposé en une addition de vecteurs qui passent par des points intermédiaires:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{Z/A}  =   \vec{r}_{Z/Y} + \vec{r}_{Y/X} + ... + \vec{r}_{C/B} + \vec{r}_{B/A} 
-\end{align} 
+	\vec{r}_{Z/A}  =   \vec{r}_{Z/Y} + \vec{r}_{Y/X} + ... + \vec{r}_{C/B} + \vec{r}_{B/A}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 \paragraph{Inversion}
@@ -280,8 +282,8 @@ Par définition, un vecteur position peut être décomposé en une addition de v
 L'inversion de l'origine et la destination est équivalente à la négation du vecteur de position:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{B/A}  = - \vec{r}_{A/B}
-\end{align} 
+	\vec{r}_{B/A}  = - \vec{r}_{A/B}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 \paragraph{Vecteurs unitaires}
@@ -289,10 +291,10 @@ L'inversion de l'origine et la destination est équivalente à la négation du v
 Les vecteurs unitaires sont utilisés pour représenter des directions dans l'espace. Les vecteurs positions peuvent être exprimés comme des \textbf{combinaisons de distances et directions} qui sont représentées respectivement par des paires de scalaires $l_i$ et vecteurs unitaires $\hat{n}_i$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r} = l_1 \hat{n}_1 + l_2 \hat{n}_2 + ... + l_n \hat{n}_n
-\end{equation} 
+	\vec{r} = l_1 \hat{n}_1 + l_2 \hat{n}_2 + ... + l_n \hat{n}_n
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Des vecteurs unitaires doivent être identifiés selon les axes pertinents pour l'analyse d'un problème. 
+%Des vecteurs unitaires doivent être identifiés selon les axes pertinents pour l'analyse d'un problème.
 
 
 
@@ -300,43 +302,43 @@ Les vecteurs unitaires sont utilisés pour représenter des directions dans l'es
 \subsection{Mesures avec les vecteurs de position}
 \label{sec:vecuni}
 %
-%Les vecteurs unitaires sont aussi utiles pour pouvoir mesurer une position selon une direction particulière. 
-La norme d'un vecteur position, i.e. sa longueur, peut être calculée en effectuant un produit scalaire du vecteur avec lui même:
+%Les vecteurs unitaires sont aussi utiles pour pouvoir mesurer une position selon une direction particulière.
+La norme d'un vecteur position, c.-à-d. sa longueur, peut être calculée en effectuant un produit scalaire du vecteur avec lui même:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\| \vec{r} \|^2 = \vec{r} \bullet \vec{r} 
-\label{eq:dotnorm}
-\end{equation} 
+	\| \vec{r} \|^2 = \vec{r} \bullet \vec{r}
+	\label{eq:dotnorm}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Aussi, la dimension $d$ d'un vecteur position $\vec{r}$ selon un axe particulier correspond au produit scalaire du vecteur position avec un vecteur unitaire $\hat{n}$ aligné sur cet axe:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-d = \vec{r} \bullet \hat{n} = \| \vec{r} \|  \cos \angle (\vec{r},\hat{n})
-\label{eq:vecproj}
-\end{equation} 
+	d = \vec{r} \bullet \hat{n} = \| \vec{r} \|  \cos \angle (\vec{r},\hat{n})
+	\label{eq:vecproj}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Cette opération est aussi appelée \textbf{projection d'un vecteur sur un axe} et illustrée à la figure \ref{fig:distproj}. Finalement, le produit scalaire de deux vecteurs unitaires est égale au cosinus de l'angle qui les sépare puisqu'ils ont une dimension unitaire:
+Cette opération est aussi appelée \textbf{projection d'un vecteur sur un axe} et illustrée à la figure \ref{fig:distproj}. Finalement, le produit scalaire de deux vecteurs unitaires est égal au cosinus de l'angle qui les sépare puisqu'ils ont une dimension unitaire:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\cos \angle (\hat{n}_1,\hat{n}_2) =  \hat{n}_1 \bullet \hat{n}_2
-\label{eq:dotangle}
-\end{equation} 
+	\cos \angle (\hat{n}_1,\hat{n}_2) =  \hat{n}_1 \bullet \hat{n}_2
+	\label{eq:dotangle}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est donc possible d'utiliser le produit scalaire pour mesurer un angle entre deux vecteurs, comme illustré à la figure \ref{fig:dotcosuni}.  
+Il est donc possible d'utiliser le produit scalaire pour mesurer un angle entre deux vecteurs, comme illustré à la figure \ref{fig:dotcosuni}.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Distance selon un axe]{
-				\includegraphics[width=0.40\textwidth]{distproj}
-				\label{fig:distproj}}
-				\hspace{20pt}
-				\subfloat[Angle entre deux vecteurs unitaires]{
-				\includegraphics[width=0.35\textwidth]{dotcosuni}
-				\label{fig:dotcosuni}}
-        \caption{Utilisation du produit scalaire pour des mesures géométriques}
-				\label{fig:utprosca}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Distance selon un axe]{
+		\includegraphics[width=0.40\textwidth]{distproj}
+		\label{fig:distproj}}
+	\hspace{20pt}
+	\subfloat[Angle entre deux vecteurs unitaires]{
+		\includegraphics[width=0.35\textwidth]{dotcosuni}
+		\label{fig:dotcosuni}}
+	\caption{Utilisation du produit scalaire pour des mesures géométriques}
+	\label{fig:utprosca}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %TODO ajouter figure pour la norme
@@ -347,64 +349,64 @@ Il est donc possible d'utiliser le produit scalaire pour mesurer un angle entre 
 Un exemple est ici donné pour le calcul de la hauteur de l'effecteur d'un robot à 3 DDL, illustré à la figure \ref{fig:vecposphi}, avec l'aide des vecteurs géométriques de position. Comme illustré à la Figure \ref{fig:vecposcons}, par inspection il est possible de déterminer la relation vectorielle suivante:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{D/A} = \vec{r}_{D/C} + \vec{r}_{C/B} + \vec{r}_{B/A}
-\label{eq:vecadd}
-\end{equation} 
+	\vec{r}_{D/A} = \vec{r}_{D/C} + \vec{r}_{C/B} + \vec{r}_{B/A}
+	\label{eq:vecadd}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ensuite, comme illustré à la figure \ref{fig:vecposuni}, des vecteurs unitaires $\hat{n}_i$ alignés avec chacun des liens rigides du robot manipulateur permettent de préciser l'équation \eqref{eq:vecadd} avec des longueurs et des directions:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{D/A} = l_1 \hat{n}_{1} + l_2 \hat{n}_{2} + l_3 \hat{n}_{3}
-\label{eq:vecadduni}
-\end{equation} 
+	\vec{r}_{D/A} = l_1 \hat{n}_{1} + l_2 \hat{n}_{2} + l_3 \hat{n}_{3}
+	\label{eq:vecadduni}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Finalement, pour calculer la hauteur $h$ de ce robot par exemple, il suffit de prendre le produit scalaire avec un vecteur unitaire vertical $\hat{y}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-h &= \vec{r}_{D/A} \bullet \hat{y} \\
-h &= ( l_1 \hat{n}_{1} + l_2 \hat{n}_{2} + l_3 \hat{n}_{3} ) \bullet \hat{y} \\
-h &= l_1 ( \hat{n}_{1} \bullet \hat{y} ) + l_2 ( \hat{n}_{2} \bullet \hat{y} ) + l_3 ( \hat{n}_{3}  \bullet \hat{y} ) \\
-h &= l_1 \cos \angle (\hat{n}_{1},\hat{y}) + l_2 \cos \angle (\hat{n}_{2},\hat{y}) + l_3 \cos \angle (\hat{n}_{3},\hat{y})
-\label{eq:vecaddproj}
-\end{align} 
+	h &= \vec{r}_{D/A} \bullet \hat{y} \\
+	h &= ( l_1 \hat{n}_{1} + l_2 \hat{n}_{2} + l_3 \hat{n}_{3} ) \bullet \hat{y} \\
+	h &= l_1 ( \hat{n}_{1} \bullet \hat{y} ) + l_2 ( \hat{n}_{2} \bullet \hat{y} ) + l_3 ( \hat{n}_{3}  \bullet \hat{y} ) \\
+	h &= l_1 \cos \angle (\hat{n}_{1},\hat{y}) + l_2 \cos \angle (\hat{n}_{2},\hat{y}) + l_3 \cos \angle (\hat{n}_{3},\hat{y})
+	\label{eq:vecaddproj}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-À noter ici que le produit scalaire de deux vecteurs unitaires correspond au cosinus de l'angle entre les deux vecteurs, voir équation \eqref{eq:dotangle}. Donc avec l’exemple ci-dessus le produit scalaire $\hat{n}_{i} \bullet \hat{y}$ correspond simplement au cosinus de l'angle du joint $i$ avec l'axe vertical, donné par les angles $\varphi_i$ à la figure \ref{fig:vecposphi}. L'équation \eqref{eq:vecaddproj} peut donc être précisée comme une expression des variables de distances $l_i$ et des variables d'angles $\varphi_i$: 
+À noter ici que le produit scalaire de deux vecteurs unitaires correspond au cosinus de l'angle entre les deux vecteurs, voir équation \eqref{eq:dotangle}. Donc avec l’exemple ci-dessus le produit scalaire $\hat{n}_{i} \bullet \hat{y}$ correspond simplement au cosinus de l'angle du joint $i$ avec l'axe vertical, donné par les angles $\varphi_i$ à la figure \ref{fig:vecposphi}. L'équation \eqref{eq:vecaddproj} peut donc être précisée comme une expression des variables de distances $l_i$ et des variables d'angles $\varphi_i$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-h &= l_1 \cos (\varphi_1) + l_2 \cos (\varphi_2) + l_3 \cos (\varphi_3)
-\label{eq:vecaddprojphi}
-\end{align} 
+	h &= l_1 \cos (\varphi_1) + l_2 \cos (\varphi_2) + l_3 \cos (\varphi_3)
+	\label{eq:vecaddprojphi}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Dans un cas simple planaire comme celui-ci il aurait été assez simple de calculer la hauteur du robot directement par trigonométrie. L'approche vectorielle est toutefois plus systématique et se généralise beaucoup plus facilement à des systèmes complexes et tri-dimensionnels comme les robots industriels.
+Dans un cas simple planaire comme celui-ci, il aurait été assez simple de calculer la hauteur du robot directement par trigonométrie. L'approche vectorielle est toutefois plus systématique et se généralise beaucoup plus facilement à des systèmes complexes et tridimensionnels comme les robots industriels.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				%%%
-        \subfloat[Robot à 3 DLL]{
-				\includegraphics[width=0.17\textwidth]{vecposphi}
-				\label{fig:vecposphi}}
-				%%%%%%%%%%%%%%%%%%
-				\hspace{3pt}
-				%%%%
-				\subfloat[Vecteurs géométrique]{
-				\includegraphics[width=0.26\textwidth]{vecposcons}
-				\label{fig:vecposcons}}
-				%%%%
-				\hspace{3pt}
-				%%%%
-        \subfloat[Vecteur unitaires]{
-				\includegraphics[width=0.17\textwidth]{vecposuni}
-				\label{fig:vecposuni}}
-				%%%%
-				\hspace{3pt}
-				%%%%
-				\subfloat[Projection sur l'axe vertical]{
-				\includegraphics[width=0.29\textwidth]{vecpospro}
-				\label{fig:vecpospro}}
-        \caption{Exemple de calcul de la hauteur d'un robot.}
-				\label{fig:vecposunipro}
+	%\vspace{-10pt}
+	\centering
+	%%%
+	\subfloat[Robot à 3 DLL]{
+		\includegraphics[width=0.17\textwidth]{vecposphi}
+		\label{fig:vecposphi}}
+	%%%%%%%%%%%%%%%%%%
+	\hspace{3pt}
+	%%%%
+	\subfloat[Vecteurs géométriques]{
+		\includegraphics[width=0.26\textwidth]{vecposcons}
+		\label{fig:vecposcons}}
+	%%%%
+	\hspace{3pt}
+	%%%%
+	\subfloat[Vecteurs unitaires]{
+		\includegraphics[width=0.17\textwidth]{vecposuni}
+		\label{fig:vecposuni}}
+	%%%%
+	\hspace{3pt}
+	%%%%
+	\subfloat[Projection sur l'axe vertical]{
+		\includegraphics[width=0.29\textwidth]{vecpospro}
+		\label{fig:vecpospro}}
+	\caption{Exemple de calcul de la hauteur d'un robot.}
+	\label{fig:vecposunipro}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -417,22 +419,22 @@ La démarche utilisée pour calculer des positions avec les vecteurs géométriq
 	\item Par inspection, construire le vecteur position $\vec{r}$ d’intérêt comme une addition/soustraction de plusieurs vecteurs positions $\vec{r}_i$ avec des longueurs et orientations connues:
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\begin{equation}
-	\vec{r} = \sum_i \vec{r}_i
-	\end{equation} 
+		\vec{r} = \sum_i \vec{r}_i
+	\end{equation}
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\item Substituer les vecteurs positions symboliques $\vec{r}_i$ par des variables de distance $l_i$ et des vecteurs unitaires $\hat{n}_i$ représentant des directions qui peuvent être mesurées:
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\begin{equation}
-	\vec{r} = \sum_i l_i \hat{n}_i
-	\end{equation} 
+		\vec{r} = \sum_i l_i \hat{n}_i
+	\end{equation}
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\item Calculer les distances désirées $d$ en effectuant un produit scalaire avec les vecteurs unitaires selon les axes désirés:
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\begin{align}
-	d_x = \vec{r} \bullet \hat{x} = \sum_i l_i ( \hat{n}_i \bullet \hat{x} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{x}) \\ 
-	d_y = \vec{r} \bullet \hat{y} = \sum_i l_i ( \hat{n}_i \bullet \hat{y} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{y}) \\ 
-	d_z = \vec{r} \bullet \hat{z} = \sum_i l_i ( \hat{n}_i \bullet \hat{z} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{z}) 
-	\end{align} 
+		d_x = \vec{r} \bullet \hat{x} = \sum_i l_i ( \hat{n}_i \bullet \hat{x} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{x}) \\
+		d_y = \vec{r} \bullet \hat{y} = \sum_i l_i ( \hat{n}_i \bullet \hat{y} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{y}) \\
+		d_z = \vec{r} \bullet \hat{z} = \sum_i l_i ( \hat{n}_i \bullet \hat{z} ) =  \sum_i l_i \cos \angle (\hat{n}_{i},\hat{z})
+	\end{align}
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \end{enumerate}
 
@@ -443,47 +445,48 @@ La démarche utilisée pour calculer des positions avec les vecteurs géométriq
 \section{Bases vectorielles et composantes d'un vecteur position}
 \label{sec:basevecpos}
 
-Les vecteurs positions tri-dimensionnels $\vec{r}$ peuvent être décris par trois scalaires qui représentent des distances ($r_1$, $r_2$ et $r_3$) qui multiplient trois vecteur unitaires orthogonaux ($\hat{a}_1$, $\hat{a}_2$ et $\hat{a}_3$) qui forment une base vectorielle.  Les scalaires $r_i$ qui multiplient chaque vecteur unitaire sont appelés composantes et peuvent être regroupés sous la forme d'un vecteur-colonne, la notation suivante sera utilisée:
+Les vecteurs positions tridimensionnels $\vec{r}$ peuvent être décrits par trois scalaires qui représentent des distances ($r_1$, $r_2$ et $r_3$) qui multiplient trois vecteurs unitaires orthogonaux ($\hat{a}_1$, $\hat{a}_2$ et $\hat{a}_3$) qui forment une base vectorielle.  Les scalaires $r_i$ qui multiplient chaque vecteur unitaire sont appelés composantes et peuvent être regroupés sous la forme d'un vecteur-colonne, la notation suivante sera utilisée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\text{\textbf{Vecteur-géométrique:}}\quad
-\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
-\quad \quad 
-\text{\textbf{Vecteur-colonne:}}\quad
-\col{r}^{a} = \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right] 
-\label{eq:veccoldef}
-\end{equation} 
+	\text{\textbf{Vecteur-géométrique:}}\quad
+	\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
+	\quad \quad
+	\text{\textbf{Vecteur-colonne:}}\quad
+	\col{r}^{a} = \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right]
+	\label{eq:veccoldef}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée aux composantes scalaires. 
+où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée aux composantes scalaires.
 
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{figure}[htpb]
-% 				%\vspace{-10pt}
+%           %\vspace{-10pt}
 %         \centering
-% 				\subfloat[Base $a$]{
-% 				\includegraphics[width=0.20\textwidth]{base}
-% 				\label{fig:base}}
-% 				%%%%
-% 				\hspace{10pt}
-% 				%%%%
+%           \subfloat[Base $a$]{
+%           \includegraphics[width=0.20\textwidth]{base}
+%           \label{fig:base}}
+%           %%%%
+%           \hspace{10pt}
+%           %%%%
 %         \subfloat[Vecteur vs. ses composantes]{
-% 				\includegraphics[width=0.25\textwidth]{baseex}
-% 				\label{fig:baseex}}
-% 				%%%%
-% 				\hspace{10pt}
-% 				%%%%
-% 				\subfloat[Convention de la main droite]{
-% 				\includegraphics[width=0.25\textwidth]{righthand}
-% 				\label{fig:righthand}}
+%           \includegraphics[width=0.25\textwidth]{baseex}
+%           \label{fig:baseex}}
+%           %%%%
+%           \hspace{10pt}
+%           %%%%
+%           \subfloat[Convention de la main droite]{
+%           \includegraphics[width=0.25\textwidth]{righthand}
+%           \label{fig:righthand}}
 %         \caption{Les bases vectorielles}
-% 				\label{fig:vecbasis}
+%           \label{fig:vecbasis}
 % \end{figure}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\note{Note sur la séquence de lecture: }{Il est suggérer au lecteur de lire les sections \ref{sec:vec}, \ref{vectorbasis} et \ref{sec:opeveccol} dans le chapitre \ref{sec:calcvec} qui couvre le calcul vectoriel de façon plus générique. Ces sections couvrent plus en détails les fondements qui sont ici utilisés dans un contexte de cinématique. }
+\note{Note sur la séquence de lecture: }{Il est suggéré au lecteur de lire les sections \ref{sec:vec}, \ref{vectorbasis} et \ref{sec:opeveccol} dans le chapitre \ref{sec:calcvec} qui couvre le calcul vectoriel de façon plus générique. Ces sections couvrent plus en détail les fondements qui sont ici utilisés dans un contexte de cinématique. }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% TODO: Si c'est plus utile de le lire maintenant, pourquoi ne pas le placer plus proche? %%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -492,33 +495,33 @@ où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée au
 Une base vectorielle correspond à un ensemble de trois vecteurs unitaires (en 3D) orthogonaux qui déterminent l'orientation de trois axes dans l'espace et forment une base qui permet de décrire n'importe quel vecteur position $\vec{r}$ sous la forme:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
-\label{eq:vecbasisr}
-\end{equation} 
+	\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
+	\label{eq:vecbasisr}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 On appellera \textit{base vectorielle} $a$, une base formée par l'ensemble des vecteurs unitaires $\{\hat{a}_{1},\hat{a}_{2},\hat{a}_{3}\}$.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Base $a$]{
-				\includegraphics[width=0.20\textwidth]{base}
-				\label{fig:base}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-        \subfloat[Exemple]{
-				\includegraphics[width=0.25\textwidth]{baseex}
-				\label{fig:baseex}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-				\subfloat[Convention de la main droite]{
-				\includegraphics[width=0.25\textwidth]{righthand}
-				\label{fig:righthand}}
-        \caption{Les bases vectorielles}
-				\label{fig:vecbasis}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Base $a$]{
+		\includegraphics[width=0.20\textwidth]{base}
+		\label{fig:base}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Exemple]{
+		\includegraphics[width=0.25\textwidth]{baseex}
+		\label{fig:baseex}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Convention de la main droite]{
+		\includegraphics[width=0.25\textwidth]{righthand}
+		\label{fig:righthand}}
+	\caption{Les bases vectorielles}
+	\label{fig:vecbasis}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -529,84 +532,84 @@ Les bases vectorielles permettent de faire des opérations et combiner des vecte
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Rappel sur la relations entre le vecteur et les composantes}
+\subsection{Rappel sur la relation entre le vecteur et les composantes}
 
 Comme illustré à la figure \ref{fig:vecpospro2}, il est possible de calculer les composantes d'un vecteur exprimé dans une base par un produit scalaire du vecteur géométrique avec chacun des vecteurs unitaires de la base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-r_i^a = \vec{r} \bullet \hat{a}_i  \quad \Rightarrow \quad 
-\col{r}^{a} = \left[ \begin{array}{c} \vec{r} \bullet \hat{a}_1 \\ \vec{r} \bullet \hat{a}_2 \\ \vec{r} \bullet \hat{a}_3  \end{array} \right] 
-\end{equation} 
+	r_i^a = \vec{r} \bullet \hat{a}_i  \quad \Rightarrow \quad
+	\col{r}^{a} = \left[ \begin{array}{c} \vec{r} \bullet \hat{a}_1 \\ \vec{r} \bullet \hat{a}_2 \\ \vec{r} \bullet \hat{a}_3  \end{array} \right]
+\end{equation}
 Inversement, comme illustré à la figure \ref{fig:vecpospro3}, le vecteur position géométrique peut être reconstruit en effectuant la somme des composantes multipliées avec leurs vecteurs unitaires respectifs:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r} = \sum_{i} r_i^a \hat{a}_i = r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3%= \left[ \begin{array}{c c c} p_1^a & p_2^a & p_3^a  \end{array} \right]  \left[ \begin{array}{c} \hat{a}_1 \\ \hat{a}_2 \\ \hat{a}_3  \end{array} \right] 
-\end{equation} 
+	\vec{r} = \sum_{i} r_i^a \hat{a}_i = r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3%= \left[ \begin{array}{c c c} p_1^a & p_2^a & p_3^a  \end{array} \right]  \left[ \begin{array}{c} \hat{a}_1 \\ \hat{a}_2 \\ \hat{a}_3  \end{array} \right]
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htb]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Projection sur une base vectorielle]{
-				\includegraphics[width=0.50\textwidth]{vecpospro2.png}
-				\label{fig:vecpospro2}}
-				\hspace{+20pt}
-				\subfloat[Décomposition selon les directions de la base]{
-				\includegraphics[width=0.40\textwidth]{vecpospro3.png}
-				\label{fig:vecpospro3}}
-				%\vspace{+30pt}
-        \caption{Relations entre le vecteur géométrique de position et les composantes du vecteur-colonne}
-				\label{fig:vecpospro23}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Projection sur une base vectorielle]{
+		\includegraphics[width=0.50\textwidth]{vecpospro2.png}
+		\label{fig:vecpospro2}}
+	\hspace{+20pt}
+	\subfloat[Décomposition selon les directions de la base]{
+		\includegraphics[width=0.40\textwidth]{vecpospro3.png}
+		\label{fig:vecpospro3}}
+	%\vspace{+30pt}
+	\caption{Relations entre le vecteur géométrique de position et les composantes du vecteur-colonne}
+	\label{fig:vecpospro23}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Transfert d'une équation vectorielle vers une équation matricielle} 
+\subsection{Transfert d'une équation vectorielle vers une équation matricielle}
 %
-Lorsque les composantes de plusieurs vecteurs-géométrique de position sont exprimées avec la même base, il est possible de faire des opérations directement avec les vecteur-colonnes de composantes. Cela permet de traiter simultanément les calculs de plusieurs axes, et aussi de faire des calculs numériques efficaces en utilisant les outils de l'algèbre linéaire. Par exemple, les additions et soustractions de vecteurs géométriques peuvent être calculées directement en termes des vecteur-colonnes dans une base:
+Lorsque les composantes de plusieurs vecteurs géométriques de position sont exprimées avec la même base, il est possible de faire des opérations directement avec les vecteurs-colonne de composantes. Cela permet de traiter simultanément les calculs de plusieurs axes, et aussi de faire des calculs numériques efficaces en utilisant les outils de l'algèbre linéaire. Par exemple, les additions et soustractions de vecteurs géométriques peuvent être calculées directement en termes des vecteurs-colonne dans une base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   \quad \Rightarrow \quad
-\col{r}_{A/C}^a = \col{r}_{A/B}^a + \col{r}_{B/C}^a
-\end{equation} 
+	\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   \quad \Rightarrow \quad
+	\col{r}_{A/C}^a = \col{r}_{A/B}^a + \col{r}_{B/C}^a
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ce transfert d'une seule équation vectorielle à une équation matricielle (équivalent à un système de trois équations scalaires) correspond à une projection de l'équation vectorielle sur chacun des axes de la base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}  
-\quad \Rightarrow \quad
-\left[ \begin{array}{c} (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   ) \bullet \hat{a}_1 \\ (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   ) \bullet \hat{a}_2 \\ (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}  ) \bullet \hat{a}_3  \end{array} \right] 
-\quad \Rightarrow \quad
-\col{r}_{A/C}^a = \col{r}_{A/B}^a + \col{r}_{B/C}^a
-\end{equation} 
+	\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}
+	\quad \Rightarrow \quad
+	\left[ \begin{array}{c} (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   ) \bullet \hat{a}_1 \\ (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}   ) \bullet \hat{a}_2 \\ (\vec{r}_{A/C}   = \vec{r}_{A/B} + \vec{r}_{B/C}  ) \bullet \hat{a}_3  \end{array} \right]
+	\quad \Rightarrow \quad
+	\col{r}_{A/C}^a = \col{r}_{A/B}^a + \col{r}_{B/C}^a
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les équations vectorielles avec des vecteurs de position peuvent donc être substituées par des équations matricielles équivalentes avec les vecteur-colonnes,\textbf{ à condition que tous les vecteur-colonnes soient exprimés dans une base commune}. 
-  
+Les équations vectorielles avec des vecteurs de position peuvent donc être substituées par des équations matricielles équivalentes avec les vecteurs-colonne,\textbf{ à condition que tous les vecteurs-colonne soient exprimés dans une base commune}.
+
 
 % Voici quelques exemples de substitution d'équation de vecteurs de position vers des équations matricielles:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{align}
-% \vec{r}_{B/C}   = \vec{r}_{B/A} - \vec{r}_{C/A}   
-% \quad &\Rightarrow \quad  \col{r}_{B/C}^a   = \col{r}_{B/A}^a - \col{r}_{C/A}^a 
+% \vec{r}_{B/C}   = \vec{r}_{B/A} - \vec{r}_{C/A}
+% \quad &\Rightarrow \quad  \col{r}_{B/C}^a   = \col{r}_{B/A}^a - \col{r}_{C/A}^a
 % \\
-% \vec{r}_{B/C}   = \vec{r}_{B/A} - \vec{r}_{C/A} \quad &\Rightarrow \quad \col{r}_{B/C}^b   = \col{r}_{B/A}^b - \col{r}_{C/A}^b 
+% \vec{r}_{B/C}   = \vec{r}_{B/A} - \vec{r}_{C/A} \quad &\Rightarrow \quad \col{r}_{B/C}^b   = \col{r}_{B/A}^b - \col{r}_{C/A}^b
 % \\
 % 2  \vec{r}_{D/A} = 3 \vec{r}_{B/A} + \vec{r}_{C/A} \quad &\Rightarrow \quad  2  \col{r}_{D/A}^a = 3 \col{r}_{B/A}^a + \col{r}_{C/A}^a
-% \end{align} 
+% \end{align}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \\ \noindent
 \rule{\linewidth}{0.3mm}
-\textbf{Programmation de calculs de cinématique:} Lors de l'écriture d'un programme informatique pour effectuer des calculs de cinématique, les calculs numériques doivent être fait en termes de composantes. En effet, les ordinateurs sont adaptés à manipuler des chiffres, des vecteur-colonnes de chiffres, des matrices de chiffres, etc. Toutefois, un ordinateur ne peut manipuler directement des éléments conceptuels comme les vecteurs unitaires.
-\\ 
+\textbf{Programmation de calculs de cinématique:} Lors de l'écriture d'un programme informatique pour effectuer des calculs de cinématique, les calculs numériques doivent être faits en termes de composantes. En effet, les ordinateurs sont adaptés à manipuler des chiffres, des vecteurs-colonne de chiffres, des matrices de chiffres, etc. Toutefois, un ordinateur ne peut manipuler directement des éléments conceptuels comme les vecteurs unitaires.
+\\
 \rule{\linewidth}{0.3mm}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% \subsection{Opérations avec les vecteur-colonnes} 
+% \subsection{Opérations avec les vecteur-colonnes}
 % %
 % Les opérations vectorielles ont des équivalents en termes d'opérations matricielle avec les vecteur-colonnes qui sont très utiles pour les calculs numériques. Cette section introduit les opérations principales utiles pour la cinématique.
 
@@ -616,61 +619,61 @@ Les équations vectorielles avec des vecteurs de position peuvent donc être sub
 % \begin{equation}
 % \vec{u} \bullet \vec{v} = \col{u}^T \col{v} = \left[ \begin{array}{c c c} u_1 & u_2 & u_3  \end{array} \right]  \left[ \begin{array}{c} v_1 \\ v_2 \\ v_3  \end{array} \right]
 % = u_1 v_1 + u_2 v_2 + u_3 v_3
-% \end{equation} 
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % si $\col{u}$ et $\col{v}$ sont les composantes exprimées dans une base vectorielle commune, par exemple:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{align}
 % \vec{u} \bullet \vec{v} &= (\col{u}^a)^T \col{v}^a = (\col{u}^b)^T \col{v}^b
-% \end{align} 
+% \end{align}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% mais attention car: 
+% mais attention car:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{align}
 % \vec{u} \bullet \vec{v} &\ne (\col{u}^a)^T \col{v}^b \\
-% \vec{u} \bullet \vec{v} &\ne (\col{u}^b)^T \col{v}^a 
-% \end{align} 
+% \vec{u} \bullet \vec{v} &\ne (\col{u}^b)^T \col{v}^a
+% \end{align}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Il est à noter que l'ordre de multiplication ne change pas le résultat pour le produit scalaire:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{equation}
-% \vec{u} \bullet \vec{v} = \vec{v} \bullet \vec{u} = \col{u}^T \col{v} = \col{v}^T \col{u} 
-% \end{equation} 
+% \vec{u} \bullet \vec{v} = \vec{v} \bullet \vec{u} = \col{u}^T \col{v} = \col{v}^T \col{u}
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \subsection{Calcul de longueurs, projections et angles avec les composantes}
 Lorsqu'on connaît les composantes d'un vecteur position $\vec{r}$, le produit intérieur peut être utilisé pour calculer sa longueur:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\|\vec{r}\|^2 &= \vec{r} \bullet \vec{r} = \col{r}^T \col{r} = r_1^2 + r_2^2 + r_3^2  \\
-\|\vec{r}\|  &= \sqrt{ \col{r}^T \col{r} }
-\end{align} 
+	\|\vec{r}\|^2 &= \vec{r} \bullet \vec{r} = \col{r}^T \col{r} = r_1^2 + r_2^2 + r_3^2  \\
+	\|\vec{r}\|  &= \sqrt{ \col{r}^T \col{r} }
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 pour calculer une distance projetée selon un axe décrit par un vecteur unitaire $\hat{n}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-d_n &= \vec{r} \bullet \hat{n} = \col{r}^T \col{n} = 
-\left[ \begin{array}{c c c} r_1 &  r_2 &  r_3  \end{array} \right]
-\left[ \begin{array}{c}     n_1 \\ n_2 \\ n_3  \end{array} \right]
-= r_1 n_1 + r_2 n_2 + r_3 n_3
-\end{align} 
+	d_n &= \vec{r} \bullet \hat{n} = \col{r}^T \col{n} =
+	\left[ \begin{array}{c c c} r_1 &  r_2 &  r_3  \end{array} \right]
+	\left[ \begin{array}{c}     n_1 \\ n_2 \\ n_3  \end{array} \right]
+	= r_1 n_1 + r_2 n_2 + r_3 n_3
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 pour calculer un angle entre deux vecteurs unitaires $\hat{x}$ et $\hat{y}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\cos \angle (\hat{x},\hat{y}) &= \hat{x} \bullet \hat{y} = \col{x}^T \col{y} \\
-\angle (\hat{x},\hat{y}) &= \arccos{ ( \col{x}^T \col{y} ) } 
-\end{align} 
+	\cos \angle (\hat{x},\hat{y}) &= \hat{x} \bullet \hat{y} = \col{x}^T \col{y} \\
+	\angle (\hat{x},\hat{y}) &= \arccos{ ( \col{x}^T \col{y} ) }
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 et pour calculer entre deux vecteurs position $\vec{r}_A$ et $\vec{r}_B$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_A \bullet \vec{r}_B = \|\vec{r}_A\|  \|\vec{r}_B\|  \cos \angle (\vec{r}_A,\vec{r}_B) &= \col{r}_A^T \col{r}_B \\
-\angle (\vec{r}_A,\vec{r}_B) &= \arccos{ \left( \frac{\col{r}_A^T \col{r}_B }{ \sqrt{ \col{r}_A^T \col{r}_A} \, \sqrt{ \col{r}_B^T \col{r}_B}} \right) }
-\end{align} 
+	\vec{r}_A \bullet \vec{r}_B = \|\vec{r}_A\|  \|\vec{r}_B\|  \cos \angle (\vec{r}_A,\vec{r}_B) &= \col{r}_A^T \col{r}_B \\
+	\angle (\vec{r}_A,\vec{r}_B) &= \arccos{ \left( \frac{\col{r}_A^T \col{r}_B }{ \sqrt{ \col{r}_A^T \col{r}_A} \, \sqrt{ \col{r}_B^T \col{r}_B}} \right) }
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Il est à noter que dans ces équations les vecteur-colonnes de composantes doivent tous être dans la même base. Les résultats sont des scalaires qui ne dépendent pas de la base utilisée. 
+Il est à noter que dans ces équations les vecteurs-colonne de composantes doivent tous être dans la même base. Les résultats sont des scalaires qui ne dépendent pas de la base utilisée.
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \subsubsection{Produit vectoriel}
@@ -678,27 +681,27 @@ Il est à noter que dans ces équations les vecteur-colonnes de composantes doiv
 % Un produit vectoriel (\textit{cross product}) peut être calculé directement par une opération matricielle définie avec les vecteur-colonnes:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{equation}
-% \vec{u} = \vec{v} \times \vec{w} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} \quad \Rightarrow \quad 
-%  \left[ \begin{array}{c} u_1 \\ u_2 \\ u_3  \end{array} \right] = 
+% \vec{u} = \vec{v} \times \vec{w} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} \quad \Rightarrow \quad
+%  \left[ \begin{array}{c} u_1 \\ u_2 \\ u_3  \end{array} \right] =
 % \left[ \begin{array}{c c c}
-% 	0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
+%  0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
 % \end{array}  \right]
 %  \left[ \begin{array}{c} w_1 \\ w_2 \\ w_3  \end{array} \right]
-% \end{equation} 
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % L'ordre de multiplication est important pour le produit vectoriel, il change la direction du vecteur résultant:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{equation}
 % \vec{u} = \vec{v} \times \vec{w} =  -\vec{w} \times \vec{v} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} = - \col{w}^{\times}\col{v}
-% \end{equation} 
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % \paragraph{Vecteurs unitaires d'une base vectorielle:}
-% Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux: 
+% Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{equation}
 % \hat{b}_3 = \hat{b}_1 \times \hat{b}_2  \quad \Rightarrow \quad   \col{b}_3 = \col{b}_1^{\times}\col{b}_2
-% \end{equation} 
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % \paragraph{Note:}
@@ -715,54 +718,54 @@ Il est à noter que dans ces équations les vecteur-colonnes de composantes doiv
 %  \left[ \begin{array}{c} v_1^b \\ v_2^b \\ v_3^b  \end{array} \right]
 % =
 % \left[ \begin{array}{c c c}
-% 	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\ 
-% 	{}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
-% 	{}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
+%  {}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\
+%  {}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
+%  {}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
 % \end{array}  \right]
 %  \left[ \begin{array}{c} v_1^a \\ v_2^a \\ v_3^a  \end{array} \right]
 % \label{eq:basechange1}
-% \end{align} 
+% \end{align}
 % %%%%%%%%%%%%%%%%%
 % Les propriétés et le calcul des matrices de rotation seront traités en détails à la section \ref{sec:changematrice}.
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\subsection{Calculs appliqués dans un contexte de cinématique} 
+%\subsection{Calculs appliqués dans un contexte de cinématique}
 %%
 %\paragraph{Normes, projections et calcul d'angles:}
 %Lorsque qu'on connait les composantes de vecteurs dans une base commune, le produit intérieur peut être utilisé pour calculer la longueur d'un vecteur position:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %\|\vec{r}\|^2 &= \vec{r} \bullet \vec{r} = \col{r}^T \col{r} = r_1^2 + r_2^2 + r_3^2
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %pour calculer une distance projeté selon un axe décrit par un vecteur unitaire $\hat{n}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %d_n &= \vec{r} \bullet \hat{n} = \col{r}^T \col{n} = r_1 n_1 + r_2 n_2 + r_3 n_3
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %et pour calculer un angle entre deux vecteurs unitaires $\hat{x}$ et $\hat{y}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %\cos \angle (\hat{x},\hat{y}) = \hat{x} \bullet \hat{y} = \col{x}^T \col{y} = x_1 y_1 + x_2 y_2 + x_3 y_3
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 %\paragraph{Vecteurs unitaires:}
-%Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux: 
+%Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{equation}
 %\hat{b}_3 = \hat{b}_1 \times \hat{b}_2  \quad \Rightarrow \quad   \col{b}_3 = \col{b}_1^{\times}\col{b}_2
-%\end{equation} 
+%\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% \subsection{Invariants} 
+% \subsection{Invariants}
 % %
-% Le vecteur géométrique $\vec{r}$ est une quantité constante peu importe la base vectorielle utilisée: 
+% Le vecteur géométrique $\vec{r}$ est une quantité constante peu importe la base vectorielle utilisée:
 % %%%%%%%%%%%%%%%
 % \begin{equation}
 % \vec{r} = \sum_{i} r_i^a \hat{a}_i = \sum_{i} r_i^b \hat{b}_i = \sum_{i} r_i^c \hat{c}_i
@@ -771,8 +774,8 @@ Il est à noter que dans ces équations les vecteur-colonnes de composantes doiv
 % mais le vecteur-colonne dépend de la base vectorielle. Les vecteur-colonnes sont en générale différents sauf dans le cas particulier de bases vectorielles coïncidentes:
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \begin{equation}
-% \col{r}^{a} \ne \col{r}^{b} \quad\quad \text{sauf dans le cas particulier:} \quad \hat{a}_1 = \hat{b}_1 \;,\; \hat{a}_2 = \hat{b}_2  \;\text{et}\; \hat{a}_3 = \hat{b}_3 
-% \end{equation} 
+% \col{r}^{a} \ne \col{r}^{b} \quad\quad \text{sauf dans le cas particulier:} \quad \hat{a}_1 = \hat{b}_1 \;,\; \hat{a}_2 = \hat{b}_2  \;\text{et}\; \hat{a}_3 = \hat{b}_3
+% \end{equation}
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % La longueur du vecteur géométrique étant une constante peut importe la base vectorielle utilisée, il est possible d'établir la relation suivante entre les vecteur-colonnes utilisant différentes bases:
 % %%%%%%%%%%%%%%%
@@ -780,7 +783,7 @@ Il est à noter que dans ces équations les vecteur-colonnes de composantes doiv
 % \|\vec{r}\|^2 = \vec{r} \bullet \vec{r} = (\col{r}^{a})^T \col{r}^{a} = (\col{r}^{b})^T \col{r}^{b} = (\col{r}^{c})^T \col{r}^{c}
 % \end{equation}
 % %%%%%%%%%%%%%%%
-% La norme des vecteur-colonnes est donc invariante par rapport au choix de la base. 
+% La norme des vecteur-colonnes est donc invariante par rapport au choix de la base.
 
 
 
@@ -793,14 +796,14 @@ Il est à noter que dans ces équations les vecteur-colonnes de composantes doiv
 \section{Les matrices de rotations}
 \label{sec:changematrice}
 
-Une matrice de rotation notée $^aR^b$, est une matrice (3$\times$3 en 3D) qui permet de calculer directement les composants d'un vecteur position dans une base $a$ avec les composants connus dans une base $b$, i.e. effectuer un \textbf{changement de base}, par une multiplication de la forme:
+Une matrice de rotation notée $^aR^b$, est une matrice (3$\times$3 en 3D) qui permet de calculer directement les composants d'un vecteur position dans une base $a$ avec les composants connus dans une base $b$, c.-à-d. effectuer un \textbf{changement de base}, par une multiplication de la forme:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^a &= {}^aR^b \col{r}^b
-\label{eq:basechange}
-\end{align} 
+	\col{r}^a &= {}^aR^b \col{r}^b
+	\label{eq:basechange}
+\end{align}
 %%%%%%%%%%%%%%%%%
-La matrice de rotation est un raccourci pour projeter un vecteur position sur trois nouveaux axes en une seule opération matricielle, plutôt que d'effectuer trois opérations de projection indépendantes. Cette matrice représente l'orientation relative de deux bases vectorielles.  
+La matrice de rotation est un raccourci pour projeter un vecteur position sur trois nouveaux axes en une seule opération matricielle, plutôt que d'effectuer trois opérations de projection indépendantes. Cette matrice représente l'orientation relative de deux bases vectorielles.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \\ \noindent
@@ -816,51 +819,51 @@ La matrice de rotation est un raccourci pour projeter un vecteur position sur tr
 Une matrice de rotation est définie par les produits scalaires des vecteurs unitaires qui forment deux bases vectorielles:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^aR^b &= 
-\left[ \begin{array}{c c c} 
-\hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 \\
-\hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 \\
-\hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 
-\end{array} \right] 
-= 
-\left[ \begin{array}{c c c} 
-\cos \angle (\hat{a}_1 , \hat{b}_1)  &  \cos \angle (\hat{a}_1 , \hat{b}_2)  &  \cos \angle (\hat{a}_1 , \hat{b}_3) \\
-\cos \angle (\hat{a}_2 , \hat{b}_1)  &  \cos \angle (\hat{a}_2 , \hat{b}_2)  &  \cos \angle (\hat{a}_2 , \hat{b}_3) \\
-\cos \angle (\hat{a}_3 , \hat{b}_1)  &  \cos \angle (\hat{a}_3 , \hat{b}_2)  &  \cos \angle (\hat{a}_3 , \hat{b}_3) 
+{}^aR^b &=
+\left[ \begin{array}{c c c}
+		   \hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 \\
+		   \hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 \\
+		   \hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3
+\end{array} \right]
+=
+\left[ \begin{array}{c c c}
+		   \cos \angle (\hat{a}_1 , \hat{b}_1)  &  \cos \angle (\hat{a}_1 , \hat{b}_2)  &  \cos \angle (\hat{a}_1 , \hat{b}_3) \\
+		   \cos \angle (\hat{a}_2 , \hat{b}_1)  &  \cos \angle (\hat{a}_2 , \hat{b}_2)  &  \cos \angle (\hat{a}_2 , \hat{b}_3) \\
+		   \cos \angle (\hat{a}_3 , \hat{b}_1)  &  \cos \angle (\hat{a}_3 , \hat{b}_2)  &  \cos \angle (\hat{a}_3 , \hat{b}_3)
 \end{array} \right]
 \label{eq:cosinusdirecteurs}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Les produits scalaires correspondent aussi aux cosinus des angles entre les vecteurs unitaires, c'est pourquoi la matrice de rotation est aussi parfois appelée la \textbf{matrice des cosinus directeurs}. Par inspection de l'équation \eqref{eq:cosinusdirecteurs}, on remarque que les colonnes de la matrice ${}^aR^b$ correspondent aux vecteur-colonnes des composantes des vecteurs unitaires $\hat{b}_i$ exprimées dans la base $a$ et que les rangés de la matrice ${}^aR^b$ correspondent à la transposée des vecteur-colonnes des composantes des vecteurs unitaires $\hat{a}_i$ exprimées dans la base $b$. Cela permet donc des définitions équivalentes plus compactes:
+Les produits scalaires correspondent aussi aux cosinus des angles entre les vecteurs unitaires, c'est pourquoi la matrice de rotation est aussi parfois appelée la \textbf{matrice des cosinus directeurs}. Par inspection de l'équation \eqref{eq:cosinusdirecteurs}, on remarque que les colonnes de la matrice ${}^aR^b$ correspondent aux vecteurs-colonne des composantes des vecteurs unitaires $\hat{b}_i$ exprimées dans la base $a$ et que les rangées de la matrice ${}^aR^b$ correspondent à la transposée des vecteurs-colonne des composantes des vecteurs unitaires $\hat{a}_i$ exprimées dans la base $b$. Cela permet donc des définitions équivalentes plus compactes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^aR^b &= 
-%\left[ \begin{array}{c c c} 
+{}^aR^b &=
+%\left[ \begin{array}{c c c}
 %\col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
-%\end{array} \right] 
+%\end{array} \right]
 %=
-%\left[ \begin{array}{c} 
+%\left[ \begin{array}{c}
 %(\col{a}_1^b)^T \\
 %(\col{a}_2^b)^T \\
 %(\col{a}_3^b)^T
-%\end{array} \right] = 
-\left[ \begin{array}{c c c} 
-	\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
+%\end{array} \right] =
+\left[ \begin{array}{c c c}
+		   \left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
 \end{array} \right]
 =
-\left[ \begin{array}{c} 
-\left[ \begin{array}{c c c} & (\col{a}_1^b)^T & \end{array} \right] \\[\medskipamount]
-\left[ \begin{array}{c c c} & (\col{a}_2^b)^T & \end{array} \right] \\[\medskipamount]
-\left[ \begin{array}{c c c} & (\col{a}_3^b)^T & \end{array} \right] 
-\end{array} \right] 
+\left[ \begin{array}{c}
+		   \left[ \begin{array}{c c c} & (\col{a}_1^b)^T & \end{array} \right] \\[\medskipamount]
+		   \left[ \begin{array}{c c c} & (\col{a}_2^b)^T & \end{array} \right] \\[\medskipamount]
+		   \left[ \begin{array}{c c c} & (\col{a}_3^b)^T & \end{array} \right]
+\end{array} \right]
 \label{eq:matricerotcol}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Finalement, la matrice de rotation peut aussi être définie en termes de composantes et d'indices par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^aR^b_{ij} &= \hat{a}_i \bullet \hat{b}_j
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 une équation qui est simple à se rappeler et permet d'éviter de mélanger l'ordre de rotation ${}^aR^b$ vs. ${}^bR^a$ avec la notation utilisée dans ces notes.
 
@@ -871,57 +874,57 @@ une équation qui est simple à se rappeler et permet d'éviter de mélanger l'o
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Démonstration de l'origine de la matrice de rotation}
-%Cette section démontre l'équation \eqref{eq:basechange} basé sur les définitions des vecteur-colonnes de composants. 
-Si les composantes d'un vecteur $\vec{r}$ sont connus dans une base $a$:
+%Cette section démontre l'équation \eqref{eq:basechange} basé sur les définitions des vecteur-colonnes de composants.
+Si les composantes d'un vecteur $\vec{r}$ sont connues dans une base $a$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^a &= \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right]
-\end{align} 
+	\col{r}^a &= \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 le vecteur géométrique associé est donné par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r} &= r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3
-\label{eq:pvec}
-\end{align} 
+	\vec{r} &= r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3
+	\label{eq:pvec}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Les composantes dans une base $b$ peuvent être calculées par des produits scalaires suivants:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-r_1^b &= \vec{r} \bullet \hat{b}_1 \\
-r_2^b &= \vec{r} \bullet \hat{b}_2 \\
-r_3^b &= \vec{r} \bullet \hat{b}_3
-\end{align} 
+	r_1^b &= \vec{r} \bullet \hat{b}_1 \\
+	r_2^b &= \vec{r} \bullet \hat{b}_2 \\
+	r_3^b &= \vec{r} \bullet \hat{b}_3
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Si on substitue $\vec{r}$ par l'équation \eqref{eq:pvec}:
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-r_1^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_1 \\
-r_2^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_2 \\
-r_3^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_3
-\end{align} 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-et on réarrange les termes:
+Si l'on substitue $\vec{r}$ par l'équation \eqref{eq:pvec}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-r_1^b &= (\hat{a}_1 \bullet \hat{b}_1 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_1 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_1 ) r_3^a \\
-r_2^b &= (\hat{a}_1 \bullet \hat{b}_2 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_2 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_2 ) r_3^a \\
-r_3^b &= (\hat{a}_1 \bullet \hat{b}_3 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_3 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_3 ) r_3^a 
-\end{align} 
+	r_1^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_1 \\
+	r_2^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_2 \\
+	r_3^b &= (r_1^a \hat{a}_1 + r_2^a \hat{a}_2 + r_3^a \hat{a}_3) \bullet \hat{b}_3
+\end{align}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+et l'on réarrange les termes:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{align}
+	r_1^b &= (\hat{a}_1 \bullet \hat{b}_1 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_1 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_1 ) r_3^a \\
+	r_2^b &= (\hat{a}_1 \bullet \hat{b}_2 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_2 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_2 ) r_3^a \\
+	r_3^b &= (\hat{a}_1 \bullet \hat{b}_3 ) r_1^a + (\hat{a}_2 \bullet \hat{b}_3 ) r_2^a + (\hat{a}_3 \bullet \hat{b}_3 ) r_3^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 On obtient trois équations qui peuvent être regroupées sous forme matricielle:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{ \left[ \begin{array}{c} r_1^b \\ r_2^b \\ r_3^b  \end{array} \right] }_{\col{r}^b}
-=
-\underbrace{ \left[ \begin{array}{c c c} 
-\hat{a}_1 \bullet \hat{b}_1 & \hat{a}_2 \bullet \hat{b}_1 & \hat{a}_3 \bullet \hat{b}_1 \\
-\hat{a}_1 \bullet \hat{b}_2 & \hat{a}_2 \bullet \hat{b}_2 & \hat{a}_3 \bullet \hat{b}_2 \\
-\hat{a}_1 \bullet \hat{b}_3 & \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_3 \bullet \hat{b}_3 
-\end{array} \right] }_{^bR^a}
-\underbrace{ \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right] }_{\col{r}^a}
-\label{eq:Rdot}
-\end{align} 
+	\underbrace{ \left[ \begin{array}{c} r_1^b \\ r_2^b \\ r_3^b  \end{array} \right] }_{\col{r}^b}
+	=
+	\underbrace{ \left[ \begin{array}{c c c}
+							\hat{a}_1 \bullet \hat{b}_1 & \hat{a}_2 \bullet \hat{b}_1 & \hat{a}_3 \bullet \hat{b}_1 \\
+							\hat{a}_1 \bullet \hat{b}_2 & \hat{a}_2 \bullet \hat{b}_2 & \hat{a}_3 \bullet \hat{b}_2 \\
+							\hat{a}_1 \bullet \hat{b}_3 & \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_3 \bullet \hat{b}_3
+	\end{array} \right] }_{^bR^a}
+	\underbrace{ \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right] }_{\col{r}^a}
+	\label{eq:Rdot}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 La matrice de rotation $^bR^a$ consiste donc à des produits scalaires entre les vecteurs unitaires des bases vectorielles $a$ et $b$. \textbf{L'opération de multiplication d'un vecteur-colonne $\col{r}^a$ par la matrice de rotation $^bR^a$ correspond à la projection du vecteur géométrique associé $\vec{r}$ sur la base vectorielle $b$.}
@@ -931,11 +934,11 @@ La matrice de rotation $^bR^a$ consiste donc à des produits scalaires entre les
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Exemple: matrice de rotation dans le plan calculée par trigonométrie}
 
-La figure \ref{fig:basechange2d} montre un exemple d'un vecteur $\vec{r}$ en 2 dimensions exprimé dans deux base vectorielles $b$ et $a$. Comme illustré à la figure \ref{fig:r_trigo}, avec une construction de triangles il est possible de déterminer par trigonométrie les relations entre les composantes dans les deux bases, et donc la matrice de rotation ${}^aR^b$. L'approche par trigonométrie est toutefois limitée pour les rotations en 3D, une approche vectorielle plus simple et plus universelle pour calculer des matrices de rotation est présentée à la section \ref{sec:calmat}.
+La figure \ref{fig:basechange2d} montre un exemple d'un vecteur $\vec{r}$ en 2 dimensions exprimé dans deux bases vectorielles $b$ et $a$. Comme illustré à la figure \ref{fig:r_trigo}, avec une construction de triangles il est possible de déterminer par trigonométrie les relations entre les composantes dans les deux bases, et donc la matrice de rotation ${}^aR^b$. L'approche par trigonométrie est toutefois limitée pour les rotations en 3D, une approche vectorielle plus simple et plus universelle pour calculer des matrices de rotation est présentée à la section \ref{sec:calmat}.
 %%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.65\textwidth]{basechange.png}
+	\includegraphics[width=0.65\textwidth]{basechange.png}
 	\caption{Vecteur position exprimé dans deux bases vectorielles}
 	\label{fig:basechange2d}
 \end{figure}
@@ -943,7 +946,7 @@ La figure \ref{fig:basechange2d} montre un exemple d'un vecteur $\vec{r}$ en 2 d
 %%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.65\textwidth]{r_trigo.png}
+	\includegraphics[width=0.65\textwidth]{r_trigo.png}
 	\caption{Calcul par trigonométrie de la matrice de rotation 2x2 ${}^aR^b$ pour le changement de base illustré à la figure \ref{fig:basechange2d}}
 	\label{fig:r_trigo}
 \end{figure}
@@ -956,95 +959,95 @@ La figure \ref{fig:basechange2d} montre un exemple d'un vecteur $\vec{r}$ en 2 d
 \subsection{Méthode de calcul des matrices de rotation basé sur les colonnes}
 \label{sec:calmat}
 
-La définition des matrices de rotation basée sur les vecteurs unitaires de eq.\eqref{eq:matricerotcol} est particulièrement utile pour calculer une matrice de rotation. Une astuce pour ne pas mélanger l'ordre de rotation ($^bR^a$ vs. $^aR^b$) est d'avoir en tête que la multiplication matricielle c'est une combinaison linéaire de vecteur-colonnes:
+La définition des matrices de rotation basée sur les vecteurs unitaires de l'eq. \eqref{eq:matricerotcol} est particulièrement utile pour calculer une matrice de rotation. Une astuce pour ne pas mélanger l'ordre de rotation ($^bR^a$ vs. $^aR^b$) est d'avoir en tête que la multiplication matricielle c'est une combinaison linéaire de vecteur-colonnes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^a &= 
-\underbrace{ \left[ \begin{array}{c c c} 
-	\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
-\end{array} \right] }_{^aR^b}
-\underbrace{ \left[ \begin{array}{c} r_1^b \\ r_2^b \\ r_3^b  \end{array} \right] }_{\col{r}^b}
-= 
-\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] \, r_1^b + \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right]\, r_2^b + \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right] \, r_3^b 
+	\col{r}^a &=
+	\underbrace{ \left[ \begin{array}{c c c}
+							\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
+	\end{array} \right] }_{^aR^b}
+	\underbrace{ \left[ \begin{array}{c} r_1^b \\ r_2^b \\ r_3^b  \end{array} \right] }_{\col{r}^b}
+	=
+	\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] \, r_1^b + \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right]\, r_2^b + \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right] \, r_3^b
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % TODO figure combinaisons de vecteur colonnes?
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-et donc que si on cherche la matrice de rotation ${}^aR^b$ pour calculer le passage de la base $b$ vers la base $a$, il faut trouver les directions spatiales $\hat{b}_1$, $\hat{b}_2$ et $\hat{b}_3$ qui seront combinées linéairement selon les coeficients $r_1^b$, $r_2^b$, $r_3^b$. 
+et donc si l'on cherche la matrice de rotation ${}^aR^b$ pour calculer le passage de la base $b$ vers la base $a$, il faut trouver les directions spatiales $\hat{b}_1$, $\hat{b}_2$ et $\hat{b}_3$ qui seront combinées linéairement selon les coefficients $r_1^b$, $r_2^b$, $r_3^b$.
 
 %Une méthode rapide et universelle pour calculer une matrice de rotation est de \textbf{1)} construire par inspection les vecteur unitaires $\hat{b}_i$ de la base vectorielle initiale, comme une combinaison de vecteur unitaires $\hat{a}_i$ de la base cible, \textbf{2)} convertir les équations en vecteur-colonnes $\col{b}_i^a$, et \textbf{3)} assembler la matrice avec la définition de l'équation \eqref{eq:matricerotcol}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %\hat{b}_1 &= a \, \hat{a}_1 + b \, \hat{a}_2 + c \, \hat{a}_3  \quad\quad  \hat{b}_2 = d \, \hat{a}_1 + e \, \hat{a}_2 + f \, \hat{a}_3   \quad\quad  \hat{b}_3 = g \, \hat{a}_1 + h \, \hat{a}_2 + i \, \hat{a}_3  \\
-%\col{b}_1^a  &= \left[ \begin{array}{c} a \\ b \\ c  \end{array} \right] \quad\quad\quad\quad\quad\quad\;  
-%\col{b}_2^a  = \left[ \begin{array}{c} d \\ e \\ f  \end{array} \right]  \quad\quad\quad\quad\quad\quad\; 
+%\col{b}_1^a  &= \left[ \begin{array}{c} a \\ b \\ c  \end{array} \right] \quad\quad\quad\quad\quad\quad\;
+%\col{b}_2^a  = \left[ \begin{array}{c} d \\ e \\ f  \end{array} \right]  \quad\quad\quad\quad\quad\quad\;
 %\col{b}_3^a  = \left[ \begin{array}{c} g \\ h \\ i  \end{array} \right]  \\
-%{}^aR^b = 
-%\left[ \begin{array}{c c c} 
+%{}^aR^b =
+%\left[ \begin{array}{c c c}
 %\col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
-%\end{array} \right] 
-%=
-%\left[ \begin{array}{c c c} 
-%a & d & g \\ 
-%b & e & h \\ 
-%c & f & i 
 %\end{array} \right]
-%\end{align} 
+%=
+%\left[ \begin{array}{c c c}
+%a & d & g \\
+%b & e & h \\
+%c & f & i
+%\end{array} \right]
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Une méthode rapide et universelle pour calculer une matrice de rotation est de construire par inspection les vecteur unitaires $\hat{b}_i$ de la base vectorielle initiale, comme une combinaison de vecteurs unitaires $\hat{a}_i$ de la base cible:
+Une méthode rapide et universelle pour calculer une matrice de rotation est de construire par inspection les vecteurs unitaires $\hat{b}_i$ de la base vectorielle initiale, comme une combinaison de vecteurs unitaires $\hat{a}_i$ de la base cible:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{b}_1 &= a \, \hat{a}_1 + b \, \hat{a}_2 + c \, \hat{a}_3  \quad\quad  \hat{b}_2 = d \, \hat{a}_1 + e \, \hat{a}_2 + f \, \hat{a}_3   \quad\quad  \hat{b}_3 = g \, \hat{a}_1 + h \, \hat{a}_2 + i \, \hat{a}_3 
-\end{align} 
+	\hat{b}_1 &= a \, \hat{a}_1 + b \, \hat{a}_2 + c \, \hat{a}_3  \quad\quad  \hat{b}_2 = d \, \hat{a}_1 + e \, \hat{a}_2 + f \, \hat{a}_3   \quad\quad  \hat{b}_3 = g \, \hat{a}_1 + h \, \hat{a}_2 + i \, \hat{a}_3
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 pour ensuite convertir les équations en vecteur-colonnes $\col{b}_i^a$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{b}_1^a  &= \left[ \begin{array}{c} a \\ b \\ c  \end{array} \right] \quad\quad\quad\quad\quad\quad\;  
-\col{b}_2^a  = \left[ \begin{array}{c} d \\ e \\ f  \end{array} \right]  \quad\quad\quad\quad\quad\quad\; 
-\col{b}_3^a  = \left[ \begin{array}{c} g \\ h \\ i  \end{array} \right] 
-\end{align} 
+	\col{b}_1^a  &= \left[ \begin{array}{c} a \\ b \\ c  \end{array} \right] \quad\quad\quad\quad\quad\quad\;
+	\col{b}_2^a  = \left[ \begin{array}{c} d \\ e \\ f  \end{array} \right]  \quad\quad\quad\quad\quad\quad\;
+	\col{b}_3^a  = \left[ \begin{array}{c} g \\ h \\ i  \end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 et assembler la matrice avec la définition de l'équation \eqref{eq:matricerotcol}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^aR^b = 
-\left[ \begin{array}{c c c} 
-\col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
-\end{array} \right] 
-=
-\left[ \begin{array}{c c c} 
-a & d & g \\ 
-b & e & h \\ 
-c & f & i 
+{}^aR^b =
+\left[ \begin{array}{c c c}
+		   \col{b}_1^a &  \col{b}_2^a & \col{b}_3^a
 \end{array} \right]
-\end{align} 
+=
+\left[ \begin{array}{c c c}
+		   a & d & g \\
+		   b & e & h \\
+		   c & f & i
+\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Pour les matrices de rotation élémentaires, i.e. les matrices qui représentent une rotation d'un angle $\theta$ autour de l'axe $\hat{b}_1$, $\hat{b}_2$ ou $\hat{b}_3$, les neufs éléments $a,b,c,d,..$ de la matrice peuvent seulement prendre comme valeurs $\cos \theta$, $\pm \sin \theta$, $1$ ou $0$. Il est donc relativement facile de les identifier par inspection, comme il est illustré à la section suivante.
+Pour les matrices de rotation élémentaires, c.-à-d. les matrices qui représentent une rotation d'un angle $\theta$ autour de l'axe $\hat{b}_1$, $\hat{b}_2$ ou $\hat{b}_3$, les neufs éléments $a,b,c,d,..$ de la matrice peuvent seulement prendre comme valeurs $\cos \theta$, $\pm \sin \theta$, $1$ ou $0$. Il est donc relativement facile de les identifier par inspection, comme il est illustré à la section suivante.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Matrices de rotation élémentaires}
 
-Les matrices de rotation élémentaires représentent des rotations relatives d'un angle $\theta$ autour de l'axe 1, 2 ou 3 entre deux bases vectorielles. Ces matrices seront notées $R_i(\theta)$ où $i$ est l'indice de l'axe de rotation. Ces matrices sont caractérisées par le fait que le vecteur unitaire $\hat{b}_i$ de la base mobile coïncide avec le vecteur unitaire $\hat{a}_i$ de la base fixe, et la relation entre les autres vecteurs unitaires peut être facilement représentée dans le plan perpendiculaire à l'axe de rotation. 
+Les matrices de rotation élémentaires représentent des rotations relatives d'un angle $\theta$ autour de l'axe 1, 2 ou 3 entre deux bases vectorielles. Ces matrices seront notées $R_i(\theta)$ où $i$ est l'indice de l'axe de rotation. Ces matrices sont caractérisées par le fait que le vecteur unitaire $\hat{b}_i$ de la base mobile coïncide avec le vecteur unitaire $\hat{a}_i$ de la base fixe, et la relation entre les autres vecteurs unitaires peut être facilement représentée dans le plan perpendiculaire à l'axe de rotation.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \note{Notation simplifiée pour les calculs trigonométriques:}{ Les symboles $c\theta$ et $s\theta$ sont ici introduits pour alléger les équations et représentent les fonctions trigonométriques $\cos(\theta)$ et $\sin(\theta)$ respectivement:
 %%%%%%%%%%%%%%%%%%%%
-\begin{align}
-s\theta &= \sin(\theta)\\
-c\theta &= \cos(\theta)
-\end{align}
+	\begin{align}
+		s\theta &= \sin(\theta)\\
+		c\theta &= \cos(\theta)
+	\end{align}
 %%%%%%%%%%%%%%%%%%%%%
-Pour les calculs de cinématique qui implique plusieurs angles, une notation encore plus compacte sera utilisée avec seulement les lettres $s$ ou $c$ et des indices qui spécifie les angles:
+	Pour les calculs de cinématique qui implique plusieurs angles, une notation encore plus compacte sera utilisée avec seulement les lettres $s$ ou $c$ et des indices qui spécifie les angles:
 %%%%%%%%%%%%%%%%%%%%
-\begin{align}
-s_i &= \sin(\theta_i)\\
-c_i &= \cos(\theta_i) \\
-s_{ijk} &=  \sin( \theta_i + \theta_j + \theta_k)
-\end{align}
+	\begin{align}
+		s_i &= \sin(\theta_i)\\
+		c_i &= \cos(\theta_i) \\
+		s_{ijk} &=  \sin( \theta_i + \theta_j + \theta_k)
+	\end{align}
 %%%%%%%%%%%%%%%%%%%%%
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1053,44 +1056,44 @@ s_{ijk} &=  \sin( \theta_i + \theta_j + \theta_k)
 \paragraph{Rotation selon l'axe 3}
 \label{sec:rot3}
 %
-Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 3, les vecteurs unitaires $\hat{a}_3$ et $\hat{b}_3$ sont égaux et, comme illustré à la figure \ref{fig:r3vv}, les quatre autres vecteurs unitaires ($\hat{a}_1$, $\hat{b}_1$, $\hat{a}_2$ et $\hat{b}_2$) sont dans le plan formé par l'axe 1 et l'axe 2. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples: 
+Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 3, les vecteurs unitaires $\hat{a}_3$ et $\hat{b}_3$ sont égaux et, comme illustré à la figure \ref{fig:r3vv}, les quatre autres vecteurs unitaires ($\hat{a}_1$, $\hat{b}_1$, $\hat{a}_2$ et $\hat{b}_2$) sont dans le plan formé par l'axe 1 et l'axe 2. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{b}_1 = c\theta \, \hat{a}_1 + s\theta \, \hat{a}_2 \quad\quad
-\hat{b}_2 = -s\theta \, \hat{a}_1 + c\theta \, \hat{a}_2 \quad\quad
-\hat{b}_3 = \hat{a}_3
-\label{eq:rot3vecuni}
+	\hat{b}_1 = c\theta \, \hat{a}_1 + s\theta \, \hat{a}_2 \quad\quad
+	\hat{b}_2 = -s\theta \, \hat{a}_1 + c\theta \, \hat{a}_2 \quad\quad
+	\hat{b}_3 = \hat{a}_3
+	\label{eq:rot3vecuni}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
 La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:matricerotcol}:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{b}_1^a = \left[ \begin{array}{c} c\theta \\ s\theta \\ 0  \end{array} \right] \quad
-\col{b}_2^a = \left[ \begin{array}{c} -s\theta \\ c\theta \\ 0  \end{array} \right] \quad
-\col{b}_3^a = \left[ \begin{array}{c} 0 \\ 0 \\ 1  \end{array} \right]
-\quad \Rightarrow \quad
-^aR^b_3(\theta) = \left[ \begin{array}{c c c}
-	c\theta & -s\theta & 0 \\
-	s\theta & c\theta & 0 \\
-	0 & 0 & 1 
-\end{array}  \right]
-\label{eq:rot3theta}
+	\col{b}_1^a = \left[ \begin{array}{c} c\theta \\ s\theta \\ 0  \end{array} \right] \quad
+	\col{b}_2^a = \left[ \begin{array}{c} -s\theta \\ c\theta \\ 0  \end{array} \right] \quad
+	\col{b}_3^a = \left[ \begin{array}{c} 0 \\ 0 \\ 1  \end{array} \right]
+	\quad \Rightarrow \quad
+	^aR^b_3(\theta) = \left[ \begin{array}{c c c}
+								 c\theta & -s\theta & 0 \\
+								 s\theta & c\theta & 0 \\
+								 0 & 0 & 1
+	\end{array}  \right]
+	\label{eq:rot3theta}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%
-À noter que le coin supérieur gauche de la matrice $^aR^b_3(\theta)$ correspond à une matrice de rotation 2$\times$2 dans la plan.
+À noter que le coin supérieur gauche de la matrice $^aR^b_3(\theta)$ correspond à une matrice de rotation 2$\times$2 dans le plan.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-        \centering
-        \subfloat[3D]{
-				\includegraphics[width=0.30\textwidth]{r3.png}
-				\label{fig:r3}}
-				\hspace{+20pt}
-				\subfloat[Vue de face]{
-				\includegraphics[width=0.40\textwidth]{r3v.png}
-				\label{fig:r3v}}
-        \caption{Rotation relative selon l'axe 3}
-				\label{fig:r3vv}
+	\centering
+	\subfloat[3D]{
+		\includegraphics[width=0.30\textwidth]{r3.png}
+		\label{fig:r3}}
+	\hspace{+20pt}
+	\subfloat[Vue de face]{
+		\includegraphics[width=0.40\textwidth]{r3v.png}
+		\label{fig:r3v}}
+	\caption{Rotation relative selon l'axe 3}
+	\label{fig:r3vv}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -1098,43 +1101,43 @@ La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:ma
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{Rotation selon l'axe 2}
 %
-Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 2, les vecteurs unitaires $\hat{a}_2$ et $\hat{b}_2$ sont égaux et, comme illustré à la figure \ref{fig:r2vv}, les quatre autres vecteurs unitaires ($\hat{a}_1$, $\hat{b}_1$, $\hat{a}_3$ et $\hat{b}_3$) sont dans le plan formé par l'axe 1 et l'axe 3. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples: 
+Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 2, les vecteurs unitaires $\hat{a}_2$ et $\hat{b}_2$ sont égaux et, comme illustré à la figure \ref{fig:r2vv}, les quatre autres vecteurs unitaires ($\hat{a}_1$, $\hat{b}_1$, $\hat{a}_3$ et $\hat{b}_3$) sont dans le plan formé par l'axe 1 et l'axe 3. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{b}_1 = c\theta \, \hat{a}_1 -s\theta \, \hat{a}_3 \quad\quad
-\hat{b}_2 = \hat{a}_2 \quad\quad
-\hat{b}_3 = s\theta \, \hat{a}_1 + c\theta \, \hat{a}_3
-\label{eq:rot2vecuni}
+	\hat{b}_1 = c\theta \, \hat{a}_1 -s\theta \, \hat{a}_3 \quad\quad
+	\hat{b}_2 = \hat{a}_2 \quad\quad
+	\hat{b}_3 = s\theta \, \hat{a}_1 + c\theta \, \hat{a}_3
+	\label{eq:rot2vecuni}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
 La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:matricerotcol}:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{b}_1^a = \left[ \begin{array}{c} c\theta \\ 0 \\ -s\theta  \end{array} \right] \quad
-\col{b}_2^a = \left[ \begin{array}{c} 0 \\ 1 \\ 0  \end{array} \right] \quad
-\col{b}_3^a = \left[ \begin{array}{c} s\theta \\ 0 \\ c\theta  \end{array} \right]
-\quad \Rightarrow \quad
-^aR^b_2(\theta) = \left[ \begin{array}{c c c}
-	c\theta  & 0 & s\theta \\
-	0        & 1 & 0 \\
-	-s\theta & 0 & c\theta 
-\end{array}  \right]
-\label{eq:rot2theta}
+	\col{b}_1^a = \left[ \begin{array}{c} c\theta \\ 0 \\ -s\theta  \end{array} \right] \quad
+	\col{b}_2^a = \left[ \begin{array}{c} 0 \\ 1 \\ 0  \end{array} \right] \quad
+	\col{b}_3^a = \left[ \begin{array}{c} s\theta \\ 0 \\ c\theta  \end{array} \right]
+	\quad \Rightarrow \quad
+	^aR^b_2(\theta) = \left[ \begin{array}{c c c}
+								 c\theta  & 0 & s\theta \\
+								 0        & 1 & 0 \\
+								 -s\theta & 0 & c\theta
+	\end{array}  \right]
+	\label{eq:rot2theta}
 \end{align}
 %%%%%%%%%%%%%%%%%%%
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-        \centering
-        \subfloat[3D]{
-				\includegraphics[width=0.30\textwidth]{r2.png}
-				\label{fig:r2}}
-				\hspace{+20pt}
-				\subfloat[Vue de dessus]{
-				\includegraphics[width=0.30\textwidth]{r2v.png}
-				\label{fig:r2v}}
-        \caption{Rotation relative selon l'axe 2}
-				\label{fig:r2vv}
+	\centering
+	\subfloat[3D]{
+		\includegraphics[width=0.30\textwidth]{r2.png}
+		\label{fig:r2}}
+	\hspace{+20pt}
+	\subfloat[Vue de dessus]{
+		\includegraphics[width=0.30\textwidth]{r2v.png}
+		\label{fig:r2v}}
+	\caption{Rotation relative selon l'axe 2}
+	\label{fig:r2vv}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -1143,44 +1146,44 @@ La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:ma
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{Rotation selon l'axe 1}
 %
-Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 1, les vecteurs unitaires $\hat{a}_1$ et $\hat{b}_1$ sont égaux et, comme illustré à la figure \ref{fig:r3vv}, les quatre autres vecteurs unitaires ($\hat{a}_2$, $\hat{b}_2$, $\hat{a}_3$ et $\hat{b}_3$) sont dans le plan formé par l'axe 2 et l'axe 3. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples: 
+Si les bases vectorielles $a$ et $b$ ont une orientation relative décrite par une rotation d'un angle $\theta$ autour de l'axe 1, les vecteurs unitaires $\hat{a}_1$ et $\hat{b}_1$ sont égaux et, comme illustré à la figure \ref{fig:r3vv}, les quatre autres vecteurs unitaires ($\hat{a}_2$, $\hat{b}_2$, $\hat{a}_3$ et $\hat{b}_3$) sont dans le plan formé par l'axe 2 et l'axe 3. Les vecteurs unitaires sont reliés par des fonctions trigonométriques simples:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{b}_1 = \hat{a}_1 \quad\quad
-\hat{b}_2 = c\theta \, \hat{a}_2 + s\theta \, \hat{a}_3 \quad\quad
-\hat{b}_3 = -s\theta \, \hat{a}_2 + c\theta \, \hat{a}_3
-\label{eq:rot1vecuni}
+	\hat{b}_1 = \hat{a}_1 \quad\quad
+	\hat{b}_2 = c\theta \, \hat{a}_2 + s\theta \, \hat{a}_3 \quad\quad
+	\hat{b}_3 = -s\theta \, \hat{a}_2 + c\theta \, \hat{a}_3
+	\label{eq:rot1vecuni}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
 La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:matricerotcol}:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{b}_1^a = \left[ \begin{array}{c} 1 \\ 0 \\ 0  \end{array} \right] \quad
-\col{b}_2^a = \left[ \begin{array}{c} 0 \\ c\theta \\ s\theta  \end{array} \right] \quad
-\col{b}_3^a = \left[ \begin{array}{c} 0 \\ -s\theta \\ c\theta  \end{array} \right]
-\quad \Rightarrow \quad
-^aR^b_1(\theta) 
-= \left[ \begin{array}{c c c}
-	1 & 0 & 0 \\
-	0 & c\theta  & -s\theta \\
-	0 & s\theta & c\theta 
-\end{array}  \right]
-\label{eq:rot1theta}
+	\col{b}_1^a = \left[ \begin{array}{c} 1 \\ 0 \\ 0  \end{array} \right] \quad
+	\col{b}_2^a = \left[ \begin{array}{c} 0 \\ c\theta \\ s\theta  \end{array} \right] \quad
+	\col{b}_3^a = \left[ \begin{array}{c} 0 \\ -s\theta \\ c\theta  \end{array} \right]
+	\quad \Rightarrow \quad
+	^aR^b_1(\theta)
+	= \left[ \begin{array}{c c c}
+				 1 & 0 & 0 \\
+				 0 & c\theta  & -s\theta \\
+				 0 & s\theta & c\theta
+	\end{array}  \right]
+	\label{eq:rot1theta}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-        \centering
-        \subfloat[3D]{
-				\includegraphics[width=0.30\textwidth]{r1.png}
-				\label{fig:r1}}
-				\hspace{+20pt}
-				\subfloat[Vue de côté]{
-				\includegraphics[width=0.30\textwidth]{r1v.png}
-				\label{fig:r1v}}
-        \caption{Rotation relative selon l'axe 1}
-				\label{fig:r1vv}
+	\centering
+	\subfloat[3D]{
+		\includegraphics[width=0.30\textwidth]{r1.png}
+		\label{fig:r1}}
+	\hspace{+20pt}
+	\subfloat[Vue de côté]{
+		\includegraphics[width=0.30\textwidth]{r1v.png}
+		\label{fig:r1v}}
+	\caption{Rotation relative selon l'axe 1}
+	\label{fig:r1vv}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1191,44 +1194,44 @@ La matrice $^aR^b$ peut donc être formée grâce à la définition \eqref{eq:ma
 Cette section présente plusieurs propriétés des matrices de rotation qui sont utiles dans un contexte de changement de bases vectorielles.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\paragraph{Norme des colonnes et rangés}
+\paragraph{Norme des colonnes et rangées}
 
-Les colonnes $\col{c}_i$ et les rangés $\col{r}_i$ d'une matrice de rotation ont une norme égale à 1:
+Les colonnes $\col{c}_i$ et les rangées $\col{r}_i$ d'une matrice de rotation ont une norme égale à 1:
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R &= 
-\left[ \begin{array}{c c c} 
-	\left[ \begin{array}{c} \\ \col{c}_1 \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{c}_2 \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{c}_3 \\  \\ \end{array}  \right]
-\end{array} \right]
-=
-\left[ \begin{array}{c} 
-\left[ \begin{array}{c c c} & \col{r}_1^T & \end{array} \right] \\[\medskipamount]
-\left[ \begin{array}{c c c} & \col{r}_2^T & \end{array} \right] \\[\medskipamount]
-\left[ \begin{array}{c c c} & \col{r}_3^T & \end{array} \right] 
-\end{array} \right] 
-\quad \Rightarrow \quad
-(\col{c}_i)^T \col{c}_i = 1 \quad \& \quad (\col{r}_i)^T \col{r}_i = 1  \quad \forall i 
+	R &=
+	\left[ \begin{array}{c c c}
+			   \left[ \begin{array}{c} \\ \col{c}_1 \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{c}_2 \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{c}_3 \\  \\ \end{array}  \right]
+	\end{array} \right]
+	=
+	\left[ \begin{array}{c}
+			   \left[ \begin{array}{c c c} & \col{r}_1^T & \end{array} \right] \\[\medskipamount]
+			   \left[ \begin{array}{c c c} & \col{r}_2^T & \end{array} \right] \\[\medskipamount]
+			   \left[ \begin{array}{c c c} & \col{r}_3^T & \end{array} \right]
+	\end{array} \right]
+	\quad \Rightarrow \quad
+	(\col{c}_i)^T \col{c}_i = 1 \quad \& \quad (\col{r}_i)^T \col{r}_i = 1  \quad \forall i
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%
 L’identité trigonométrique suivante est souvent utile pour ce type de calculs:
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\sin^2(\theta) + \cos^2(\theta) = 1
+	\sin^2(\theta) + \cos^2(\theta) = 1
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \paragraph{Matrice identité}
-Une matrice de rotation est réduite à une matrice identitée lorsque les bases vectorielle sont coïncidentes. Par exemple, pour les matrices de rotation élémentaires des équations \eqref{eq:rot3theta}, \eqref{eq:rot2theta} et \eqref{eq:rot1theta}, lorsque l'angle est égale à zéro, les matrices sont réduites à des matrices identités:
+Une matrice de rotation est réduite à une matrice identité lorsque les bases vectorielles sont coïncidentes. Par exemple, pour les matrices de rotation élémentaires des équations \eqref{eq:rot3theta}, \eqref{eq:rot2theta} et \eqref{eq:rot1theta}, lorsque l'angle est égal à zéro, les matrices sont réduites à des matrices identités:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_1( \theta ) = R_2( \theta ) = R_3( \theta ) = I_{3\times3} = 
-\left[ \begin{array}{c c c}
-	1 & 0 & 0 \\
-	0 & 1 & 0 \\
-	0 & 0 & 1 
-\end{array}  \right]  \quad\text{si}\quad \theta = 0
-\label{eq:rot3thetaident}
+	R_1( \theta ) = R_2( \theta ) = R_3( \theta ) = I_{3\times3} =
+	\left[ \begin{array}{c c c}
+			   1 & 0 & 0 \\
+			   0 & 1 & 0 \\
+			   0 & 0 & 1
+	\end{array}  \right]  \quad\text{si}\quad \theta = 0
+	\label{eq:rot3thetaident}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%
 
@@ -1238,24 +1241,24 @@ R_1( \theta ) = R_2( \theta ) = R_3( \theta ) = I_{3\times3} =
 Pour inverser la direction d'une opération de changement de base, il suffit de multiplier par l'inverse de la matrice de rotation:
 %%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^a &= {}^aR^b \, \col{r}^b \\
-({}^aR^b)^{-1} \, \col{r}^a &= ({}^aR^b)^{-1} \, {}^aR^b \, \col{r}^b  \\
-({}^aR^b)^{-1} \, \col{r}^a &= \col{r}^b
+	\col{r}^a &= {}^aR^b \, \col{r}^b \\
+	({}^aR^b)^{-1} \, \col{r}^a &= ({}^aR^b)^{-1} \, {}^aR^b \, \col{r}^b  \\
+	({}^aR^b)^{-1} \, \col{r}^a &= \col{r}^b
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 L'inversion d'une matrice de rotation est équivalente à inverser le signe de l'angle $\theta$ utilisé dans le calcul de la matrice, à prendre la transposée de la matrice et, en termes de notation, à inverser les bases:
 %%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-R(\theta)^{-1} &= R(-\theta) \\
-R^{-1} &= R^T \\
-({}^bR^a)^{-1} &= {}^aR^b
+	R(\theta)^{-1} &= R(-\theta) \\
+	R^{-1} &= R^T \\
+	({}^bR^a)^{-1} &= {}^aR^b
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\paragraph{Exercices de lecture}: Vérifiez ces propriétés pour la matrice exemple donnée à l'équation \eqref{eq:rot3theta}.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\paragraph{Changements de base successifs} 
+\paragraph{Changements de base successifs}
 
 Des changements de base successifs $a \rightarrow b \rightarrow c \rightarrow ... \rightarrow z$  peuvent être combinés en une seule matrice de rotation en multipliant les matrices de rotation intermédiaires par la gauche:
 %%%%%%%%%%%%%%%%%%%
@@ -1263,15 +1266,15 @@ Des changements de base successifs $a \rightarrow b \rightarrow c \rightarrow ..
 {}^cR^a &=  {}^cR^b \, {}^bR^a \\
 {}^dR^a &=  {}^dR^c \, {}^cR^b \, {}^bR^a \\
 & \vdots \\
-{}^zR^a &=  {}^zR^y \, {}^yR^x \, \hdots \, {}^cR^b \, {}^bR^a 
+{}^zR^a &=  {}^zR^y \, {}^yR^x \, \hdots \, {}^cR^b \, {}^bR^a
 \end{align}
 %%%%%%%%%%%%%%%%%%%
-Notez que selon la notation utilisée dans ces notes, \textbf{les lettres des bases intermédiaires doivent être côte-à-côte dans les équations}, et la matrice de rotation totale conserve la première et la dernière base de la séquence dans le même ordre. Cette propriété découle des définitions, en combinant deux changements de base intermédiaires, une matrice totale peut être obtenue: 
+Notez que selon la notation utilisée dans ces notes, \textbf{les lettres des bases intermédiaires doivent être côte à côte dans les équations}, et la matrice de rotation totale conserve la première et la dernière base de la séquence dans le même ordre. Cette propriété découle des définitions, en combinant deux changements de base intermédiaires, une matrice totale peut être obtenue:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left. \begin{array}{c}
-\col{r}^b = {}^bR^a \col{r}^a \\  \col{r}^c = {}^cR^b \col{r}^b \\ \col{r}^c = {}^cR^a \col{r}^a 
-\end{array} \right\} \quad \Rightarrow \quad \col{r}^c = \underbrace{{}^cR^b \,  {}^bR^a}_{ {}^cR^a } \col{r}^a \quad \Rightarrow \quad {}^cR^a  = {}^cR^b \,  {}^bR^a 
+	\left. \begin{array}{c}
+			   \col{r}^b = {}^bR^a \col{r}^a \\  \col{r}^c = {}^cR^b \col{r}^b \\ \col{r}^c = {}^cR^a \col{r}^a
+	\end{array} \right\} \quad \Rightarrow \quad \col{r}^c = \underbrace{{}^cR^b \,  {}^bR^a}_{ {}^cR^a } \col{r}^a \quad \Rightarrow \quad {}^cR^a  = {}^cR^b \,  {}^bR^a
 \end{align}
 %%%%%%%%%%%%%%%%%%
 
@@ -1281,14 +1284,14 @@ Notez que selon la notation utilisée dans ces notes, \textbf{les lettres des ba
 Le produit des matrices de rotation n'est toutefois pas commutatif, sauf pour des petites rotations infinitésimales. L'ordre de multiplication des matrices est donc important et généralement:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-^cR^b \, ^bR^a \ne {}^bR^a \, ^cR^b
-\end{equation} 
+	^cR^b \, ^bR^a \ne {}^bR^a \, ^cR^b
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%
 Une \textbf{exception à cette règle} est pour les rotations successives selon le même axe de rotation. Par exemple pour deux matrices de rotation élémentaires selon un axe $i$:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-R_i( \theta_1 ) R_i( \theta_2 )  = R_i( \theta_2 ) R_i( \theta_1 ) = R_i( \theta_1 + \theta_2 )
-\end{equation} 
+	R_i( \theta_1 ) R_i( \theta_2 )  = R_i( \theta_2 ) R_i( \theta_1 ) = R_i( \theta_1 + \theta_2 )
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -1296,39 +1299,39 @@ R_i( \theta_1 ) R_i( \theta_2 )  = R_i( \theta_2 ) R_i( \theta_1 ) = R_i( \theta
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Exemple: réorganisation des vecteurs unitaires}
 %
-La figure \ref{fig:r_reorg} illustre deux bases vectorielles qui ont des vecteurs unitaires parallèles mais avec des directions et un ordre différents. Pour calculer la matrice de rotation associée $^bR^a$, la première étape est d'identifier la relation entre les vecteurs unitaires $\hat{a}_i$ et $\hat{b}_i$. 
+La figure \ref{fig:r_reorg} illustre deux bases vectorielles qui ont des vecteurs unitaires parallèles, mais avec des directions et un ordre différents. Pour calculer la matrice de rotation associée $^bR^a$, la première étape est d'identifier la relation entre les vecteurs unitaires $\hat{a}_i$ et $\hat{b}_i$.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Vue 3D]{
-				\includegraphics[width=0.25\textwidth]{r_reorg_3d}
-				\label{fig:r_reorg_3}}
-				%%%%
-				\hspace{20pt}
-				%%%%
-        \subfloat[Vue de face]{
-				\includegraphics[width=0.25\textwidth]{r_reorg_face}
-				\label{fig:r_reorg_face}}
-				%%%%
-				\hspace{20pt}
-				%%%%
-				\subfloat[Vue de dessus]{
-				\includegraphics[width=0.25\textwidth]{r_reorg_top}
-				\label{fig:r_reorg_top}}
-        \caption{Réorganisation des directions des vecteurs unitaires}
-				\label{fig:r_reorg}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Vue 3D]{
+		\includegraphics[width=0.25\textwidth]{r_reorg_3d}
+		\label{fig:r_reorg_3}}
+	%%%%
+	\hspace{20pt}
+	%%%%
+	\subfloat[Vue de face]{
+		\includegraphics[width=0.25\textwidth]{r_reorg_face}
+		\label{fig:r_reorg_face}}
+	%%%%
+	\hspace{20pt}
+	%%%%
+	\subfloat[Vue de dessus]{
+		\includegraphics[width=0.25\textwidth]{r_reorg_top}
+		\label{fig:r_reorg_top}}
+	\caption{Réorganisation des directions des vecteurs unitaires}
+	\label{fig:r_reorg}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-On peut constater que le vecteur unitaire $\hat{a}_1=-\hat{b}_3$, le vecteur unitaire $\hat{a}_2=-\hat{b}_2$ et le vecteur unitaire $\hat{a}_3=-\hat{b}_1$. Avec ces résultats il est possible d'assembler les vecteur-colonnes $\col{a}_i^b$:
+On peut constater que le vecteur unitaire $\hat{a}_1=-\hat{b}_3$, le vecteur unitaire $\hat{a}_2=-\hat{b}_2$ et le vecteur unitaire $\hat{a}_3=-\hat{b}_1$. Avec ces résultats il est possible d'assembler les vecteurs-colonne $\col{a}_i^b$:
 %%
 %%%%%%%%%%%%%
 \begin{align}
-\col{a}_1^b = \left[ \begin{array}{c} 0 \\ 0 \\ -1  \end{array} \right] \quad
-\col{a}_2^b = \left[ \begin{array}{c} 0 \\ -1 \\ 0 \end{array} \right] \quad
-\col{a}_3^b = \left[ \begin{array}{c} -1 \\ 0 \\ 0   \end{array} \right]
+	\col{a}_1^b = \left[ \begin{array}{c} 0 \\ 0 \\ -1  \end{array} \right] \quad
+	\col{a}_2^b = \left[ \begin{array}{c} 0 \\ -1 \\ 0 \end{array} \right] \quad
+	\col{a}_3^b = \left[ \begin{array}{c} -1 \\ 0 \\ 0   \end{array} \right]
 \end{align}
 %%%%%%%%%%%%%
 %%
@@ -1336,14 +1339,14 @@ Il est donc maintenant possible d'assembler la matrice de rotation $^bR^a$ basé
 %%
 %%%%%%%%%%%%
 \begin{align}
-^bR^a =\left[ \begin{array}{c c c}
-	\col{a}_1^b  & \col{a}_2^b & \col{a}_3^b
-\end{array}  \right]
-= \left[ \begin{array}{c c c}
-	0 & 0 & -1 \\
-	0 & -1 & 0 \\
--1 & 0 & 0 
-\end{array}  \right]
+	^bR^a =\left[ \begin{array}{c c c}
+					  \col{a}_1^b  & \col{a}_2^b & \col{a}_3^b
+	\end{array}  \right]
+	= \left[ \begin{array}{c c c}
+				 0 & 0 & -1 \\
+				 0 & -1 & 0 \\
+				 -1 & 0 & 0
+	\end{array}  \right]
 %\label{eq:rot3theta}
 \end{align}
 %%%%%%%%%%%%
@@ -1354,54 +1357,54 @@ Il est donc maintenant possible d'assembler la matrice de rotation $^bR^a$ basé
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Exemple: réorganisation des vecteurs unitaires et rotation selon un axe}
 %
-Un exemple de calcul d'une matrice de rotation $^bR^a$ est donné pour une base $a$ qui subit une révolution de $\theta$ degrés autour de l'axe $\hat{b}_3$ par rapport à une base $b$, mais ici avec des vecteurs unitaires qui sont définis avec des directions différentes, tel qu'illustré à la figure \ref{fig:rot3}, et ce n'est donc pas un cas de rotation élémentaire. Pour construire la matrice de rotation, la première étape est de dessiner les deux bases avec une origine commune, dans une configuration où la rotation $\theta$ est relativement faible (pour simplifier la visualisation). On peut constater que le vecteur unitaire $\hat{a}_1$ est aligné avec l'axe de rotation, donc indépendant de $\theta$ et toujours donné par $\hat{a}_1=-\hat{b}_3$. Ensuite, par inspection, il est possible d'exprimer chaque vecteur unitaire $\hat{a}_i$ comme une combinaison des vecteurs unitaires $\hat{b}_i$, avec des relations trigonométriques simples comme illustrés par les figures \ref{fig:rot3_a1} et \ref{fig:rot3_a2}. 
+Un exemple de calcul d'une matrice de rotation $^bR^a$ est donné pour une base $a$ qui subit une révolution de $\theta$ degrés autour de l'axe $\hat{b}_3$ par rapport à une base $b$, mais ici avec des vecteurs unitaires qui sont définis avec des directions différentes, tel qu'illustré à la figure \ref{fig:rot3}, et ce n'est donc pas un cas de rotation élémentaire. Pour construire la matrice de rotation, la première étape est de dessiner les deux bases avec une origine commune, dans une configuration où la rotation $\theta$ est relativement faible (pour simplifier la visualisation). On peut constater que le vecteur unitaire $\hat{a}_1$ est aligné avec l'axe de rotation, donc indépendant de $\theta$ et toujours donné par $\hat{a}_1=-\hat{b}_3$. Ensuite, par inspection, il est possible d'exprimer chaque vecteur unitaire $\hat{a}_i$ comme une combinaison des vecteurs unitaires $\hat{b}_i$, avec des relations trigonométriques simples comme illustrées par les figures \ref{fig:rot3_a1} et \ref{fig:rot3_a2}.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Base vectorielles $a$ et $b$]{
-				\includegraphics[width=0.25\textwidth]{rot3}
-				\label{fig:rot3}}
-				%%%%
-				\hspace{20pt}
-				%%%%
-        \subfloat[Calcul de $\col{a}_3^b$]{
-				\includegraphics[width=0.25\textwidth]{rot3_a3}
-				\label{fig:rot3_a1}}
-				%%%%
-				\hspace{20pt}
-				%%%%
-				\subfloat[Calcul de $\col{a}_2^b$]{
-				\includegraphics[width=0.25\textwidth]{rot3_a2}
-				\label{fig:rot3_a2}}
-        \caption{Rotation selon l'axe 3 et réorganisation des directions des vecteurs unitaires}
-				\label{fig:rot3_a2}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Bases vectorielles $a$ et $b$]{
+		\includegraphics[width=0.25\textwidth]{rot3}
+		\label{fig:rot3}}
+	%%%%
+	\hspace{20pt}
+	%%%%
+	\subfloat[Calcul de $\col{a}_3^b$]{
+		\includegraphics[width=0.25\textwidth]{rot3_a3}
+		\label{fig:rot3_a1}}
+	%%%%
+	\hspace{20pt}
+	%%%%
+	\subfloat[Calcul de $\col{a}_2^b$]{
+		\includegraphics[width=0.25\textwidth]{rot3_a2}
+		\label{fig:rot3_a2}}
+	\caption{Rotation selon l'axe 3 et réorganisation des directions des vecteurs unitaires}
+	\label{fig:rot3_a2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Avec ces résultats il est possible d'assembler les vecteur-colonnes $\col{a}_i^b$:
+Avec ces résultats il est possible d'assembler les vecteurs-colonne $\col{a}_i^b$:
 %%
 %%%%%%%%%%%%%
 \begin{align}
-\col{a}_1^b = \left[ \begin{array}{c} 0 \\ 0 \\ -1  \end{array} \right] \quad
-\col{a}_2^b = \left[ \begin{array}{c} -s\theta \\ c\theta \\ 0 \end{array} \right] \quad
-\col{a}_3^b = \left[ \begin{array}{c} c\theta \\ s\theta \\ 0   \end{array} \right]
+	\col{a}_1^b = \left[ \begin{array}{c} 0 \\ 0 \\ -1  \end{array} \right] \quad
+	\col{a}_2^b = \left[ \begin{array}{c} -s\theta \\ c\theta \\ 0 \end{array} \right] \quad
+	\col{a}_3^b = \left[ \begin{array}{c} c\theta \\ s\theta \\ 0   \end{array} \right]
 \end{align}
 %%%%%%%%%%%%%
 %%
-Il est donc maintenant possible d'assembler la matrice de rotation $^bR^a$ basé sur l'équation \eqref{eq:matricerotcol}:
+Il est donc maintenant possible d'assembler la matrice de rotation $^bR^a$ basée sur l'équation \eqref{eq:matricerotcol}:
 %%
 %%%%%%%%%%%%
 \begin{align}
-^bR^a =\left[ \begin{array}{c c c}
-	\col{a}_1^b  & \col{a}_2^b & \col{a}_3^b
-\end{array}  \right]
-= \left[ \begin{array}{c c c}
-	0 & -s\theta & c\theta \\
-	0 & c\theta & s\theta \\
--1 & 0 & 0 
-\end{array}  \right]
+	^bR^a =\left[ \begin{array}{c c c}
+					  \col{a}_1^b  & \col{a}_2^b & \col{a}_3^b
+	\end{array}  \right]
+	= \left[ \begin{array}{c c c}
+				 0 & -s\theta & c\theta \\
+				 0 & c\theta & s\theta \\
+				 -1 & 0 & 0
+	\end{array}  \right]
 %\label{eq:rot3theta}
 \end{align}
 %%%%%%%%%%%%
@@ -1411,98 +1414,100 @@ Il est donc maintenant possible d'assembler la matrice de rotation $^bR^a$ basé
 \subsection{Exemple: calcul de la position globale de l'effecteur d'un robot}
 \label{sec:exer-cinematique-base}
 %
-Dans cet exemple, le robot précédemment étudié (Figure \ref{fig:vecposunipro}) est ici analysé à nouveau mais cette fois avec l'aide des bases vectorielles. L'objectif est ici de calculer la position du point $D$ par rapport au point $A$ exprimée dans la base vectorielle $a$. Comme illustré à la figure \ref{fig:vecposbase1}, la première étape est de décrire la position qui doit être calculée en terme de vecteurs de position géométriques:
+
+%% TODO Attention au ref de (Figure \ref{fig:vecposunipro}) car il était invalide %%
+Dans cet exemple, le robot précédemment étudié (Figure \ref{fig:vecposunipro}) est ici analysé à nouveau, mais cette fois avec l'aide des bases vectorielles. L'objectif est ici de calculer la position du point $D$ par rapport au point $A$ exprimé dans la base vectorielle $a$. Comme illustré à la figure \ref{fig:vecposbase1}, la première étape est de décrire la position qui doit être calculée en termes de vecteurs de position géométriques:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{D/A} &= \vec{r}_{D/C} + \vec{r}_{C/B} + \vec{r}_{B/A}
-\end{align} 
+	\vec{r}_{D/A} &= \vec{r}_{D/C} + \vec{r}_{C/B} + \vec{r}_{B/A}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Cette relation vectorielle peut ensuite être convertie en une équation matricielle entre les composantes dans une base $a$ fixe qui correspond aux axes selon lesquels la position doit être exprimée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D/A}^a &= \col{r}_{D/C}^a + \col{r}_{C/B}^a + \col{r}_{B/A}^a
-\label{eq:exaddbase}
-\end{align} 
+	\col{r}_{D/A}^a &= \col{r}_{D/C}^a + \col{r}_{C/B}^a + \col{r}_{B/A}^a
+	\label{eq:exaddbase}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ensuite, comme illustré à la Figure \ref{fig:vecposrot}, les différents vecteurs positions qui représentent chaque joint ont des composantes connues dans des bases vectorielles locales attachées aux différents liens rigides du robot:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{B/A}^b = 
-\left[ \begin{array}{c} 
-l_1 \\ 0 \\ 0
-\end{array} \right] 
-\quad\quad
-\col{r}_{C/B}^c = 
-\left[ \begin{array}{c} 
-0 \\ l_2 \\ 0
-\end{array} \right]
-\quad\quad
-\col{r}_{D/C}^d = 
-\left[ \begin{array}{c} 
-0 \\ l_3 \\ 0
-\end{array} \right] 
-\end{align} 
+	\col{r}_{B/A}^b =
+	\left[ \begin{array}{c}
+			   l_1 \\ 0 \\ 0
+	\end{array} \right]
+	\quad\quad
+	\col{r}_{C/B}^c =
+	\left[ \begin{array}{c}
+			   0 \\ l_2 \\ 0
+	\end{array} \right]
+	\quad\quad
+	\col{r}_{D/C}^d =
+	\left[ \begin{array}{c}
+			   0 \\ l_3 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est à noter que ces vecteur-colonnes qui utilisent les bases locales sont constants et indépendants des angles des joints car les base locales tournent avec les liens rigides. Il est ensuite possible de convertir ces vecteur-colonnes de positions dans la base $a$ par des opérations de changement de base avec les matrices de rotation appropriées:
+Il est à noter que ces vecteurs-colonne qui utilisent les bases locales sont constants et indépendants des angles des joints, car les bases locales tournent avec les liens rigides. Il est ensuite possible de convertir ces vecteurs-colonne de positions dans la base $a$ par des opérations de changement de base avec les matrices de rotation appropriées:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D/C}^a = {}^aR^d \, \col{r}_{D/C}^d 
-\quad \quad
-\col{r}_{C/B}^a = {}^aR^c \, \col{r}_{C/B}^c
-\quad \quad
-\col{r}_{B/A}^a = {}^aR^b \, \col{r}_{B/A}^b
-\end{align} 
+	\col{r}_{D/C}^a = {}^aR^d \, \col{r}_{D/C}^d
+	\quad \quad
+	\col{r}_{C/B}^a = {}^aR^c \, \col{r}_{C/B}^c
+	\quad \quad
+	\col{r}_{B/A}^a = {}^aR^b \, \col{r}_{B/A}^b
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Finalement, en substituant dans l'équation \eqref{eq:exaddbase}, l'équation matricielle nécessaire pour obtenir les composantes du vecteur position $\vec{r}_{D/A}$ exprimé avec la base $a$ est obtenue:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D/A}^a &= {}^aR^d \, \col{r}_{D/C}^d + {}^aR^c \, \col{r}_{C/B}^c + {}^aR^b \, \col{r}_{B/A}^b
-\label{eq:ex333cinematique}
-\end{align} 
+	\col{r}_{D/A}^a &= {}^aR^d \, \col{r}_{D/C}^d + {}^aR^c \, \col{r}_{C/B}^c + {}^aR^b \, \col{r}_{B/A}^b
+	\label{eq:ex333cinematique}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Les matrices de rotation doivent ensuite être calculées pour solutionner cette équation.
+Les matrices de rotation doivent ensuite être calculées pour résoudre cette équation.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Construction géométrique]{
-				\includegraphics[width=0.30\textwidth]{vecposcons}
-				\label{fig:vecposrot1}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-        \subfloat[Bases vectorielles]{
-				\includegraphics[width=0.27\textwidth]{vecposbase}
-				\label{fig:vecposrot2}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-        \subfloat[Angles]{
-				\includegraphics[width=0.27\textwidth]{vecposbaseangle}
-				\label{fig:vecposrot3}}
-        \caption{Utilisation des bases vectorielles pour les vecteurs de position}
-				\label{fig:vecposrot}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Construction géométrique]{
+		\includegraphics[width=0.30\textwidth]{vecposcons}
+		\label{fig:vecposrot1}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Bases vectorielles]{
+		\includegraphics[width=0.27\textwidth]{vecposbase}
+		\label{fig:vecposrot2}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Angles]{
+		\includegraphics[width=0.27\textwidth]{vecposbaseangle}
+		\label{fig:vecposrot3}}
+	\caption{Utilisation des bases vectorielles pour les vecteurs de position}
+	\label{fig:vecposrot}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Grâce à une inspection des mouvements relatifs des bases vectorielles, comme illustrée à la figure \ref{fig:vecposrot2}, les matrices de rotation peuvent être calculées. Puisque le robot est planaire, les bases vectorielles $b$, $c$ et $d$ fixées aux pièces mobiles du robot ont tous une rotation relative autour de l'axe $\hat{a}_3$ par rapport à la base vectorielle fixe $a$, tel qu'illustré à la figure \ref{fig:exer-cinematique-base-rotation}.  
+Grâce à une inspection des mouvements relatifs des bases vectorielles, comme illustrée à la figure \ref{fig:vecposrot2}, les matrices de rotation peuvent être calculées. Puisque le robot est planaire, les bases vectorielles $b$, $c$ et $d$ fixées aux pièces mobiles du robot ont toutes une rotation relative autour de l'axe $\hat{a}_3$ par rapport à la base vectorielle fixe $a$, tel qu'illustré à la figure \ref{fig:exer-cinematique-base-rotation}.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[$^aR^b$]{
-				\includegraphics[width=0.20\textwidth]{baseext1}
-				\label{fig:baseext1}}
-				\hspace{10pt}
-				\subfloat[$^aR^c$]{
-				\includegraphics[width=0.20\textwidth]{baseext2}
-				\label{fig:baseext2}}
-				\hspace{10pt}
-				\subfloat[$^aR^d$]{
-				\includegraphics[width=0.20\textwidth]{baseext3}
-				\label{fig:baseext3}}
-        \caption{Calcul des matrices de rotation pour l'exemple \ref{sec:exer-cinematique-base}}
-				\label{fig:exer-cinematique-base-rotation}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[$^aR^b$]{
+		\includegraphics[width=0.20\textwidth]{baseext1}
+		\label{fig:baseext1}}
+	\hspace{10pt}
+	\subfloat[$^aR^c$]{
+		\includegraphics[width=0.20\textwidth]{baseext2}
+		\label{fig:baseext2}}
+	\hspace{10pt}
+	\subfloat[$^aR^d$]{
+		\includegraphics[width=0.20\textwidth]{baseext3}
+		\label{fig:baseext3}}
+	\caption{Calcul des matrices de rotation pour l'exemple \ref{sec:exer-cinematique-base}}
+	\label{fig:exer-cinematique-base-rotation}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -1511,166 +1516,166 @@ En fonction des angles définis à la figure \ref{fig:vecposrot3}, les matrices 
 \begin{align}
 {}^aR^b =
 \left[ \begin{array}{c c c}
-	c\theta_1 & -s\theta_1 & 0 \\
-	s\theta_1 & c\theta_1 & 0 \\
-	0 & 0 & 1 
+		   c\theta_1 & -s\theta_1 & 0 \\
+		   s\theta_1 & c\theta_1 & 0 \\
+		   0 & 0 & 1
 \end{array}  \right]
 \quad \quad
- {}^aR^c =
+{}^aR^c =
 \left[ \begin{array}{c c c}
-	c\theta_2 & -s\theta_2 & 0 \\
-	s\theta_2 & c\theta_2 & 0 \\
-	0 & 0 & 1 
+		   c\theta_2 & -s\theta_2 & 0 \\
+		   s\theta_2 & c\theta_2 & 0 \\
+		   0 & 0 & 1
 \end{array}  \right]
 \quad \quad
 {}^aR^d =
 \left[ \begin{array}{c c c}
-	c\theta_3 & -s\theta_3 & 0 \\
-	s\theta_3 & c\theta_3 & 0 \\
-	0 & 0 & 1 
+		   c\theta_3 & -s\theta_3 & 0 \\
+		   s\theta_3 & c\theta_3 & 0 \\
+		   0 & 0 & 1
 \end{array}  \right]
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ces résultats peuvent donc être substitués dans l'équation matricielle qui avait été obtenue à l'exemple \ref{sec:exer-cinematique-base}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D/A}^a &= {}^aR^d \, \col{r}_{D/C}^d + {}^aR^c \, \col{r}_{C/B}^c + {}^aR^b \, \col{r}_{B/A}^b
-\label{eq:ex333cinematique-2}
-\end{align} 
+	\col{r}_{D/A}^a &= {}^aR^d \, \col{r}_{D/C}^d + {}^aR^c \, \col{r}_{C/B}^c + {}^aR^b \, \col{r}_{B/A}^b
+	\label{eq:ex333cinematique-2}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 et on obtient l’expression précise qui permet de calculer la position du point $D$ par rapport au point de référence $A$ exprimée dans la base vectorielle $a$ en fonction des variables de distances $l_i$ et d'angles $\theta_i$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D/A}^a &= \left[ \begin{array}{c c c}
-	c\theta_3 & -s\theta_3 & 0 \\
-	s\theta_3 & c\theta_3 & 0 \\
-	0 & 0 & 1 
-\end{array}  \right] \, \left[ \begin{array}{c} 
-0 \\ l_3 \\ 0
-\end{array} \right] + \left[ \begin{array}{c c c}
-	c\theta_2 & -s\theta_2 & 0 \\
-	s\theta_2 & c\theta_2 & 0 \\
-	0 & 0 & 1 
-\end{array}  \right] \, \left[ \begin{array}{c} 
-0 \\ l_2 \\ 0
-\end{array} \right]  + \left[ \begin{array}{c c c}
-	c\theta_1 & -s\theta_1 & 0 \\
-	s\theta_1 & c\theta_1 & 0 \\
-	0 & 0 & 1 
-\end{array}  \right] \, \left[ \begin{array}{c} 
-l_1 \\ 0 \\ 0
-\end{array} \right] \\
-\col{r}_{D/A}^a &= \left[ \begin{array}{c}
--s\theta_3 l_3 - s\theta_2 l_2  + c\theta_1 l_1 \\
-c\theta_3 l_3 + c\theta_2 l_2  + s\theta_1 l_1  \\
-0
-\end{array} \right]
-\label{eq:robot2dpos}
-\end{align} 
+	\col{r}_{D/A}^a &= \left[ \begin{array}{c c c}
+								  c\theta_3 & -s\theta_3 & 0 \\
+								  s\theta_3 & c\theta_3 & 0 \\
+								  0 & 0 & 1
+	\end{array}  \right] \, \left[ \begin{array}{c}
+									   0 \\ l_3 \\ 0
+	\end{array} \right] + \left[ \begin{array}{c c c}
+									 c\theta_2 & -s\theta_2 & 0 \\
+									 s\theta_2 & c\theta_2 & 0 \\
+									 0 & 0 & 1
+	\end{array}  \right] \, \left[ \begin{array}{c}
+									   0 \\ l_2 \\ 0
+	\end{array} \right]  + \left[ \begin{array}{c c c}
+									  c\theta_1 & -s\theta_1 & 0 \\
+									  s\theta_1 & c\theta_1 & 0 \\
+									  0 & 0 & 1
+	\end{array}  \right] \, \left[ \begin{array}{c}
+									   l_1 \\ 0 \\ 0
+	\end{array} \right] \\
+	\col{r}_{D/A}^a &= \left[ \begin{array}{c}
+								  -s\theta_3 l_3 - s\theta_2 l_2  + c\theta_1 l_1 \\
+								  c\theta_3 l_3 + c\theta_2 l_2  + s\theta_1 l_1  \\
+								  0
+	\end{array} \right]
+	\label{eq:robot2dpos}
+\end{align}
 %%%%%%%%%%%%%%%%%
-À noter que ici les angles $\theta_i$ sont tous des angles absolus qui représentent l'orientation des bases $b$, $c$ et $d$ du robot par rapport à la base fixe $a$ directement. Lorsqu'on contrôle un bras robotisé, c'est généralement les angles relatifs entre chacun des joints qui sont les variables mesurées et contrôlées. 
+À noter qu’ici les angles $\theta_i$ sont tous des angles absolus qui représentent l'orientation des bases $b$, $c$ et $d$ du robot par rapport à la base fixe $a$ directement. Lorsqu'on contrôle un bras robotisé, c'est généralement les angles relatifs entre chacun des joints qui sont les variables mesurées et contrôlées.
 
 
 
-\note{Exercice de lecture: }{La hauteur du robot correspond à la deuxième ligne de l'équation \eqref{eq:robot2dpos}, qui est la distance $\vec{r}_{D/A}$ selon le vecteur unitaire $\hat{a}_2$: 
+\note{Exercice de lecture: }{La hauteur du robot correspond à la deuxième ligne de l'équation \eqref{eq:robot2dpos}, qui est la distance $\vec{r}_{D/A}$ selon le vecteur unitaire $\hat{a}_2$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-h = c\theta_3 l_3 + c\theta_2 l_2  + s\theta_1 l_1  
-\end{align} 
+	\begin{align}
+		h = c\theta_3 l_3 + c\theta_2 l_2  + s\theta_1 l_1
+	\end{align}
 %%%%%%%%%%%%%%%%%
-Alternativement, à l'exemple \ref{sec:hauteurrobot}, l'équation suivante avait été obtenue pour la hauteur du robot:
+	Alternativement, à l'exemple \ref{sec:hauteurrobot}, l'équation suivante avait été obtenue pour la hauteur du robot:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-h &= l_1 \cos (\varphi_1) + l_2 \cos (\varphi_2) + l_3 \cos (\varphi_3)
-\end{align} 
+	\begin{align}
+		h &= l_1 \cos (\varphi_1) + l_2 \cos (\varphi_2) + l_3 \cos (\varphi_3)
+	\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Trouvez la correspondance entre les angles $\theta_i$ et $\varphi_i$ et vérifiez que les deux expressions sont équivalentes.}
+	Trouvez la correspondance entre les angles $\theta_i$ et $\varphi_i$ et vérifiez que les deux expressions sont équivalentes.}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Exemple: distance projetée calculée avec les vecteur-colonnes}
+\subsection{Exemple: distance projetée calculée avec les vecteurs-colonne}
 %
-Comme illustré à la figure \ref{fig:exprojcomp}, cet exemple démontre comment calculer la distance projetée $d_n$ d'un vecteur $\vec{r}_{C/A}$ selon un axe décrit par $\hat{n}$, connaissant les vecteur-colonnes de composantes:
+Comme illustré à la figure \ref{fig:exprojcomp}, cet exemple démontre comment calculer la distance projetée $d_n$ d'un vecteur $\vec{r}_{C/A}$ selon un axe décrit par $\hat{n}$, connaissant les vecteurs-colonne de composantes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{C/B}^b = \left[ \begin{array}{c} x \\ y \\ z  \end{array} \right]
-\quad\quad
-\col{r}_{B/A}^a = \left[ \begin{array}{c} X \\ Y \\ Z  \end{array} \right]
-\quad\quad
-\col{n}^b       = \left[ \begin{array}{c} n_x \\ n_y \\ n_z  \end{array} \right]
-\label{eq:disprojexdef}
-\end{align} 
+	\col{r}_{C/B}^b = \left[ \begin{array}{c} x \\ y \\ z  \end{array} \right]
+	\quad\quad
+	\col{r}_{B/A}^a = \left[ \begin{array}{c} X \\ Y \\ Z  \end{array} \right]
+	\quad\quad
+	\col{n}^b       = \left[ \begin{array}{c} n_x \\ n_y \\ n_z  \end{array} \right]
+	\label{eq:disprojexdef}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Premièrement, l'équation vectorielle de vecteurs géométriques de position est développée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{C/A} = \vec{r}_{C/B} + \vec{r}_{B/A}
-\end{align} 
+	\vec{r}_{C/A} = \vec{r}_{C/B} + \vec{r}_{B/A}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 pour ensuite effectuer le produit scalaire pour calculer la distance projetée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-d_n = \vec{r}_{C/A} \bullet \hat{n} = (\vec{r}_{C/B} + \vec{r}_{B/A} ) \bullet \hat{n} 
-\end{align} 
+	d_n = \vec{r}_{C/A} \bullet \hat{n} = (\vec{r}_{C/B} + \vec{r}_{B/A} ) \bullet \hat{n}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Deuxièmement, on choisi la base $b$ pour transformer la relation vectorielle en équation matricielle:
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-d_n &= (\col{r}_{C/B}^b + \col{r}_{B/A}^b )^T \col{n}^b \\
-d_n &= ( \col{r}_{C/B}^b )^T \col{n}^b + ( \col{r}_{B/A}^b )^T \col{n}^b
-\end{align} 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Tous les vecteur-colonnes sont connus sauf le vecteur-colonne $\col{r}_{C/B}^b$, qui doit être substitué par $\col{r}_{C/B}^b = {}^bR^a \, \col{r}_{C/B}^a$ car les composantes de $\vec{r}_{C/B}$ sont connues seulement dans la base $a$. On obtient alors:
+Deuxièmement, on choisit la base $b$ pour transformer la relation vectorielle en équation matricielle:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-d_n &= ( {}^bR^a \, \col{r}_{C/B}^a )^T \col{n}^b + ( \col{r}_{B/A}^b )^T \col{n}^b \\
-d_n &= ( \col{n}^b )^T \, {}^bR^a \, \col{r}_{C/B}^a + ( \col{r}_{B/A}^b )^T \col{n}^b 
-\end{align} 
+	d_n &= (\col{r}_{C/B}^b + \col{r}_{B/A}^b )^T \col{n}^b \\
+	d_n &= ( \col{r}_{C/B}^b )^T \col{n}^b + ( \col{r}_{B/A}^b )^T \col{n}^b
+\end{align}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Tous les vecteurs-colonne sont connus sauf le vecteur-colonne $\col{r}_{C/B}^b$, qui doit être substitué par $\col{r}_{C/B}^b = {}^bR^a \, \col{r}_{C/B}^a$ car les composantes de $\vec{r}_{C/B}$ sont connues seulement dans la base $a$. On obtient alors:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{align}
+	d_n &= ( {}^bR^a \, \col{r}_{C/B}^a )^T \col{n}^b + ( \col{r}_{B/A}^b )^T \col{n}^b \\
+	d_n &= ( \col{n}^b )^T \, {}^bR^a \, \col{r}_{C/B}^a + ( \col{r}_{B/A}^b )^T \col{n}^b
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 et ce qui correspond en termes de composantes à l'équation:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-d_n &= \left[ \begin{array}{c c c}
-	n_1^b & n_2^b & n_3^b  
-\end{array}  \right]
-\left[ \begin{array}{c c c}
-	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\ 
+	d_n &= \left[ \begin{array}{c c c}
+					  n_1^b & n_2^b & n_3^b
+	\end{array}  \right]
+	\left[ \begin{array}{c c c}
+	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\
 	{}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
 	{}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
-\end{array}  \right]
- \left[ \begin{array}{c} r_{C/B,1}^a \\ r_{C/B,2}^a \\ r_{C/B,3}^a  \end{array} \right]
-+
-\left[ \begin{array}{c c c}
-	r_{B/A,1}^b & r_{B/A,2}^b & r_{B/A,3}^b  
-\end{array}  \right]
- \left[ \begin{array}{c} n_1^b \\ n_2^b \\ n_3^b  \end{array} \right]
-\end{align} 
+	\end{array}  \right]
+	\left[ \begin{array}{c} r_{C/B,1}^a \\ r_{C/B,2}^a \\ r_{C/B,3}^a  \end{array} \right]
+	+
+	\left[ \begin{array}{c c c}
+			   r_{B/A,1}^b & r_{B/A,2}^b & r_{B/A,3}^b
+	\end{array}  \right]
+	\left[ \begin{array}{c} n_1^b \\ n_2^b \\ n_3^b  \end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 si on substitue par les composantes connues définies à l'équation \eqref{eq:disprojexdef}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-d_n &=
-\left[ \begin{array}{c c c}
-	n_x & n_y & n_z  
-\end{array}  \right]
-\left[ \begin{array}{c c c}
-	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\ 
+	d_n &=
+	\left[ \begin{array}{c c c}
+			   n_x & n_y & n_z
+	\end{array}  \right]
+	\left[ \begin{array}{c c c}
+	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\
 	{}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
 	{}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
-\end{array}  \right]
- \left[ \begin{array}{c} x \\ y \\ z  \end{array} \right]
-+
-\left[ \begin{array}{c c c}
-	X & Y & Z  
-\end{array}  \right]
- \left[ \begin{array}{c} n_x \\ n_y \\ n_z  \end{array} \right]
-\end{align} 
+	\end{array}  \right]
+	\left[ \begin{array}{c} x \\ y \\ z  \end{array} \right]
+	+
+	\left[ \begin{array}{c c c}
+			   X & Y & Z
+	\end{array}  \right]
+	\left[ \begin{array}{c} n_x \\ n_y \\ n_z  \end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 C'est donc cette équation qui devrait être programmée pour faire ce calcul numériquement sur un ordinateur.
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.50\textwidth]{exprojcomp.png}
+	\includegraphics[width=0.50\textwidth]{exprojcomp.png}
 	\caption{Exemple de calcul d'une distance projetée}
 	\label{fig:exprojcomp}
 \end{figure}
@@ -1682,11 +1687,11 @@ C'est donc cette équation qui devrait être programmée pour faire ce calcul nu
 \section{Coordonnées dans un repère et transformations homogènes}
 \label{sec:repere}
 
-En robotique, il est souvent utile de placer un point de référence ainsi qu'une base vectorielle sur chaque corps rigide du robot. Bien qu'on peut travailler avec des points de référence et des bases vectorielles de façon indépendante, il est souvent pratique de les jumeler en paires puisqu'il faut ces deux types de références pour exprimer des coordonnées. \textbf{La combinaison d'un point d'origine et d'une base vectorielle est appelée repère dans ces notes}, le terme \textit{Frame} est généralement utilisé en anglais. Un repère $A$ dans ces notes fait donc référence à la fois à un point d'origine $A_o$ et à une base vectorielle $a$ qui consiste des trois vecteurs unitaires $\{ \hat{a}_1, \hat{a}_2, \hat{a}_3 \}$. Autrement dit, on appellera \textit{repère} $A$ le repère formé par l'ensemble $\{ A_o, \hat{a}_1, \hat{a}_2, \hat{a}_3 \}$. 
+En robotique, il est souvent utile de placer un point de référence ainsi qu'une base vectorielle sur chaque corps rigide du robot. Bien qu'on peut travailler avec des points de référence et des bases vectorielles de façon indépendante, il est souvent pratique de les jumeler en paires puisqu'il faut ces deux types de références pour exprimer des coordonnées. \textbf{La combinaison d'un point d'origine et d'une base vectorielle est appelée repère dans ces notes}, le terme \textit{Frame} est généralement utilisé en anglais. Un repère $A$ dans ces notes fait donc référence à la fois à un point d'origine $A_o$ et à une base vectorielle $a$ qui consiste des trois vecteurs unitaires $\{ \hat{a}_1, \hat{a}_2, \hat{a}_3 \}$. Autrement dit, on appellera \textit{repère} $A$ le repère formé par l'ensemble $\{ A_o, \hat{a}_1, \hat{a}_2, \hat{a}_3 \}$.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
 	\centering
-		\includegraphics[width=0.45\textwidth]{repere}
+	\includegraphics[width=0.45\textwidth]{repere}
 	\caption{Système de coordonnées cartésiennes $(x,y,z)$ basé sur le repère $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$}
 	\label{fig:repere}
 \end{figure}
@@ -1695,13 +1700,13 @@ En robotique, il est souvent utile de placer un point de référence ainsi qu'un
 Comme illustré à la figure \ref{fig:repere}, les coordonnées cartésiennes ($x$, $y$, $z$) d'un point $P$ correspondent directement aux composantes du vecteur position avec comme origine l'intersection des axes du système de coordonnées (le point $A_o$) et exprimé dans une base vectorielle $a$ alignée sur les axes du système de coordonnées:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{P/A_o}^a = \left[ \begin{array}{c} 
-x \\ y \\ z
-\end{array} \right]   \quad \Leftrightarrow \quad
-\vec{r}_{P/A_o} = x \, \hat{a}_{1} + y \, \hat{a}_{2} + z \, \hat{a}_{3}
-\end{align} 
+	\col{r}_{P/A_o}^a = \left[ \begin{array}{c}
+								   x \\ y \\ z
+	\end{array} \right]   \quad \Leftrightarrow \quad
+	\vec{r}_{P/A_o} = x \, \hat{a}_{1} + y \, \hat{a}_{2} + z \, \hat{a}_{3}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Un système de coordonnées est toujours implicitement attaché à un repère, même s'il n'est pas explicitement défini. L'ensemble de l'origine des axes et des vecteurs unitaires alignés sur ces axes forment un repère. 
+Un système de coordonnées est toujours implicitement attaché à un repère, même s'il n'est pas explicitement défini. L'ensemble de l'origine des axes et des vecteurs unitaires alignés sur ces axes forment un repère.
 
 %Pour modéliser un bras robotique, il est utile de définir un repère sur chaque corps rigides, car les coordonnées des différents points d’intérêts sont constantes quand elles sont exprimées dans des repères locaux.
 
@@ -1710,83 +1715,83 @@ Un système de coordonnées est toujours implicitement attaché à un repère, m
 \subsection{Changement de repère}
 \label{sec:repchan}
 
-Un changement de repère implique deux opérations: \textbf{1)} un changement de l'origine utilisée pour les vecteurs de position et \textbf{2)} un changement de la base vectorielle utilisée pour exprimer les composantes de ce vecteur position. 
+Un changement de repère implique deux opérations: \textbf{1)} un changement de l'origine utilisée pour les vecteurs de position et \textbf{2)} un changement de la base vectorielle utilisée pour exprimer les composantes de ce vecteur position.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Deux systèmes de coordonnées]{
-				\includegraphics[width=0.40\textwidth]{repchaA}
-				\label{fig:repchaA}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-				\subfloat[Construction géométrique]{
-				\includegraphics[width=0.40\textwidth]{repchaB}
-				\label{fig:repchaB}}
-        \caption{Changement du repère $\{B_o,\hat{b}_1,\hat{b}_2,\hat{b}_3\}$ vers  le repère $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$}
-				\label{fig:repcha}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Deux systèmes de coordonnées]{
+		\includegraphics[width=0.40\textwidth]{repchaA}
+		\label{fig:repchaA}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Construction géométrique]{
+		\includegraphics[width=0.40\textwidth]{repchaB}
+		\label{fig:repchaB}}
+	\caption{Changement du repère $\{B_o,\hat{b}_1,\hat{b}_2,\hat{b}_3\}$ vers  le repère $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$}
+	\label{fig:repcha}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Comme illustré à la figure \ref{fig:repcha} pour une transformation d'un repère B vers un repère A, les coordonnées cartésiennes d'un point $C$ correspondent au vecteur-colonne $\col{r}_{C/B_o}^b$ dans le repère B et au vecteur-colonne $\col{r}_{C/A_o}^a$ dans le repère A:
+Comme illustré à la figure \ref{fig:repcha} pour une transformation d'un repère $B$ vers un repère $A$, les coordonnées cartésiennes d'un point $C$ correspondent au vecteur-colonne $\col{r}_{C/B_o}^b$ dans le repère $B$ et au vecteur-colonne $\col{r}_{C/A_o}^a$ dans le repère $A$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{C/B_o}^b = 
-\left[ \begin{array}{c} 
-x \\ y \\ z
-\end{array} \right]  \quad \quad
-\col{r}_{C/A_o}^a = 
-\left[ \begin{array}{c} 
-X \\ Y \\ Z
-\end{array} \right] 
-\end{align} 
+	\col{r}_{C/B_o}^b =
+	\left[ \begin{array}{c}
+			   x \\ y \\ z
+	\end{array} \right]  \quad \quad
+	\col{r}_{C/A_o}^a =
+	\left[ \begin{array}{c}
+			   X \\ Y \\ Z
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Pour effectuer la transformation des coordonnées ($x$, $y$, $z$) vers les coordonnées ($X$, $Y$, $Z$), la première étape est de construire la relation vectorielle qui relie les trois points:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{C/A_o}   &= \vec{r}_{C/B_o}  + \vec{r}_{B_o/A_o} 
-\end{align} 
+	\vec{r}_{C/A_o}   &= \vec{r}_{C/B_o}  + \vec{r}_{B_o/A_o}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 et ensuite il suffit de tout exprimer ces vecteurs dans la base $a$ pour effectuer l'addition:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{C/A_o}^a &=         \col{r}_{C/B_o}^a  + \col{r}_{B_o/A_o}^a  \\
-\col{r}_{C/A_o}^a &= {}^aR^b \col{r}_{C/B_o}^b  + \col{r}_{B_o/A_o}^a 
-\label{eq:reperechang}
-\end{align} 
+	\col{r}_{C/A_o}^a &=         \col{r}_{C/B_o}^a  + \col{r}_{B_o/A_o}^a  \\
+	\col{r}_{C/A_o}^a &= {}^aR^b \col{r}_{C/B_o}^b  + \col{r}_{B_o/A_o}^a
+	\label{eq:reperechang}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-ce qui correspond en termes de coordonnées à: 
+ce qui correspond en termes de coordonnées à:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-X \\ Y \\ Z
-\end{array} \right]  &=  
- {}^aR^b
-\left[ \begin{array}{c} 
-x \\ y \\ z
-\end{array} \right] + \col{r}_{B_o/A_o}^a 
-\end{align} 
+	\left[ \begin{array}{c}
+			   X \\ Y \\ Z
+	\end{array} \right]  &=
+	{}^aR^b
+	\left[ \begin{array}{c}
+			   x \\ y \\ z
+	\end{array} \right] + \col{r}_{B_o/A_o}^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Un changement de base est nécessaire puisque que le vecteur $\vec{r}_{C/B_o}$ est connu dans la base vectorielle $b$. Donc les informations nécessaires pour effectuer la transformation sont: \textbf{1)} les composantes $\col{r}_{B_o/A_o}^a$ du vecteur position qui relie les origines $A_o$ et $B_o$ et 2\textbf{)} la matrice de rotation $^aR^b$ qui donne l'orientation relative des bases vectorielles $a$ et $b$. 
+Un changement de base est nécessaire puisque le vecteur $\vec{r}_{C/B_o}$ est connu dans la base vectorielle $b$. Donc les informations nécessaires pour effectuer la transformation sont: \textbf{1)} les composantes $\col{r}_{B_o/A_o}^a$ du vecteur position qui relie les origines $A_o$ et $B_o$ et 2\textbf{)} la matrice de rotation $^aR^b$ qui donne l'orientation relative des bases vectorielles $a$ et $b$.
 
 L'\textbf{opération inverse} s'obtient à partir de l'équation \eqref{eq:reperechang}, d'abord on soustrait le vecteur translation $\col{r}_{B_o/A_o}^a$ et on multiplie par la gauche l'inverse de la matrice de rotation pour obtenir:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{C/B_o}^b &= {}^bR^a \; \col{r}_{C/A_o}^a - {}^bR^a \; \col{r}_{B_o/A_o}^a 
-\label{eq:reperechanginv}
-\end{align} 
+	\col{r}_{C/B_o}^b &= {}^bR^a \; \col{r}_{C/A_o}^a - {}^bR^a \; \col{r}_{B_o/A_o}^a
+	\label{eq:reperechanginv}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-ce qui correspond en termes des coordonnées à: 
+ce qui correspond en termes des coordonnées à:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-x \\ y \\ z
-\end{array} \right]  &=  
- {}^bR^a
-\left[ \begin{array}{c} 
-X \\ Y \\ Z
-\end{array} \right] + {}^bR^a \; \col{r}_{B_o/A_o}^a 
-\end{align} 
+	\left[ \begin{array}{c}
+			   x \\ y \\ z
+	\end{array} \right]  &=
+	{}^bR^a
+	\left[ \begin{array}{c}
+			   X \\ Y \\ Z
+	\end{array} \right] + {}^bR^a \; \col{r}_{B_o/A_o}^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -1796,87 +1801,87 @@ X \\ Y \\ Z
 \subsection{Coordonnées et transformations homogènes}
 \label{sec:coordhomo}
 
-Dans les logiciels de cinématique et de graphique, les opérations de changement de repère peuvent être très fréquentes. Il existe une méthode standard pour combiner l'opération d'addition vectorielle et la multiplication avec la matrice de rotation en une seule opération équivalente qui consiste à multiplier une matrice de transformation $4\times4$ notée $^AT^B$, avec un vecteur-colonne $4\times1$ de \textit{coordonnées homogènes}. Les coordonnées homogènes sont tout simplement les coordonnées cartésiennes pour les trois premières composantes et la valeur 1 pour la quatrième composante. 
+Dans les logiciels de cinématique et de graphique, les opérations de changement de repère peuvent être très fréquentes. Il existe une méthode standard pour combiner l'opération d'addition vectorielle et la multiplication avec la matrice de rotation en une seule opération équivalente qui consiste à multiplier une matrice de transformation $4\times4$ notée $^AT^B$, avec un vecteur-colonne $4\times1$ de \textit{coordonnées homogènes}. Les coordonnées homogènes sont tout simplement les coordonnées cartésiennes pour les trois premières composantes et la valeur 1 pour la quatrième composante.
 
 Le changement de repère décrit à la section \ref{sec:repchan} correspond alors à l'opération suivante:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-\col{r}_{C/A_o}^a \\ 1
-\end{array} \right] 
-= 
-\underbrace{
-\left[ \begin{array}{c c } 
-^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
-}_{^AT^B}
-\left[ \begin{array}{c} 
-\col{r}_{C/B_o}^b \\ 1
-\end{array} \right] 
-\label{eq:homo1}
-\end{align} 
+	\left[ \begin{array}{c}
+			   \col{r}_{C/A_o}^a \\ 1
+	\end{array} \right]
+	=
+	\underbrace{
+		\left[ \begin{array}{c c }
+				   ^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+		\end{array} \right]
+	}_{^AT^B}
+	\left[ \begin{array}{c}
+			   \col{r}_{C/B_o}^b \\ 1
+	\end{array} \right]
+	\label{eq:homo1}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ce qui correspond en termes de coordonnées à:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-X \\ Y \\ Z \\ 1
-\end{array} \right] 
-= 
-\underbrace{
-\left[ \begin{array}{c c } 
-^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
-}_{^AT^B}
-\left[ \begin{array}{c} 
-x \\ y \\ z \\ 1
-\end{array} \right] 
-\label{eq:homo2}
-\end{align} 
+	\left[ \begin{array}{c}
+			   X \\ Y \\ Z \\ 1
+	\end{array} \right]
+	=
+	\underbrace{
+		\left[ \begin{array}{c c }
+				   ^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+		\end{array} \right]
+	}_{^AT^B}
+	\left[ \begin{array}{c}
+			   x \\ y \\ z \\ 1
+	\end{array} \right]
+	\label{eq:homo2}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Les trois premières rangés des équations matricielles \eqref{eq:homo1} et \eqref{eq:homo2} correspondent exactement à l'équation \eqref{eq:reperechang}, et la dernière ligne correspond simplement à une équation 1=1. Les transformations homogènes c'est donc rien de fondamentalement nouveau, mais une astuce bien utile dans un contexte de programmation pour grouper deux opérations en une seule. %D'autre types d'opérations peuvent aussi être exprimés sous la forme d'une multiplication d'une matrice de transformation 4x4 sur un vecteur-colonne 4x1 de coordonnées homogènes. 
+Les trois premières rangées des équations matricielles \eqref{eq:homo1} et \eqref{eq:homo2} correspondent exactement à l'équation \eqref{eq:reperechang}, et la dernière ligne correspond simplement à une équation $1=1$. Les transformations homogènes ce n’est donc rien de fondamentalement nouveau, mais une astuce bien utile dans un contexte de programmation pour grouper deux opérations en une seule. %D'autre types d'opérations peuvent aussi être exprimés sous la forme d'une multiplication d'une matrice de transformation 4x4 sur un vecteur-colonne 4x1 de coordonnées homogènes.
 
-Si on substitut les définitions, la matrice de transformation peut être définie directement en termes de vecteurs de vecteurs unitaires et du vecteur géométrique qui définie la translation d'une origine à l'autre:
+Si l'on substitut les définitions, la matrice de transformation peut être définie directement en termes de vecteurs de vecteurs unitaires et du vecteur géométrique qui définit la translation d'une origine à l'autre:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^AT^B &= 
-\left[ \begin{array}{c c } 
-^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
+{}^AT^B &=
+\left[ \begin{array}{c c }
+		   ^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+\end{array} \right]
 =
-\left[ \begin{array}{c c c c} 
-\hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 & \hat{a}_1 \bullet \vec{r}_{B_o/A_o} \\
-\hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_2 \bullet \vec{r}_{B_o/A_o}\\
-\hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 & \hat{a}_3 \bullet \vec{r}_{B_o/A_o} \\
-0 & 0 & 0 & 1
-\end{array} \right] 
+\left[ \begin{array}{c c c c}
+		   \hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 & \hat{a}_1 \bullet \vec{r}_{B_o/A_o} \\
+		   \hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_2 \bullet \vec{r}_{B_o/A_o}\\
+		   \hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 & \hat{a}_3 \bullet \vec{r}_{B_o/A_o} \\
+		   0 & 0 & 0 & 1
+\end{array} \right]
 \label{eq:transformationdef}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 L'\textbf{opération inverse} de changement de repère avec les coordonnées homogènes est formée par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-\col{r}_{C/B_o}^b \\ 1
-\end{array} \right] 
-= 
-\underbrace{
-\left[ \begin{array}{c c } 
-^bR^a & - ^bR^a \, \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
-}_{ ({}^AT^B)^{-1} }
-\left[ \begin{array}{c} 
-\col{r}_{C/A_o}^a \\ 1
-\end{array} \right] 
-\end{align} 
+	\left[ \begin{array}{c}
+			   \col{r}_{C/B_o}^b \\ 1
+	\end{array} \right]
+	=
+	\underbrace{
+		\left[ \begin{array}{c c }
+				   ^bR^a & - ^bR^a \, \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+		\end{array} \right]
+	}_{ ({}^AT^B)^{-1} }
+	\left[ \begin{array}{c}
+			   \col{r}_{C/A_o}^a \\ 1
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Comme pour les matrices de rotation l'inverse de la matrice de transformation correspond à inverser les repères avec la notation utilisée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-({}^AT^B)^{-1}= {}^BT^A
-\end{align} 
+	({}^AT^B)^{-1}= {}^BT^A
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Dernièrement, les \textbf{changements de repères successifs} $A \rightarrow B \rightarrow C \rightarrow ... \rightarrow Z$  peuvent être combinés en une seule matrice de transformation en multipliant les matrices de transformation intermédiaires par la gauche:
@@ -1885,10 +1890,10 @@ Dernièrement, les \textbf{changements de repères successifs} $A \rightarrow B 
 {}^CT^A &=  {}^CT^B \, {}^BT^A \\
 {}^DT^A &=  {}^DT^C \, {}^CT^B \, {}^BT^A \\
 & \vdots \nonumber \\
-{}^ZT^A &= {}^ZT^Y \, {}^YT^X \, ... \, {}^CT^B \,  {}^BT^A 
-\end{align} 
+{}^ZT^A &= {}^ZT^Y \, {}^YT^X \, ... \, {}^CT^B \,  {}^BT^A
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Avec la notation utilisée dans ces notes, \textbf{les lettres des repères intermédiaires doivent être côte-à-côte dans les équations}, et la matrice de transformation totale conserve le premier et le dernier repère de la séquence dans le même ordre. 
+Avec la notation utilisée dans ces notes, \textbf{les lettres des repères intermédiaires doivent être côte à côte dans les équations}, et la matrice de transformation totale conserve le premier et le dernier repère de la séquence dans le même ordre.
 
 
 
@@ -1898,13 +1903,13 @@ Avec la notation utilisée dans ces notes, \textbf{les lettres des repères inte
 \section{Représentation de la pose d'un corps rigide}
 \label{sec:corps}
 
-De façon générale, six variables sont nécessaires pour définir la positon d'un corps rigide par rapport à un repère, trois pour décrire la translation et trois pour décrire l'orientation. Pour un corps rigide sans aucune contrainte, par exemple un avion en vol, le nombre de DDL est donc de six. 
+De façon générale, six variables sont nécessaires pour définir la position d'un corps rigide par rapport à un repère, trois pour décrire la translation et trois pour décrire l'orientation. Pour un corps rigide sans aucune contrainte, par exemple un avion en vol, le nombre de DDL est donc de six.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.95\textwidth]{rigid.png}
-	\caption{Représentation de la pose d'un corp rigide}
+	\includegraphics[width=0.95\textwidth]{rigid.png}
+	\caption{Représentation de la pose d'un corps rigide}
 	\label{fig:rigid}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1914,40 +1919,42 @@ De façon générale, six variables sont nécessaires pour définir la positon d
 Les trois DDL de translation peuvent être représentés par un vecteur position qui a comme origine un point fixe $A$ et comme cible un point arbitraire $B$ sur le corps rigide. Ce vecteur position $\vec{r}_{B/A}$, est typiquement représenté avec trois coordonnées cartésiennes ($x$, $y$, $z$) qui utilisent une base vectorielle fixe $a$:
 %%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\col{r}_{B/A}^a = \left[ \begin{array}{c} x \\  y \\ z  \end{array} \right]
-\quad \Leftrightarrow  \quad 
-\vec{r}_{B/A} = x \, \vec{a}_1 + y \, \vec{a}_2 + z \, \vec{a}_3
-\end{equation} 
+	\col{r}_{B/A}^a = \left[ \begin{array}{c} x \\  y \\ z  \end{array} \right]
+	\quad \Leftrightarrow  \quad
+	\vec{r}_{B/A} = x \, \vec{a}_1 + y \, \vec{a}_2 + z \, \vec{a}_3
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%
 
 \subsubsection{Orientation}
 %
-Ensuite, même avec un point défini dans l'espace par un vecteur translation, un corps rigide a plusieurs orientations possibles. Pour définir l'orientation, une autre base vectorielle $b$ attachée au corps rigide doit être utilisée. L'orientation d'un corps rigide est alors représentée par la direction des vecteurs unitaires $\hat{b}_i$, qui peuvent être représentés par leurs composantes dans la base fixe $a$. Les trois vecteur-colonnes $\col{b}_i^a$ de trois composantes peuvent être regroupés sous la forme d'une matrice de rotation, comme il a été discuté à la section \ref{sec:changematrice} dans le contexte des changements de base:
+Ensuite, même avec un point défini dans l'espace par un vecteur translation, un corps rigide a plusieurs orientations possibles. Pour définir l'orientation, une autre base vectorielle $b$ attachée au corps rigide doit être utilisée. L'orientation d'un corps rigide est alors représentée par la direction des vecteurs unitaires $\hat{b}_i$, qui peuvent être représentés par leurs composantes dans la base fixe $a$. Les trois vecteurs-colonne $\col{b}_i^a$ de trois composantes peuvent être regroupés sous la forme d'une matrice de rotation, comme il a été discuté à la section \ref{sec:changematrice} dans le contexte des changements de base:
 %%%%%%%%%%%%%%%%%%%
 \begin{equation}
-^aR^b = \left[ \begin{array}{ c c c } \col{b}_1^a &  \col{b}_2^a & \col{b}_3^a  \end{array} \right] = R(\phi,\theta,\psi)
-\end{equation} 
+	^aR^b = \left[ \begin{array}{ c c c } \col{b}_1^a &  \col{b}_2^a & \col{b}_3^a  \end{array} \right] = R(\phi,\theta,\psi)
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%
 
-Malgré les neuf composants d'une matrice de rotation, puisque les vecteurs $\hat{b}_i$ sont unitaires et orthogonaux seulement trois variables suffisent pour la définir; il y a un total de neuf composantes et six équations de contraintes, voir les équations \eqref{eq:unit} et \eqref{eq:ortho}. Il est donc possible de paramétrer la matrice $^aR^b$ avec trois variables, par exemple trois angles $\phi$, $\theta$ et $\psi$, sans limiter les orientations possibles. On appelle trois angles qui paramétrisent une matrice de rotation des angles de Euler, diverses conventions de paramétrisation sont possibles et c'est le sujet de la section \ref{sec:angeuler}. Selon la situation, d'autres représentations alternatives aux matrices de rotation et aux angles de Euler peuvent aussi être utiles, chaque représentation a ses avantages et inconvénients. La section \ref{sec:rotaxe} présente la représentation axe-angle et la section \ref{sec:quaternions} présente les quaternions. 
+Malgré les neuf composants d'une matrice de rotation, puisque les vecteurs $\hat{b}_i$ sont unitaires et orthogonaux seulement trois variables suffisent pour la définir; il y a un total de neuf composantes et six équations de contraintes, voir les équations \eqref{eq:unit} et \eqref{eq:ortho}. Il est donc possible de paramétrer la matrice $^aR^b$ avec trois variables, par exemple trois angles $\phi$, $\theta$ et $\psi$, sans limiter les orientations possibles. On appelle ces trois angles qui paramètrent une matrice de rotation des angles de Euler, diverses conventions de paramétrisation sont possibles et c'est le sujet de la section \ref{sec:angeuler}. Selon la situation, d'autres représentations alternatives aux matrices de rotation et aux angles de Euler peuvent aussi être utiles, chaque représentation a ses avantages et inconvénients. La section \ref{sec:rotaxe} présente la représentation axe-angle et la section \ref{sec:quaternions} présente les quaternions.
 
 %\paragraph{Note:} L'orientation d'un corps rigide est aussi parfois appelée \textit{attitude}, typiquement dans le domaine de l'aérospatiale, ou bien \textit{position angulaire}.
 
 \subsubsection{Pose}
 
-La pose d'un corps rigide, c'est la combinaison de sa translation et de son orientation. Il est possible d'utiliser des représentations indépendantes pour la translation et l'orientation, mais alternativement on peut regrouper une matrice de rotation (pour représenter l'orientation) et un vecteur-colonne (pour représenter la translation)  sous la forme d'une matrice de transformation 4x4, qui relie le repère $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$ formé par le point fixe et la base fixe, au repère $\{B_o,\hat{b}_1,\hat{b}_2,\hat{b}_3\}$ formé par le point mobile et la base mobile attachés au corps rigide. Cette matrice peut alors être paramétrée par 6 variables qui représent tous les DDL du corps rigide:
+La pose d'un corps rigide, c'est la combinaison de sa translation et de son orientation. Il est possible d'utiliser des représentations indépendantes pour la translation et l'orientation, mais alternativement on peut regrouper une matrice de rotation (pour représenter l'orientation) et un vecteur-colonne (pour représenter la translation)  sous la forme d'une matrice de transformation 4x4,
+%% TODO: 4x4 est écrit avec une notation différente ailleurs %%
+qui relie le repère $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$ formé par le point fixe et la base fixe, au repère $\{B_o,\hat{b}_1,\hat{b}_2,\hat{b}_3\}$ formé par le point mobile et la base mobile attachés au corps rigide. Cette matrice peut alors être paramétrée par 6 variables qui représentent tous les DDL du corps rigide:
 %%%%%%%%%%%%%%%%%%%
 \begin{equation}
-^{A}T^B(x,y,z,\phi,\theta,\psi) = \left[ \begin{array}{c c}
-	^aR^b  & \col{r}^a_{B/A} \\ 0 \; 0 \; 0 & 1
-\end{array}  \right] = 
-\left[ \begin{array}{c c}
-\left[	\begin{array}{c} \\  R(\phi,\theta,\psi) \\ \\ \end{array} \right] & \left[ \begin{array}{c} x \\ y \\ z \end{array} \right] \\  \begin{array}{ccc} 0 & 0 & 0 \end{array}   &  1 
-\end{array}  \right] 
-\end{equation} 
+	^{A}T^B(x,y,z,\phi,\theta,\psi) = \left[ \begin{array}{c c}
+												 ^aR^b  & \col{r}^a_{B/A} \\ 0 \; 0 \; 0 & 1
+	\end{array}  \right] =
+	\left[ \begin{array}{c c}
+			   \left[ \begin{array}{c} \\  R(\phi,\theta,\psi) \\ \\ \end{array} \right] & \left[ \begin{array}{c} x \\ y \\ z \end{array} \right] \\  \begin{array}{ccc} 0 & 0 & 0 \end{array}   &  1
+	\end{array}  \right]
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%
 
-La matrice de transformation $^{A}T^B$ a donc deux fonctions: \textbf{1)} elle peut être utilisée pour effectuer des changements de repères comme vue à la section \ref{sec:coordhomo}, et \textbf{2)} elle peut aussi être utilisée pour représenter la pose d'un repère $B$ (donc aussi la pose du corps rigide sur lequel il est attaché) relativement à un repère $A$.  
+La matrice de transformation $^{A}T^B$ a donc deux fonctions: \textbf{1)} elle peut être utilisée pour effectuer des changements de repères comme vue à la section \ref{sec:coordhomo}, et \textbf{2)} elle peut aussi être utilisée pour représenter la pose d'un repère $B$ (donc aussi la pose du corps rigide sur lequel il est attaché) relativement à un repère $A$.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1958,57 +1965,57 @@ Une matrice de rotation arbitraire peut être paramétrée avec trois variables.
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^aR^d(\phi,\theta,\psi) &= R_3(\phi) \, R_1(\theta) \, R_3(\psi) \\
-{}^aR^d(\phi,\theta,\psi) &= 
+{}^aR^d(\phi,\theta,\psi) &=
 \left[ \begin{array}{c c c}
-	c\phi & -s\phi & 0 \\
-	s\phi & c\phi & 0 \\
-	0 & 0 & 1 
+		   c\phi & -s\phi & 0 \\
+		   s\phi & c\phi & 0 \\
+		   0 & 0 & 1
 \end{array}  \right]
 \left[ \begin{array}{c c c}
-	1 & 0 & 0 \\
-	0 & c\theta  & -s\theta \\
-	0 & s\theta & c\theta 
+		   1 & 0 & 0 \\
+		   0 & c\theta  & -s\theta \\
+		   0 & s\theta & c\theta
 \end{array}  \right]
 \left[ \begin{array}{c c c}
-	c\psi & -s\psi & 0 \\
-	s\psi & c\psi & 0 \\
-	0 & 0 & 1 
+		   c\psi & -s\psi & 0 \\
+		   s\psi & c\psi & 0 \\
+		   0 & 0 & 1
 \end{array}  \right] \\
-{}^aR^d(\phi,\theta,\psi) &= 
+{}^aR^d(\phi,\theta,\psi) &=
 \left[ \begin{array}{c c c}
-	 + c\phi \, c\psi - s\phi\,c\theta\,c\psi  & - c\phi \, s\psi - s\phi \, c\theta c\psi  & + s\phi \, s\theta  \\
-	 + s\phi \, c\psi + c\phi\,c\theta\,c\psi  & - s\phi \, s\psi + c\phi \, c\theta c\psi  & - c\phi \, s\theta  \\
-	 + s\theta \, s\psi                        & + s\theta \, c\psi                          & + c\theta 
+		   + c\phi \, c\psi - s\phi\,c\theta\,c\psi  & - c\phi \, s\psi - s\phi \, c\theta c\psi  & + s\phi \, s\theta  \\
+		   + s\phi \, c\psi + c\phi\,c\theta\,c\psi  & - s\phi \, s\psi + c\phi \, c\theta c\psi  & - c\phi \, s\theta  \\
+		   + s\theta \, s\psi                        & + s\theta \, c\psi                          & + c\theta
 \end{array}  \right]
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
-Cette matrice peut être interprétée comme une suite de trois rotations, avec des bases vectorielles intermédiaires, illustrées à la figure \ref{fig:euler}. 
+Cette matrice peut être interprétée comme une suite de trois rotations, avec des bases vectorielles intermédiaires, illustrées à la figure \ref{fig:euler}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[${}^aR^b=R_3(\phi)$]{
-				\includegraphics[width=0.28\textwidth]{euler1}
-				\label{fig:euler1}}
-				\subfloat[${}^bR^c=R_1(\theta)$]{
-				\includegraphics[width=0.30\textwidth]{euler2}
-				\label{fig:euler2}}
-				\subfloat[${}^cR^d=R_3(\psi)$]{
-				\includegraphics[width=0.33\textwidth]{euler3}
-				\label{fig:euler3}}
-        \caption{Angles de Euler avec la convention 3-1-3: toutes les orientations possibles de la base $d$ peuvent être décrites par la matrice de rotation ${}^aR^d(\phi,\theta,\psi) = R_3(\phi)R_1(\theta)R_3(\psi)$ paramétrisée avec trois angles.}
-				\label{fig:euler}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[${}^aR^b=R_3(\phi)$]{
+		\includegraphics[width=0.28\textwidth]{euler1}
+		\label{fig:euler1}}
+	\subfloat[${}^bR^c=R_1(\theta)$]{
+		\includegraphics[width=0.30\textwidth]{euler2}
+		\label{fig:euler2}}
+	\subfloat[${}^cR^d=R_3(\psi)$]{
+		\includegraphics[width=0.33\textwidth]{euler3}
+		\label{fig:euler3}}
+	\caption{Angles de Euler avec la convention 3-1-3: toutes les orientations possibles de la base $d$ peuvent être décrites par la matrice de rotation ${}^aR^d(\phi,\theta,\psi) = R_3(\phi)R_1(\theta)R_3(\psi)$ paramétrée avec trois angles.}
+	\label{fig:euler}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Une autre convention de trois angles utilisée fréquemment en robotique (typiquement pour les véhicules) sont les angles de roulis, tangage et lacet. Ces angles correspondent à une matrice formée par la multiplication de matrices élémentaires dans un ordre 3-2-1, si l'axe 1 correspond à la direction avant-arrière du véhicule et l'axe 2 vers à la direction haut-bas du véhicule: 
+Une autre convention de trois angles utilisée fréquemment en robotique (typiquement pour les véhicules) sont les angles de roulis, tangage et lacet (en anglais: \textit{roll}, \textit{pitch}, et \textit{yaw}). Ces angles correspondent à une matrice formée par la multiplication de matrices élémentaires dans un ordre 3-2-1, si l'axe 1 correspond à la direction avant-arrière du véhicule et l'axe 2 vers à la direction haut-bas du véhicule:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-R_{321}(\theta_{tangage}, \theta_{lacet}, \theta_{roulis}) &= R_3( \theta_{tangage} ) \, R_2( \theta_{lacet} ) \, R_1( \theta_{roulis} )
-\end{align} 
+	R_{321}(\theta_{tangage}, \theta_{lacet}, \theta_{roulis}) &= R_3( \theta_{tangage} ) \, R_2( \theta_{lacet} ) \, R_1( \theta_{roulis} )
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
-Comme l'ordre des matrices de rotation qui sont multipliées influence la matrice résultante, il y a plusieurs possibilités de définitions des trois angles de Euler qui paramétrisent la matrice. Différents auteurs, domaines et organisations utilisent des définitions différentes, il est donc toujours \textbf{important de vérifier la convention utilisée si on travail avec les angles de Euler}. 
+Comme l'ordre des matrices de rotation qui sont multipliées influence la matrice résultante, il y a plusieurs possibilités de définitions des trois angles de Euler qui paramètrent la matrice. Différents auteurs, domaines et organisations utilisent des définitions différentes, il est donc toujours \textbf{important de vérifier la convention utilisée si on travail avec les angles de Euler}.
 
 
 
@@ -2021,13 +2028,13 @@ Une orientation relative entre deux bases vectorielles peut aussi être représe
 %%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.35\textwidth]{angleaxis.png}
+	\includegraphics[width=0.35\textwidth]{angleaxis.png}
 	\caption{Représentation axe-angle d'une orientation relative}
 	\label{fig:angleaxis}
 \end{figure}
 %%%%%%%%%%%%%%%%
 
-Cette représentation nécessite quatre paramètres, trois pour un vecteur-colonne $\col{a}$ qui représente les composantes du vecteur unitaire qui décris l'axe de rotation, et un pour l'angle $\theta$. La représentation axe-angle permet donc d'utiliser seulement 4 variables plutôt que les 9 d'une matrice $3\times3$ pour représenter une rotation dans un espace tridimensionnel. Un paramètre est toutefois redondant, car le vecteur-colonne $\col{a}$ est unitaire et trois variables sont reliés par l'équation $a_{1}^2+a_{2}^2+a_{3}^2=1$. De plus, cette représentation présente des singularités lorsque $sin(\theta)=0$. L'avantage principal de la représentation axe-angle est le sens physique clair. Les inconvénients sont qu'il faut convertir vers des matrices de rotation (ou alternativement des quaternions) pour effectuer des calculs numériques de changement de base et pour combiner des rotations successives.
+Cette représentation nécessite quatre paramètres, trois pour un vecteur-colonne $\col{a}$ qui représente les composantes du vecteur unitaire qui décrit l'axe de rotation, et un pour l'angle $\theta$. La représentation axe-angle permet donc d'utiliser seulement 4 variables plutôt que les 9 d'une matrice $3\times3$ pour représenter une rotation dans un espace tridimensionnel. Un paramètre est toutefois redondant, car le vecteur-colonne $\col{a}$ est unitaire et trois variables sont reliées par l'équation $a_{1}^2+a_{2}^2+a_{3}^2=1$. De plus, cette représentation présente des singularités lorsque $\sin(\theta)=0$. L'avantage principal de la représentation axe-angle est le sens physique clair. Les inconvénients sont qu'il faut convertir vers des matrices de rotation (ou alternativement des quaternions) pour effectuer des calculs numériques de changement de base et pour combiner des rotations successives.
 
 
 
@@ -2035,61 +2042,61 @@ Cette représentation nécessite quatre paramètres, trois pour un vecteur-colon
 L'axe de rotation $\hat{a}$ est directement lié à la matrice de rotation qui représente la même orientation relative entre deux bases vectorielles. Le vecteur unitaire $\hat{a}$ aligné avec l'axe de rotation a les mêmes composantes dans les deux bases vectorielles:
 %%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\col{a} = \col{a}^b = {}^bR^a \col{a}^a = {}^aR^b \col{a}^b = \col{a}^a
-\end{equation} 
+	\col{a} = \col{a}^b = {}^bR^a \col{a}^a = {}^aR^b \col{a}^b = \col{a}^a
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%
-Le vecteur-colonne qui représente \textbf{l'axe de rotation est donc un vecteur propre de la matrice de rotation}, et la valeur propre associée est de valeur unitaire car le vecteur-colonne est inchangé par la multiplication avec la matrice de rotation. Il est donc possible de calculer l'axe de rotation associé à une matrice de rotation en calculant les valeurs et vecteurs propre de la matrice.
+Le vecteur-colonne qui représente \textbf{l'axe de rotation est donc un vecteur propre de la matrice de rotation}, et la valeur propre associée est de valeur unitaire, car le vecteur-colonne est inchangé par la multiplication avec la matrice de rotation. Il est donc possible de calculer l'axe de rotation associé à une matrice de rotation en calculant les valeurs et vecteurs propres de la matrice.
 
-\subsubsection{Convertions}
+\subsubsection{Conversions}
 La représentation axe-angle peut être calculée à partir d'une matrice de rotation $R$ de la façon suivante:
 %%%%%%%%%%%%%%%%%%
-\begin{equation} 
-\theta=cos^{-1}\left[\frac{R_{11}+R_{22}+R_{33}-1}{2}\right]
-\quad\quad 
-\col{a}=\frac{1}{2 \, sin(\theta)}\left[ \begin{array}{c}
-R_{32}-R_{23}  \\ 
-R_{13}-R_{31} \\ 
-R_{21}-R_{12} \end{array}
-\right]
+\begin{equation}
+	\theta=\cos^{-1}\left[\frac{R_{11}+R_{22}+R_{33}-1}{2}\right]
+	\quad\quad
+	\col{a}=\frac{1}{2 \, \sin(\theta)}\left[ \begin{array}{c}
+												 R_{32}-R_{23}  \\
+												 R_{13}-R_{31} \\
+												 R_{21}-R_{12} \end{array}
+		\right]
 \end{equation}
 %%%%%%%%%%%%%%%%%%
 où
 %%%%%%%%%%%%%%%%%%
 \begin{equation}
-R =\left[ \begin{array}{ccc}
-R_{11} & R_{12} & R_{13} \\ 
-R_{21} & R_{22} & R_{23} \\ 
-R_{31} & R_{32} & R_{33} \end{array}
-\right]
+	R =\left[ \begin{array}{ccc}
+				  R_{11} & R_{12} & R_{13} \\
+				  R_{21} & R_{22} & R_{23} \\
+				  R_{31} & R_{32} & R_{33} \end{array}
+		\right]
 \end{equation}
 %%%%%%%%%%%%%%%%%%%
 Inversement, la matrice de rotation peut être déterminée à partir de la représentation axe-angle:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-R=cos(\theta) \, I + (1-cos(\theta) ) \, \col{a}\ \col{a}^T-sin(\theta)\col{a}^{\times}
+	R=\cos(\theta) \, I + (1-\cos(\theta) ) \, \col{a}\ \col{a}^T-\sin(\theta)\col{a}^{\times}
 \end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%
 où
 %%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-I =\left[ \begin{array}{ccc}
-1 & 0 & 0 \\ 
-0 & 1 & 0 \\ 
-0 & 0 & 1      \end{array}
-\right] \quad\quad
-\col{a}=\left[ \begin{array}{c}
-a_{1}  \\ 
-a_{2}  \\ 
-a_{3} \end{array}
-\right]
-\quad\quad
-\col{a}^T=\left[ \begin{array}{ccc} a_{1} & a_{2} & a_{3} \end{array} \right]
-\quad\quad
-\col{a}^{\times} =\left[ \begin{array}{ccc}
-0      & -a_{3} &  a_{2} \\ 
- a_{3} & 0      & -a_{1} \\ 
--a_{2} &  a_{1} & 0      \end{array}
-\right]
+	I =\left[ \begin{array}{ccc}
+				  1 & 0 & 0 \\
+				  0 & 1 & 0 \\
+				  0 & 0 & 1      \end{array}
+		\right] \quad\quad
+	\col{a}=\left[ \begin{array}{c}
+					   a_{1}  \\
+					   a_{2}  \\
+					   a_{3} \end{array}
+		\right]
+	\quad\quad
+	\col{a}^T=\left[ \begin{array}{ccc} a_{1} & a_{2} & a_{3} \end{array} \right]
+	\quad\quad
+	\col{a}^{\times} =\left[ \begin{array}{ccc}
+								 0      & -a_{3} &  a_{2} \\
+								 a_{3} & 0      & -a_{1} \\
+								 -a_{2} &  a_{1} & 0      \end{array}
+		\right]
 \end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%
 
@@ -2097,24 +2104,24 @@ a_{3} \end{array}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Quaternions}
 \label{sec:quaternions}
-Les quaternions sont une autre façon de représenter une orientation avec 4 paramètres, physiquement moins représentative mais beaucoup plus pratique mathématiquement. Similairement à la représentation axe-angle, un quaternion est constitué d'un scalaire et de 3 composantes vectorielles qui peuvent être groupés dans un vecteur colonne $[\eta,\ e_{1},\ e_{2},\ e_{3}]^T$. Les quatre paramètres sont reliés par l'équation suivante $\eta^2+e_{1}^2+e_{2}^2+e_{3}^2=1$. Cette représentation se dérive facilement à partir de la représentation axe-angle.
+Les quaternions sont une autre façon de représenter une orientation avec 4 paramètres, physiquement moins représentative, mais beaucoup plus pratique mathématiquement. Similairement à la représentation axe-angle, un quaternion est constitué d'un scalaire et de 3 composantes vectorielles qui peuvent être groupés dans un vecteur colonne $[\eta,\ e_{1},\ e_{2},\ e_{3}]^T$. Les quatre paramètres sont reliés par l'équation suivante $\eta^2+e_{1}^2+e_{2}^2+e_{3}^2=1$. Cette représentation se dérive facilement à partir de la représentation axe-angle.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\eta=\cos\left(\frac{\theta}{2}\right)
+	\eta=\cos\left(\frac{\theta}{2}\right)
 \end{equation}
 \begin{equation}
-\left[ \begin{array}{c} e_{1} \\ e_{2} \\ e_{3} \end{array}
-\right]
-=\sin\left(\frac{\theta}{2}\right) \left[ \begin{array}{c} a_{1} \\ a_{2} \\ a_{3} \end{array}
-\right]
+	\left[ \begin{array}{c} e_{1} \\ e_{2} \\ e_{3} \end{array}
+		\right]
+	=\sin\left(\frac{\theta}{2}\right) \left[ \begin{array}{c} a_{1} \\ a_{2} \\ a_{3} \end{array}
+		\right]
 \end{equation}
 %%%%%%%%%%%%%%%%%%%%
-Les grands avantages de cette représentation sont \textbf{1)} l'absence de singularité et \textbf{2)} des méthodes numériquement efficaces pour calculer des rotations successives et des changements de base directement avec le vecteur colonne $[\eta,\ e_{1},\ e_{2},\ e_{3}]^T$. 
+Les grands avantages de cette représentation sont \textbf{1)} l'absence de singularité et \textbf{2)} des méthodes numériquement efficaces pour calculer des rotations successives et des changements de base directement avec le vecteur colonne $[\eta,\ e_{1},\ e_{2},\ e_{3}]^T$.
 
 %TODO
 Détails à venir!
 
-%les rotations peuvent être calculées sans utiliser de sinus ou de cosinus. 
+%les rotations peuvent être calculées sans utiliser de sinus ou de cosinus.
 
 %En effet, l'addition de deux rotations est une opération spéciale entre deux quaternions.
 
@@ -2134,39 +2141,39 @@ Détails à venir!
 La figure illustre un exemple où un véhicule et les points d’intérêts qu'il trouve doivent être localisés par rapport à une base. La cinématique de ce problème peut se résumer à calculer la matrice de transformation $^AT^B$, qui peut être construite à partir de la définition:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^AT^B &= 
-\left[ \begin{array}{c c } 
-^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
+{}^AT^B &=
+\left[ \begin{array}{c c }
+		   ^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+\end{array} \right]
 =
-\left[ \begin{array}{c c c c} 
-\hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 & \hat{a}_1 \bullet \vec{r}_{B_o/A_o} \\
-\hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_2 \bullet \vec{r}_{B_o/A_o}\\
-\hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 & \hat{a}_3 \bullet \vec{r}_{B_o/A_o} \\
-0 & 0 & 0 & 1
-\end{array} \right] 
+\left[ \begin{array}{c c c c}
+		   \hat{a}_1 \bullet \hat{b}_1  &  \hat{a}_1 \bullet \hat{b}_2  &  \hat{a}_1 \bullet \hat{b}_3 & \hat{a}_1 \bullet \vec{r}_{B_o/A_o} \\
+		   \hat{a}_2 \bullet \hat{b}_1  &  \hat{a}_2 \bullet \hat{b}_2  &  \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_2 \bullet \vec{r}_{B_o/A_o}\\
+		   \hat{a}_3 \bullet \hat{b}_1  &  \hat{a}_3 \bullet \hat{b}_2  &  \hat{a}_3 \bullet \hat{b}_3 & \hat{a}_3 \bullet \vec{r}_{B_o/A_o} \\
+		   0 & 0 & 0 & 1
+\end{array} \right]
 \label{eq:transformationdef_app}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Cette matrice représente la pose du véhicule par rapport au repère de la base, et peut aussi être utilisée pour transformer des coordonnées cartésiennes relatives au repère du véhicule en des coordonnées cartésiennes relatives au repère de la base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c} 
-\col{r}_{C/A_o}^a \\ 1
-\end{array} \right] 
-= 
-{}^AT^B
-\left[ \begin{array}{c} 
-\col{r}_{C/B_o}^b \\ 1
-\end{array} \right] 
-\label{eq:homo1_app}
-\end{align} 
+	\left[ \begin{array}{c}
+			   \col{r}_{C/A_o}^a \\ 1
+	\end{array} \right]
+	=
+	{}^AT^B
+	\left[ \begin{array}{c}
+			   \col{r}_{C/B_o}^b \\ 1
+	\end{array} \right]
+	\label{eq:homo1_app}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.95\textwidth]{vec.png}
+	\includegraphics[width=0.95\textwidth]{vec.png}
 	\caption{Cinématique d'un robot mobile}
 	\label{fig:vec}
 \end{figure}
@@ -2179,25 +2186,25 @@ Cette matrice représente la pose du véhicule par rapport au repère de la base
 \section{Cinématique directe d'un manipulateur}
 \label{sec:fwdkin}
 
-La cinématique directe, c'est le calcul de la fonction de transformation qui permet de passer de l'espace des joints, i.e. le vecteur-colonne $\col{q}$, vers l'espace de la tâche. Pour les robots manipulateurs, l'espace de la tâche est normalement décrit par la translation et l'orientation de l'effecteur.  Si le point de référence de l'effecteur est noté $T_o$ (souvent dans la littérature il est appelé le \textit{TCP} pour \textit{Tool Center Point}), et la base vectorielle associée à l'orientation de l'effecteur est notée $t$, voir figure \ref{fig:serial_kin_3}, alors la fonction de cinématique directe pour la translation est:
+La cinématique directe, c'est le calcul de la fonction de transformation qui permet de passer de l'espace des joints, c.-à-d. le vecteur-colonne $\col{q}$, vers l'espace de la tâche. Pour les robots manipulateurs, l'espace de la tâche est normalement décrit par la translation et l'orientation de l'effecteur.  Si le point de référence de l'effecteur est noté $T_o$ (souvent dans la littérature il est appelé le \textit{TCP} pour \textit{Tool Center Point}), et la base vectorielle associée à l'orientation de l'effecteur est notée $t$, voir figure \ref{fig:serial_kin_3}, alors la fonction de cinématique directe pour la translation est:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\col{r}_{T_o/A_o}^a = f_{Trans}\left( \, \col{q} \, \right)
-\label{eq:kinfwdtrans} 
+	\col{r}_{T_o/A_o}^a = f_{Trans}\left( \, \col{q} \, \right)
+	\label{eq:kinfwdtrans}
 \end{equation}
 %%%%%%%%%%%%%%%
 et la fonction de cinématique directe pour l'orientation est:
 %%%%%%%%%%%%%%%%
 \begin{equation}
 {}^aR^t = f_{Orien}\left( \, \col{q} \, \right)
-\label{eq:kinfwdrot} 
+\label{eq:kinfwdrot}
 \end{equation}
 %%%%%%%%%%%%%%%5
-où le point $A_o$ et la base $a$ décrive l'origine et la base vectorielle globale qui sont fixes par rapport à la base du robot. Les deux opérations peuvent être combinées en une seule opération qui consiste à calculer la matrice de transformation homogène du repère $\{T_o,\hat{t}_1,\hat{t}_2,\hat{t}_3\}$ par rapport au repère de global $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$
+où le point $A_o$ et la base $a$ décrivent l'origine et la base vectorielle globale qui sont fixes par rapport à la base du robot. Les deux opérations peuvent être combinées en une seule opération qui consiste à calculer la matrice de transformation homogène du repère $\{T_o,\hat{t}_1,\hat{t}_2,\hat{t}_3\}$ par rapport au repère global $\{A_o,\hat{a}_1,\hat{a}_2,\hat{a}_3\}$
 %%%%%%%%%%%%%%%%
 \begin{equation}
 {}^AT^T = f_{Pose}\left( \, \col{q} \, \right)
-\label{eq:kinfwdpose} 
+\label{eq:kinfwdpose}
 \end{equation}
 %%%%%%%%%%%%%%%%
 
@@ -2208,53 +2215,53 @@ où le point $A_o$ et la base $a$ décrive l'origine et la base vectorielle glob
 %%%%%%%%%%%%%%%%%%%%
 \begin{figure}[p]
 	\centering
-		\includegraphics[width=0.90\textwidth]{serial_kin_1.png}
+	\includegraphics[width=0.90\textwidth]{serial_kin_1.png}
 	\caption{Cinématique d'une chaîne ouverte de $n$ joints}
 	\label{fig:serial_kin_1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%
 \begin{figure}[p]
 	\centering
-		\includegraphics[width=0.90\textwidth]{serial_kin_2.png}
+	\includegraphics[width=0.90\textwidth]{serial_kin_2.png}
 	\caption{Cinématique d'une chaîne ouverte de $n$ joints: addition vectorielle de $n+1$ vecteurs géométriques de position.}
 	\label{fig:serial_kin_2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%
 \begin{figure}[p]
 	\centering
-		\includegraphics[width=0.90\textwidth]{serial_kin_3.png}
+	\includegraphics[width=0.90\textwidth]{serial_kin_3.png}
 	\caption{Cinématique d'une chaîne ouverte de $n$ joints: succession de $n+1$ transformations homogènes}
 	\label{fig:serial_kin_3}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%
 
-La plupart des robots manipulateurs sont caractérisés par une chaine cinématique ouverte de $n$ joints, comme illustré à la figure \ref{fig:serial_kin_1}. Pour modéliser cette chaîne cinématique, on associera des points de référence et des bases vectorielles sur chaque lien rigide. La fonction de \textbf{cinématique directe pour la translation} se résume à calculer l'addition des $n+1$ vecteurs géométriques de position qui caractérisent la chaîne cinématique, comme illustré à la figure \ref{fig:serial_kin_2}:
+La plupart des robots manipulateurs sont caractérisés par une chaîne cinématique ouverte de $n$ joints, comme illustré à la figure \ref{fig:serial_kin_1}. Pour modéliser cette chaîne cinématique, on associera des points de référence et des bases vectorielles sur chaque lien rigide. La fonction de \textbf{cinématique directe pour la translation} se résume à calculer l'addition des $n+1$ vecteurs géométriques de position qui caractérisent la chaîne cinématique, comme illustré à la figure \ref{fig:serial_kin_2}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{T_o/A_o} = \vec{r}_{T_o/H_o} + \; ... \; + \vec{r}_{C_o/B_o} + \vec{r}_{B_o/A_o}
-\label{eq:fwdkintransvec}
-\end{align} 
+	\vec{r}_{T_o/A_o} = \vec{r}_{T_o/H_o} + \; ... \; + \vec{r}_{C_o/B_o} + \vec{r}_{B_o/A_o}
+	\label{eq:fwdkintransvec}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ce calcul peut être effectué en termes de composantes dans la base vectorielle globale:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{T_o/A_o}^a = \col{r}_{T_o/H_o}^a + \; ... \; + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a
-\label{eq:fwdkintrans}
-\end{align} 
+	\col{r}_{T_o/A_o}^a = \col{r}_{T_o/H_o}^a + \; ... \; + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a
+	\label{eq:fwdkintrans}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 La fonction de \textbf{cinématique directe pour l'orientation} de l'effecteur se résume à multiplier les $n+1$ matrices de rotation qui caractérisent les orientations relatives de deux joints successifs, pour obtenir la matrice de rotation totale qui décrit l'orientation de l'effecteur par rapport à la base globale:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^aR^t = {}^aR^b \,  {}^bR^c \; ... \; {}^hR^t
 \label{eq:fwdkinorien}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Alternativement pour combiner les opérations, la fonction de \textbf{cinématique directe pour la pose} de l'effecteur peut être calculée en multipliant les $n+1$ matrices de transformations homogènes qui caractérisent la pose relative des repères associés à deux joints successifs:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^AT{}^T = {}^AT^B \;  {}^BT^C \; ... \; {}^HT^T
 \label{eq:fwdkinhomo}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -2267,63 +2274,63 @@ Pour une chaîne cinématique où chaque joint a un seul DDL qui est décrit par
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^AT{}^T(q_1, q_2, ..., q_n) = {}^AT^B(q_1) \,  {}^BT^C(q_2) \, ... \, {}^GT^H(q_n) \, {}^HT^T
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Chaque matrice de transformation est une fonction d'une seule variable $q_i$. Notez que ici la dernière matrice de transformation ${}^HT^T$ est constante car elle décrit la positon de l'effecteur par rapport au dernier joint $n$.
+Chaque matrice de transformation est une fonction d'une seule variable $q_i$. Notez qu’ici, la dernière matrice de transformation ${}^HT^T$ est constante, car elle décrit la position de l'effecteur par rapport au dernier joint $n$.
 %
 De plus, si un robot est constitué de \textbf{joints rotatifs seulement}, comme la plupart des robots manipulateurs industriels, alors l'équation pour l'orientation \eqref{eq:fwdkinorien} a aussi une structure similaire:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 %{}^aR{}^t(q_1, q_2, ..., q_n) = {}^aR^b(q_1) \,  {}^bR^c(q_2) \, ... \, {}^gR^h(q_n) \, {}^hR^t \\
 {}^aR{}^t(\theta_1, \theta_2, ..., \theta_n) =  {}^aR^b(\theta_1) \,  {}^bR^c(\theta_2) \, ... \, {}^gR^h(\theta_n) \, {}^hR^t
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 où chaque matrice de rotation est une fonction de la variable $q_i$, qui est un angle $\theta_i$.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Transformations relatives entre les joints à 1 DDL}
 %
-Pour un joint rotatif, le DDL est une rotation relative selon un axe. Le mouvement peut donc être représenté par une matrice de rotation variable qui décrit l'orientation relative des deux liens rigides reliés par le joint. Pour un joint prismatique, il n'y a aucune rotation relative, seulement une translation selon un axe. La mouvement est donc représenté par un vecteur position de longueur variable. Donc pour représenter le mouvement du joint $i$ d'un robot, qui est décrit par la pose relative entre le repère $\{F_o, \hat{f}_1, \hat{f}_2, \hat{f}_3\}$ et le repère $\{E_o, \hat{e}_1, \hat{e}_2, \hat{e}_3\}$, c'est le vecteur position $\vec{r}_{F_o/E_o}$ qui est une fonction de $q_i$ pour un joint prismatique et la matrice $^{e}R^f$ qui est une fonction de $q_i$ pour un joint rotatif:
+Pour un joint rotatif, le DDL est une rotation relative selon un axe. Le mouvement peut donc être représenté par une matrice de rotation variable qui décrit l'orientation relative des deux liens rigides reliés par le joint. Pour un joint prismatique, il n'y a aucune rotation relative, seulement une translation selon un axe. Le mouvement est donc représenté par un vecteur position de longueur variable. Donc pour représenter le mouvement du joint $i$ d'un robot, qui est décrit par la pose relative entre le repère $\{F_o, \hat{f}_1, \hat{f}_2, \hat{f}_3\}$ et le repère $\{E_o, \hat{e}_1, \hat{e}_2, \hat{e}_3\}$, c'est le vecteur position $\vec{r}_{F_o/E_o}$ qui est une fonction de $q_i$ pour un joint prismatique et c'est la matrice $^{e}R^f$ qui est une fonction de $q_i$ pour un joint rotatif:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-Joint\;prismatique: 
-\left\{ 
-\begin{array}{l}
+	Joint\;prismatique:
+	\left\{
+	\begin{array}{l}
 %%%%%%%%%%
-\col{r}_{F_o/E_o}^e = f( q_i ) 
+		\col{r}_{F_o/E_o}^e = f( q_i )
 %%%%%%%%%
-\\ \\
+		\\ \\
 %%%%%%%%%
-^{e}R^f = constante
+		^{e}R^f = constante
 %%%%%%%%%
-\end{array} \right.
-\quad\quad 
-Joint\;rotatif: 
-\left\{ 
-\begin{array}{l}
+	\end{array} \right.
+	\quad\quad
+	Joint\;rotatif:
+	\left\{
+	\begin{array}{l}
 %%%%%%%%%%
-\col{r}_{F_o/E_o}^e = constante
+		\col{r}_{F_o/E_o}^e = constante
 %%%%%%%%%
-\\ \\
+		\\ \\
 %%%%%%%%%
-^{e}R^f = f( q_i )
+		^{e}R^f = f( q_i )
 %%%%%%%%%
-\end{array} \right.
-\end{align} 
+	\end{array} \right.
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 de façon équivalente en termes des transformations homogènes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-Prismatique: \;
-^{E}T^F( q_i ) = \left[ \begin{array}{c c}
-	^{e}R^f  & \col{r}_{F_o/E_o}^a( q_i )  \\ 0 \; 0 \; 0 & 1
-\end{array}  \right]
-\quad\quad 
-Rotatif: \;
-^{E}T^F( q_i ) = \left[ \begin{array}{c c}
-	^{e}R^f( q_i )  & \col{r}_{F_o/E_o}^a  \\ 0 \; 0 \; 0 & 1
-\end{array}  \right]
-\end{align} 
+	Prismatique: \;
+	^{E}T^F( q_i ) = \left[ \begin{array}{c c}
+								^{e}R^f  & \col{r}_{F_o/E_o}^a( q_i )  \\ 0 \; 0 \; 0 & 1
+	\end{array}  \right]
+	\quad\quad
+	Rotatif: \;
+	^{E}T^F( q_i ) = \left[ \begin{array}{c c}
+								^{e}R^f( q_i )  & \col{r}_{F_o/E_o}^a  \\ 0 \; 0 \; 0 & 1
+	\end{array}  \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -2332,32 +2339,32 @@ Rotatif: \;
 \subsection{Procédure de calcul d'une chaîne cinématique directe}
 \label{sec:cinedirectmethod}
 
-Une procédure pour calculer la cinématique d'un chaîne ouverte arbitraire de $n$ joints et $n+1$ liens rigides, est ici présentée. La notation utilisée est présentée aux figures \ref{fig:serial_kin_1}, \ref{fig:serial_kin_2} et \ref{fig:serial_kin_3}. 
+Une procédure pour calculer la cinématique d'une chaîne ouverte arbitraire de $n$ joints et $n+1$ liens rigides est ici présentée. La notation utilisée est présentée aux figures \ref{fig:serial_kin_1}, \ref{fig:serial_kin_2} et \ref{fig:serial_kin_3}.
 
 \paragraph{I: Définition des références}
 
-La première étape est de définir des coordonnées généralisées ($q_1$, $q_2$, $q_2$, ..., $q_m$) qui décrive l'état des $m$ DDL des $n$ joints du robot. En générale, pour la plupart des robots manipulateurs, $m=n$ car des joints standards à 1 DDL prismatique ou rotatif sont normalement utilisés. Ensuite, la seconde étape est de définir des points de références ($A_o$, $B_o$, $C_o$, ..., $T_o$) et des bases vectorielles ($a$, $b$, $c$, ..., $t$) sur chaque lien rigide. 
+La première étape est de définir des coordonnées généralisées ($q_1$, $q_2$, $q_2$, ..., $q_m$) qui décrivent l'état des $m$ DDL des $n$ joints du robot. En générale, pour la plupart des robots manipulateurs, $m=n$ car des joints standards à 1 DDL prismatique ou rotatif sont normalement utilisés. Ensuite, la seconde étape est de définir des points de références ($A_o$, $B_o$, $C_o$, ..., $T_o$) et des bases vectorielles ($a$, $b$, $c$, ..., $t$) sur chaque lien rigide.
 
-\note{Astuces:}{ Pour grandement simplifier le calcul des matrices de rotation, les bases vectorielles locales de deux liens rigides adjacents à un joint rotatif devraient être définies avec un vecteurs unitaire parallèle à l'axe de rotation du joint. Ensuite, l'orientation des deux autres vecteurs unitaires devrait être choisie de façon à maximiser le nombre de composantes nulles dans les vecteurs positions.}
+\note{Astuces:}{ Pour grandement simplifier le calcul des matrices de rotation, les bases vectorielles locales de deux liens rigides adjacents à un joint rotatif devraient être définies avec un vecteur unitaire parallèle à l'axe de rotation du joint. Ensuite, l'orientation des deux autres vecteurs unitaires devrait être choisie de façon à maximiser le nombre de composantes nulles dans les vecteurs positions.}
 
 \paragraph{II: Calcul des vecteurs positions locaux}
 
 Ensuite, basé sur les points et bases vectorielles définies, les $n+1$ vecteurs positions locaux peuvent être calculés par inspection selon la géométrie et les dimensions du robot. Pour un robot qui est constitué de joints rotatifs seulement, toutes les composantes de ces vecteurs positions exprimées dans les bases vectorielles locales sont constantes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{B_o/A_o}^a = 
-\left[ \begin{array}{c} 
-l_{1,x} \\ l_{1,y} \\ l_{1,z}
-\end{array} \right], \quad
-\col{r}_{C_o/B_o}^b = 
-\left[ \begin{array}{c} 
-l_{2,x} \\ l_{2,y} \\ l_{3,z}
-\end{array} \right], \quad\quad ... \quad\quad
-\col{r}_{T_o/H_o}^h = 
-\left[ \begin{array}{c} 
-l_{n+1,x} \\ l_{n+1,y} \\ l_{n+1,z}
-\end{array} \right]
-\end{align} 
+	\col{r}_{B_o/A_o}^a =
+	\left[ \begin{array}{c}
+			   l_{1,x} \\ l_{1,y} \\ l_{1,z}
+	\end{array} \right], \quad
+	\col{r}_{C_o/B_o}^b =
+	\left[ \begin{array}{c}
+			   l_{2,x} \\ l_{2,y} \\ l_{3,z}
+	\end{array} \right], \quad\quad ... \quad\quad
+	\col{r}_{T_o/H_o}^h =
+	\left[ \begin{array}{c}
+			   l_{n+1,x} \\ l_{n+1,y} \\ l_{n+1,z}
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 où les variables $l$ représentent les dimensions des liens rigides. Toutefois, si un robot utilise des joints prismatiques, certains vecteurs positions locaux vont être des fonctions des variables $q_i$ représentants l'état de ces joints prismatiques.
 
@@ -2366,25 +2373,25 @@ où les variables $l$ représentent les dimensions des liens rigides. Toutefois,
 Ensuite, les matrices de rotation qui décrive l'orientation relative des bases vectorielles de joints adjacents sont calculées en suivant la démarche décrite à la section \ref{sec:calmat}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^aR^b( q_1 ) = \left[ \begin{array}{c c c} 
-\col{b}_1^a &
-\col{b}_2^a &
-\col{b}_3^a
+{}^aR^b( q_1 ) = \left[ \begin{array}{c c c}
+							\col{b}_1^a &
+							\col{b}_2^a &
+							\col{b}_3^a
 \end{array} \right],
 \quad
 {}^bR^c( q_2 ) = \left[ \begin{array}{c c c}
-\col{c}_1^b &
-\col{c}_2^b &
-\col{c}_3^b
+							\col{c}_1^b &
+							\col{c}_2^b &
+							\col{c}_3^b
 \end{array} \right],
-%\quad  
+%\quad
 %{}^cR^d( q_3 ) = \left[ \begin{array}{c c c}
 %\col{d}_1^c &
 %\col{d}_2^c &
 %\col{d}_3^c
 %\end{array} \right]
-\quad ... 
-\end{align} 
+\quad ...
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Pour un robot qui est constitué de joints rotatifs seulement, les matrices de rotation relatives entre deux bases locales vont être des fonctions des variables $q_i$ qui décrivent l'état des joints rotatifs.
 
@@ -2396,7 +2403,7 @@ Pour un robot qui est constitué de joints rotatifs seulement, les matrices de r
 %\begin{align}
 %\vec{r}_{T_o/A_o} = \vec{r}_{T_o/H_o} +  ... + \vec{r}_{C_o/B_o} + \vec{r}_{B_o/A_o}
 %\label{eq:fwd_kin_open}
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Premièrement, les matrices de rotation qui décrivent l'orientation des bases vectorielles mobiles par rapport à la base vectorielle fixe $a$ sont calculées en multipliant les matrices de rotation relatives:
@@ -2407,185 +2414,187 @@ Premièrement, les matrices de rotation qui décrivent l'orientation des bases v
 {}^aR^d &= {}^aR^b \, {}^bR^c \, {}^cR^d \\
 \vdots  & \nonumber \\
 {}^aR^t &= {}^aR^b \, {}^bR^c \, {}^cR^d   \, ...  \, {}^hR^t
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-où la dernière ligne donne le résultat de cinématique directe pour l'orientation. Ensuite, avec ces matrices, il est possible d'effectuer des changements de base pour exprimer tous les vecteurs de position dans la base fixe $a$: 
+où la dernière ligne donne le résultat de cinématique directe pour l'orientation. Ensuite, avec ces matrices, il est possible d'effectuer des changements de base pour exprimer tous les vecteurs de position dans la base fixe $a$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{B_o/A_o}^a &= \col{r}_{B_o/A_o}^a \\
-\col{r}_{C_o/B_o}^a &= {}^aR^b \, \col{r}_{C_o/B_o}^b \\
-\col{r}_{D_o/C_o}^a &= {}^aR^c \, \col{r}_{D_o/C_o}^c \\
-\vdots  & \nonumber \\
-\col{r}_{T_o/H_o}^a &= {}^aR^h \, \col{r}_{T_o/H_o}^h 
-\end{align} 
+	\col{r}_{B_o/A_o}^a &= \col{r}_{B_o/A_o}^a \\
+	\col{r}_{C_o/B_o}^a &= {}^aR^b \, \col{r}_{C_o/B_o}^b \\
+	\col{r}_{D_o/C_o}^a &= {}^aR^c \, \col{r}_{D_o/C_o}^c \\
+	\vdots  & \nonumber \\
+	\col{r}_{T_o/H_o}^a &= {}^aR^h \, \col{r}_{T_o/H_o}^h
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Finalement, avec tous les vecteurs de position relatifs connus dans la base fixe $a$, il est maintenant possible de calculer la position de tous les points de références par rapport à l'origine $A_o$
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{B_o/A_o}^a &= \col{r}_{B_o/A_o}^a \\
-\col{r}_{C_o/A_o}^a &= \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a \\
-\col{r}_{D_o/A_o}^a &= \col{r}_{D_o/C_o}^a + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a \\
-\vdots  & \nonumber \\
-\col{r}_{T_o/A_o}^a &= \col{r}_{T_o/H_o}^a +  ... + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a
-\end{align} 
+	\col{r}_{B_o/A_o}^a &= \col{r}_{B_o/A_o}^a \\
+	\col{r}_{C_o/A_o}^a &= \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a \\
+	\col{r}_{D_o/A_o}^a &= \col{r}_{D_o/C_o}^a + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a \\
+	\vdots  & \nonumber \\
+	\col{r}_{T_o/A_o}^a &= \col{r}_{T_o/H_o}^a +  ... + \col{r}_{C_o/B_o}^a + \col{r}_{B_o/A_o}^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 où la dernière ligne donne le résultat de cinématique directe pour la translation de l'effecteur. Il est à noter que cette procédure donne aussi la position de tous les points de références ($A_o$, $B_o$, $C_o$, ..., $T_o$) dans le repère fixe $A$, ce qui est utile pour tracer le squelette du robot et visualiser la configuration.
 
 
 \paragraph{IV*: Alternative de calcul avec les transformations homogènes}
 
-Alternativement, l'étape IV peut être effectuée grâce aux transformations homogènes. Les points de références et bases vectorielles sur chaque lien rigide définissent des repères. Les matrices de transformation relative à deux repères adjacents à un joint peuvent être construites à partir des vecteurs positions locaux et des matrices de rotation relatives: 
+Alternativement, l'étape IV peut être effectuée grâce aux transformations homogènes. Les points de références et bases vectorielles sur chaque lien rigide définissent des repères. Les matrices de transformation relative à deux repères adjacents à un joint peuvent être construites à partir des vecteurs positions locaux et des matrices de rotation relatives:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-^AT^B(q_1) 
-= 
-\left[ \begin{array}{c c } 
-^aR^b(q_1)  & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] ,
-\quad 
-^BT^C(q_2) 
-= 
-\left[ \begin{array}{c c } 
-^bR^c(q_2)  & \col{r}_{C_o/B_o}^b \\ 0 \; 0 \; 0 & 1
-\end{array} \right] ,
-\quad 
-...
-%^GT^T(q_n) 
-%= 
-%\left[ \begin{array}{c c } 
+	^AT^B(q_1)
+	=
+	\left[ \begin{array}{c c }
+			   ^aR^b(q_1)  & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+	\end{array} \right] ,
+	\quad
+	^BT^C(q_2)
+	=
+	\left[ \begin{array}{c c }
+			   ^bR^c(q_2)  & \col{r}_{C_o/B_o}^b \\ 0 \; 0 \; 0 & 1
+	\end{array} \right] ,
+	\quad
+	...
+%^GT^T(q_n)
+%=
+%\left[ \begin{array}{c c }
 %^gR^h(q_n)  & \col{r}_{H_o/T_o}^b \\ 0 \; 0 \; 0 & 1
-%\end{array} \right] 
-\end{align} 
+%\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Les matrices de transformation globales de tous les repères mobiles vers le repère fixe $A$ peuvent ensuite être calculées par la multiplication des matrices de transformation intermédiaires:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-^AT^B &= ^AT^B(q_1) \\
-^AT^C &= ^AT^B(q_1) \,  ^BT^C(q_2) \\
-\vdots  & \nonumber \\
-^AT^T &= ^AT^B(q_1) \,  ^BT^C(q_2) \; ... \; ^GT^H(q_n) \, ^HT^T
-\end{align} 
+	^AT^B &= ^AT^B(q_1) \\
+	^AT^C &= ^AT^B(q_1) \,  ^BT^C(q_2) \\
+	\vdots  & \nonumber \\
+	^AT^T &= ^AT^B(q_1) \,  ^BT^C(q_2) \; ... \; ^GT^H(q_n) \, ^HT^T
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %Finalement la position du point $T_o$ dans le repère $A$ peut être calculé en transformant les coordonnées (0,0,0) du repère $T$ vers le repère $A$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
-%\left[ \begin{array}{c} 
+%\left[ \begin{array}{c}
 %\col{r}_{T_o/A_o}^a \\ 1
-%\end{array} \right] 
-%= 
+%\end{array} \right]
+%=
 %^AT^T
-%\left[ \begin{array}{c} 
+%\left[ \begin{array}{c}
 %0 \\ 0 \\ 0 \\ 1
-%\end{array} \right] 
-%\end{align} 
+%\end{array} \right]
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %%%%%%%%%%%%%%%%%%%%%%
 \subsection{Exemple de la cinématique pour un robot avec deux joints}
 
-Un exemple est ici présenté de calcul de la cinématique directe pour le robot illustré à la figure \ref{fig:kinex} qui possède un joint rotatif et un joint prismatique. L'objectif est ici de calculer les coordonnées du point $D_o$ dans le repère fixe $\{ A_o, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$ comme un fonction de la configuration des joints. Trois méthodes de résolution sont présentées, une méthode minimaliste qui utilise seulement les équations vectorielles, une méthode matricielle qui utilise les vecteur-colonnes et les matrices de rotation, ainsi qu'une méthode utilisant les coordonnées homogènes. 
+Un exemple de calcul de la cinématique directe pour le robot illustré à la figure \ref{fig:kinex} qui possède un joint rotatif et un joint prismatique est présenté ici. L'objectif ici est de calculer les coordonnées du point $D_o$ dans le repère fixe $\{ A_o, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$ comme une fonction de la configuration des joints. Trois méthodes de résolution sont présentées, une méthode minimaliste qui utilise seulement les équations vectorielles, une méthode matricielle qui utilise les vecteurs-colonne et les matrices de rotation, ainsi qu'une méthode utilisant les coordonnées homogènes.
 
-La première étape, commune aux trois méthodes, est de définir des bases vectorielles et des points de référence sur le robot comme illustré à la figure \ref{fig:kinex2}. Ici les bases vectorielles $a$ et $b$ ont été définies de sorte que les vecteurs unitaires $\hat{a}_3$ et $\hat{b}_3$ soient parallèles à l'axe de rotation du joint rotatif (axe perpendiculaire au plan de la page). De plus, le vecteur unitaire $\hat{b}_1$ a été défini en ligne avec le deuxième lien rigide et l'axe de translation du joint prismatique. Les points de référence secondaires ont été choisis ainsi: un point $B_o$ au centre du joint rotatif et un point $C$ à la base du joint prismatique. Pour les coordonnées généralisées qui décrivent la configuration du robot, l'angle $\theta$ avec la vertical du deuxième lien rigide ainsi que la distance $x$ de translation entre le point $C$ et $D_o$ ont été choisis. 
+La première étape, commune aux trois méthodes, est de définir des bases vectorielles et des points de référence sur le robot comme illustré à la figure \ref{fig:kinex2}. Ici les bases vectorielles $a$ et $b$ ont été définies de sorte que les vecteurs unitaires $\hat{a}_3$ et $\hat{b}_3$ soient parallèles à l'axe de rotation du joint rotatif (axe perpendiculaire au plan de la page). De plus, le vecteur unitaire $\hat{b}_1$ a été défini en ligne avec le deuxième lien rigide et l'axe de translation du joint prismatique. Les points de référence secondaires ont été choisis ainsi: un point $B_o$ au centre du joint rotatif et un point $C$ à la base du joint prismatique. Pour les coordonnées généralisées qui décrivent la configuration du robot,
+%% TODO Quelle angle? L'horizontale? -> l'angle $\theta$ avec la vertical du deuxième lien rigide %%
+l'angle $\theta$ avec la vertical du deuxième lien rigide ainsi que la distance $x$ de translation entre le point $C$ et $D_o$ ont été choisis.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Géométrie]{
-				\includegraphics[width=0.35\textwidth]{kinex1.png}
-				\label{fig:kinex1}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-				\subfloat[Bases vectorielles et points de références]{
-				\includegraphics[width=0.45\textwidth]{kinex2.png}
-				\label{fig:kinex2}}
-        \caption{Robot à deux joints }
-				\label{fig:kinex}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Géométrie]{
+		\includegraphics[width=0.35\textwidth]{kinex1.png}
+		\label{fig:kinex1}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Bases vectorielles et points de références]{
+		\includegraphics[width=0.45\textwidth]{kinex2.png}
+		\label{fig:kinex2}}
+	\caption{Robot à deux joints }
+	\label{fig:kinex}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{Méthode vectorielle}
 
-Premièrement, avec les points et bases qui ont été définis, il est possible de décrire les vecteurs positions qui représentent la géométrie des liens rigides et ne dépendent pas directement des joints: 
+Premièrement, avec les points et bases qui ont été définis, il est possible de décrire les vecteurs positions qui représentent la géométrie des liens rigides et ne dépendent pas directement des joints:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Éléments constants:}& \quad \vec{r}_{B_o/A_o} = l_1 \, \hat{a}_2  \quad \text{et} \quad  \vec{r}_{C/B_o} = l_2 \, \hat{b}_1 
-\end{align} 
+	\text{Éléments constants:}& \quad \vec{r}_{B_o/A_o} = l_1 \, \hat{a}_2  \quad \text{et} \quad  \vec{r}_{C/B_o} = l_2 \, \hat{b}_1
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Ensuite, la direction $\hat{b}_1$ dépend de l'état du joint rotatif donc de l'angle $\theta$, et le vecteur position du point $D_o$ par rapport au point $C$ a une longueur variable égale à $x$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Éléments variables:}& \quad \hat{b}_1(\theta) = c\theta \, \hat{a}_1  + s\theta \, \hat{a}_2  \quad \text{et} \quad  \vec{r}_{D/C}(x) = x \, \hat{b}_1
-\end{align} 
+	\text{Éléments variables:}& \quad \hat{b}_1(\theta) = c\theta \, \hat{a}_1  + s\theta \, \hat{a}_2  \quad \text{et} \quad  \vec{r}_{D/C}(x) = x \, \hat{b}_1
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Tous les éléments sont maintenant en place pour effectuer la résolution. Le vecteur pertinent pour la résolution est décomposé en une addition de vecteurs connus:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{D_o/A_o}   &=  \vec{r}_{D_o/C} + \vec{r}_{C/B_o} + \vec{r}_{B_o/A_o} 
-\end{align} 
+	\vec{r}_{D_o/A_o}   &=  \vec{r}_{D_o/C} + \vec{r}_{C/B_o} + \vec{r}_{B_o/A_o}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 qui peuvent être manipulés de sorte à garder seulement les vecteurs unitaires $\hat{a}_i$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
 %\vec{r}_{D_o/A_o}   &=  \vec{r}_{D_o/C} + \vec{r}_{C/B_o} + \vec{r}_{B_o/A_o} \\
-\vec{r}_{D_o/A_o}   &=  x \, \hat{b}_1  + l_2 \, \hat{b}_1 + l_1 \, \hat{a}_2 \\
-\vec{r}_{D_o/A_o}   &=            ( x + l_2 ) \, \hat{b}_1 + l_1 \, \hat{a}_2 \\
-\vec{r}_{D_o/A_o}   &=  ( x + l_2 ) \, (  c\theta \, \hat{a}_1  + s\theta \, \hat{a}_2 ) + l_1 \, \hat{a}_2 \\
-\vec{r}_{D_o/A_o}   &=  \underbrace{\left[  ( x + l_2 ) \, c\theta \right]}_{r_1^a}  \, \hat{a}_1  + \underbrace{\left[ ( x + l_2 ) s\theta  + l_1 \right]}_{r_2^a} \, \hat{a}_2 
-\end{align} 
+	\vec{r}_{D_o/A_o}   &=  x \, \hat{b}_1  + l_2 \, \hat{b}_1 + l_1 \, \hat{a}_2 \\
+	\vec{r}_{D_o/A_o}   &=            ( x + l_2 ) \, \hat{b}_1 + l_1 \, \hat{a}_2 \\
+	\vec{r}_{D_o/A_o}   &=  ( x + l_2 ) \, (  c\theta \, \hat{a}_1  + s\theta \, \hat{a}_2 ) + l_1 \, \hat{a}_2 \\
+	\vec{r}_{D_o/A_o}   &=  \underbrace{\left[  ( x + l_2 ) \, c\theta \right]}_{r_1^a}  \, \hat{a}_1  + \underbrace{\left[ ( x + l_2 ) s\theta  + l_1 \right]}_{r_2^a} \, \hat{a}_2
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Puisque l'équation vectorielle a été réduite aux directions $\hat{a}_i$ seulement, il est possible d'extraire directement les composantes dans la base $a$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D_o/A_o}^a   &=  \left[ \begin{array}{c} 
-( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
-\end{array} \right] 
-\end{align} 
+	\col{r}_{D_o/A_o}^a   &=  \left[ \begin{array}{c}
+										 ( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 \paragraph{Méthode matricielle}
 
-Premièrement, avec les points et bases qui ont été définis, il est possible de décrire des vecteurs de position locaux constants. Les vecteur-colonnes $\col{r}_{B_o/A_o}^a$ et $\col{r}_{C/B_o}^b$ représentent la géométrie des liens rigides et sont donc constants:
+Premièrement, avec les points et bases qui ont été définis, il est possible de décrire des vecteurs de position locaux constants. Les vecteurs-colonne $\col{r}_{B_o/A_o}^a$ et $\col{r}_{C/B_o}^b$ représentent la géométrie des liens rigides et sont donc constants:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Éléments constants:}& \quad \col{r}_{B_o/A_o}^a =  \left[ \begin{array}{c} 
-0 \\ l_1 \\ 0
-\end{array} \right]  \quad \text{et} \quad  \col{r}_{C/B_o}^b =  \left[ \begin{array}{c} 
-l_2 \\ 0 \\ 0
-\end{array} \right] 
-\end{align} 
+	\text{Éléments constants:}& \quad \col{r}_{B_o/A_o}^a =  \left[ \begin{array}{c}
+																		0 \\ l_1 \\ 0
+	\end{array} \right]  \quad \text{et} \quad  \col{r}_{C/B_o}^b =  \left[ \begin{array}{c}
+																				l_2 \\ 0 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Toutefois, la matrice de rotation ${}^aR^b$ qui décrit l'orientation relative des bases $a$ et $b$ est variable en fonction de l'état du joint rotatif décrit par la variable $\theta$, et le vecteur position $\col{r}_{D_o/C}^b$ est associé à la translation du joint prismatique et fonction de la variable $x$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Éléments variables:}& \quad {}^aR^b(\theta)= R_3(\theta) = \left[ \begin{array}{c c c}
-	c\theta & -s\theta & 0 \\
-	s\theta & c\theta & 0 \\
-	0 & 0 & 1 
-\end{array}  \right]  \quad \text{et} \quad  \col{r}_{D_o/C}^b(x) =  \left[ \begin{array}{c} 
-x \\ 0 \\ 0
-\end{array} \right] 
-\end{align} 
+	\text{Éléments variables:}& \quad {}^aR^b(\theta)= R_3(\theta) = \left[ \begin{array}{c c c}
+																				c\theta & -s\theta & 0 \\
+																				s\theta & c\theta & 0 \\
+																				0 & 0 & 1
+	\end{array}  \right]  \quad \text{et} \quad  \col{r}_{D_o/C}^b(x) =  \left[ \begin{array}{c}
+																					x \\ 0 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 La matrice de rotation peut être construite comme décrit à la section \ref{sec:calmat}, alternativement il est possible d’identifier directement qu'elle correspond ici à une matrice de rotation élémentaire selon l'axe 3.
 
-L'équation de la cinématique pour calculer la positon de l'effecteur est obtenue à partir de la relation vectorielle:
+L'équation de la cinématique pour calculer la position de l'effecteur est obtenue à partir de la relation vectorielle:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{D_o/A_o}   &=  \vec{r}_{D_o/C} + \vec{r}_{C/B_o} + \vec{r}_{B_o/A_o}
-\end{align} 
+	\vec{r}_{D_o/A_o}   &=  \vec{r}_{D_o/C} + \vec{r}_{C/B_o} + \vec{r}_{B_o/A_o}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 que l'on exprime dans la base $a$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D_o/A_o}^a &=  \col{r}_{D_o/C}^a + \col{r}_{C/B_o}^a + \col{r}_{B_o/A_o}^a \\
-\col{r}_{D_o/A_o}^a &=  {}^aR^b  \, \col{r}_{D_o/C}^b + {}^aR^b \, \col{r}_{C/B_o}^b + \col{r}_{B_o/A_o}^a \\
-\col{r}_{D_o/A_o}^a &=   \underbrace{{}^aR^b(\theta)}_{\text{joint rotatif}} \large( \, \, \underbrace{\col{r}_{D_o/C}^b(x)}_{\text{joint prismatique}} \, + \, \col{r}_{C/B_o}^b  \, \, \large) + \col{r}_{B_o/A_o}^a 
-\end{align} 
+	\col{r}_{D_o/A_o}^a &=  \col{r}_{D_o/C}^a + \col{r}_{C/B_o}^a + \col{r}_{B_o/A_o}^a \\
+	\col{r}_{D_o/A_o}^a &=  {}^aR^b  \, \col{r}_{D_o/C}^b + {}^aR^b \, \col{r}_{C/B_o}^b + \col{r}_{B_o/A_o}^a \\
+	\col{r}_{D_o/A_o}^a &=   \underbrace{{}^aR^b(\theta)}_{\text{joint rotatif}} \large( \, \, \underbrace{\col{r}_{D_o/C}^b(x)}_{\text{joint prismatique}} \, + \, \col{r}_{C/B_o}^b  \, \, \large) + \col{r}_{B_o/A_o}^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 %Similairement l'équation de la cinématique pour transformer des coordonnées cartésiennes d'un point $E$ dans le repère de l'effecteur vers le repère global:
 %%%%%%%%%%%%%%%%%%%%
@@ -2593,27 +2602,27 @@ que l'on exprime dans la base $a$:
 %\vec{r}_{E/A}   &=  \vec{r}_{E/D} + \vec{r}_{D/C} + \vec{r}_{C/B} + \vec{r}_{B/A} \\
 %\col{r}_{E/A}^a &=  \col{r}_{E/D}^a + \col{r}_{D/C}^a + \col{r}_{C/B}^a + \col{r}_{B/A}^a \\
 %\col{r}_{E/A}^a &=  {}^aR^b  \, \col{r}_{E/D}^b  + {}^aR^b  \, \col{r}_{D/C}^b + {}^aR^b \, \col{r}_{C/B}^b + \col{r}_{B/A}^a \\
-%\col{r}_{E/A}^a &=   \underbrace{{}^aR^b(\theta)}_{\text{joint rotatif}} [ \, \col{r}_{E/D}^b  \, + \, \underbrace{\col{r}_{D/C}^b(x)}_{\text{joint prismatique}} \, + \, \col{r}_{C/B}^b  \, \,] + \col{r}_{B/A}^a 
-%\end{align} 
+%\col{r}_{E/A}^a &=   \underbrace{{}^aR^b(\theta)}_{\text{joint rotatif}} [ \, \col{r}_{E/D}^b  \, + \, \underbrace{\col{r}_{D/C}^b(x)}_{\text{joint prismatique}} \, + \, \col{r}_{C/B}^b  \, \,] + \col{r}_{B/A}^a
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%
 Il est ensuite possible de substituer par les composantes connues et résoudre l'équation matricielle:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D_o/A_o}^a &=  \left[ \begin{array}{c c c}
-	c\theta & -s\theta & 0 \\
-	s\theta & c\theta & 0 \\
-	0 & 0 & 1 
-\end{array}  \right] \left( \, \left[ \begin{array}{c} 
-x \\ 0 \\ 0
-\end{array} \right]  \, + \, \left[ \begin{array}{c} 
-l_2 \\ 0 \\ 0
-\end{array} \right]   \,  \right) + \left[ \begin{array}{c} 
-0 \\ l_1 \\ 0
-\end{array} \right] = 
-\left[ \begin{array}{c} 
-( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
-\end{array} \right] 
-\end{align} 
+	\col{r}_{D_o/A_o}^a &=  \left[ \begin{array}{c c c}
+									   c\theta & -s\theta & 0 \\
+									   s\theta & c\theta & 0 \\
+									   0 & 0 & 1
+	\end{array}  \right] \left( \, \left[ \begin{array}{c}
+											  x \\ 0 \\ 0
+	\end{array} \right]  \, + \, \left[ \begin{array}{c}
+											l_2 \\ 0 \\ 0
+	\end{array} \right]   \,  \right) + \left[ \begin{array}{c}
+												   0 \\ l_1 \\ 0
+	\end{array} \right] =
+	\left[ \begin{array}{c}
+			   ( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 
@@ -2621,110 +2630,110 @@ l_2 \\ 0 \\ 0
 
 \paragraph{Méthode avec les transformations homogènes}
 
-Alternativement, une façon plus systématique de procéder, est d'associer un repère à chaque lien rigide et de calculer toutes les matrices de transformation entre ces repères. 
+Alternativement, une façon plus systématique de procéder est d'associer un repère à chaque lien rigide et de calculer toutes les matrices de transformation entre ces repères.
 
-La matrice de transformation du repère B vers le repère A implique une matrice de rotation variable selon l'état du joint rotatif, et un vecteur de translation constant:
+La matrice de transformation du repère $B$ vers le repère $A$ implique une matrice de rotation variable selon l'état du joint rotatif, et un vecteur de translation constant:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-^AT^B(\theta) 
-= 
-\left[ \begin{array}{c c } 
-^aR^b(\theta)  & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right]  = 
-\left[ \begin{array}{c c c c} 
-  c\theta & -s\theta & 0 & 0  \\
-	s\theta & c\theta  & 0 & l_1  \\
-	0 & 0 & 1              & 0  \\ 
-	0 & 0 & 0              & 1
-\end{array} \right]
-\end{align} 
+	^AT^B(\theta)
+	=
+	\left[ \begin{array}{c c }
+			   ^aR^b(\theta)  & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+	\end{array} \right]  =
+	\left[ \begin{array}{c c c c}
+			   c\theta & -s\theta & 0 & 0  \\
+			   s\theta & c\theta  & 0 & l_1  \\
+			   0 & 0 & 1              & 0  \\
+			   0 & 0 & 0              & 1
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La matrice de transformation du repère D vers le repère B implique seulement un vecteur de translation variable en fonction de l'état du joint prismatique. Puisque que les bases vectorielles $d$ et $b$ sont alignées la matrice de rotation $^bR^d$ est réduite à la matrice identité:
+La matrice de transformation du repère $D$ vers le repère $B$ implique seulement un vecteur de translation variable en fonction de l'état du joint prismatique. Puisque les bases vectorielles $d$ et $b$ son alignées, la matrice de rotation $^bR^d$ est réduite à la matrice identité:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-^BT^D(x) 
-= 
-\left[ \begin{array}{c c } 
-^bR^d  & \col{r}_{D_o/B_o}^b \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
-= \left[ \begin{array}{c c } 
-I_{3\times3} & \left( \col{r}_{D_o/C}^b(x) + \col{r}_{C/B_o}^b \right) \\ 
-\begin{array}{c c c} 
-0 & 0 & 0 
-\end{array} & 1
-\end{array} \right] 
-= 
-\left[ \begin{array}{c c c c} 
-  1 & 0 & 0 & (x + l_2)  \\
-	0 & 1 & 0 & 0  \\
-	0 & 0 & 1 & 0  \\ 
-	0 & 0 & 0 & 1
-\end{array} \right]
-\end{align} 
+	^BT^D(x)
+	=
+	\left[ \begin{array}{c c }
+			   ^bR^d  & \col{r}_{D_o/B_o}^b \\ 0 \; 0 \; 0 & 1
+	\end{array} \right]
+	= \left[ \begin{array}{c c }
+				 I_{3\times3} & \left( \col{r}_{D_o/C}^b(x) + \col{r}_{C/B_o}^b \right) \\
+				 \begin{array}{c c c}
+					 0 & 0 & 0
+				 \end{array} & 1
+	\end{array} \right]
+	=
+	\left[ \begin{array}{c c c c}
+			   1 & 0 & 0 & (x + l_2)  \\
+			   0 & 1 & 0 & 0  \\
+			   0 & 0 & 1 & 0  \\
+			   0 & 0 & 0 & 1
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Ensuite la pose de l'effecteur peut être décrite par la matrice de transformation du repère $D$ vers le repère $A$ qui est obtenu en multipliant les deux matrices de transformation locales de chaque joint:
+Ensuite, la pose de l'effecteur peut être décrite par la matrice de transformation du repère $D$ vers le repère $A$ qui est obtenu en multipliant les deux matrices de transformation locales de chaque joint:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^AT^D &=  {}^AT^B(\theta) \, {}^BT^D(x) \\
-{}^AT^D &=  
-\left[ \begin{array}{c c c c} 
-  c\theta & -s\theta & 0 & 0  \\
-	s\theta & c\theta  & 0 & l_1  \\
-	0 & 0 & 1              & 0  \\ 
-	0 & 0 & 0              & 1
+{}^AT^D &=
+\left[ \begin{array}{c c c c}
+		   c\theta & -s\theta & 0 & 0  \\
+		   s\theta & c\theta  & 0 & l_1  \\
+		   0 & 0 & 1              & 0  \\
+		   0 & 0 & 0              & 1
 \end{array} \right]
-\left[ \begin{array}{c c c c} 
-  1 & 0 & 0 & (x + l_2)  \\
-	0 & 1 & 0 & 0  \\
-	0 & 0 & 1 & 0  \\ 
-	0 & 0 & 0 & 1
+\left[ \begin{array}{c c c c}
+		   1 & 0 & 0 & (x + l_2)  \\
+		   0 & 1 & 0 & 0  \\
+		   0 & 0 & 1 & 0  \\
+		   0 & 0 & 0 & 1
 \end{array} \right] \\
-{}^AT^D &=  
-\left[ \begin{array}{c c c c} 
-  c\theta & -s\theta & 0 & (x + l_2) c\theta  \\
-	s\theta & c\theta  & 0 & (x + l_2) s\theta + l_1   \\
-	0 & 0 & 1              & 0  \\ 
-	0 & 0 & 0              & 1
+{}^AT^D &=
+\left[ \begin{array}{c c c c}
+		   c\theta & -s\theta & 0 & (x + l_2) c\theta  \\
+		   s\theta & c\theta  & 0 & (x + l_2) s\theta + l_1   \\
+		   0 & 0 & 1              & 0  \\
+		   0 & 0 & 0              & 1
 \end{array} \right]
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Avec la dernière colonne de la matrice ${}^AT^D$, il est possible d'extraire les composantes qui représentent la translation du point $D_o$ dans le repère $A$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{D_o/A_o}^a   &=  \left[ \begin{array}{c} 
-( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
-\end{array} \right] 
-\end{align} 
+	\col{r}_{D_o/A_o}^a   &=  \left[ \begin{array}{c}
+										 ( x + l_2 ) \, c\theta \\ ( x + l_2 ) s\theta  + l_1 \\ 0
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newpage
 \subsection{Les paramètres \textit{Denavit–Hartenberg}}
 
-Les paramètres \textit{DH} (\textit{Denavit–Hartenberg}) consistent en quatre paramètres associés à une convention particulière pour attacher des repères aux liens rigides d'un robot manipulateur. Plutôt que de définir arbitrairement les bases vectorielles et les points d'origine des repères, la convention impose une méthodologie standardisée pour définir les repères et les matrices de transformations associées. Plusieurs librairies de cinématique de robot utilise cette convention, qui a comme principal avantage de décrire la cinématique d'un robot avec un nombre de paramètres et repères minimum.
+Les paramètres \textit{DH} (\textit{Denavit–Hartenberg}) consistent en quatre paramètres associés à une convention particulière pour attacher des repères aux liens rigides d'un robot manipulateur. Plutôt que de définir arbitrairement les bases vectorielles et les points d'origine des repères, la convention impose une méthodologie standardisée pour définir les repères et les matrices de transformations associées. Plusieurs librairies de cinématique de robot utilisent cette convention, qui a comme principal avantage de décrire la cinématique d'un robot avec un nombre de paramètres et repères minimum.
 
 \subsubsection{Convention de positionnement relatif des repères }
-Avec la convention \textit{DH}, il faut placer les axes 3 (ou $z$) des repères sur les axe de rotation des joints révolus et sur les axes de translation des joints prismatiques. Ensuite les axes 1 (ou X) d'un joint sont positionnés relativement à la position du joint précédent (parallèle à la normale commune des axes 3), et ensuite les axes 2 sont placés selon la règle de la main droite. L'axe 1 du premier repère est un choix arbitraire. Il y a aussi plusieurs options lorsque les axes 3 de deux joints consécutifs sont parallèles ou coïncident, donc la convention de permet pas de standardisé la représentation de la cinématique d'un à 100\%. La Figure \ref{fig:dh1} illustre cette convention de définition des repères d'un robot.
+Avec la convention \textit{DH}, il faut placer les axes 3 (ou $z$) des repères sur les axes de rotation des joints révolus et sur les axes de translation des joints prismatiques. Ensuite, les axes 1 (ou $x$) d'un joint sont positionnés relativement à la position du joint précédent (parallèle à la normale commune des axes 3), et ensuite les axes 2 (ou $y$) sont placés selon la règle de la main droite. L'axe 1 du premier repère est un choix arbitraire. Il y a aussi plusieurs options lorsque les axes 3 de deux joints consécutifs sont parallèles ou coïncident, donc la convention ne permet pas de standardiser la représentation de la cinématique d'un robot à 100\%. La Figure \ref{fig:dh1} illustre cette convention de définition des repères d'un robot.
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.90\textwidth]{fig/dh1.jpg}
+	\includegraphics[width=0.90\textwidth]{fig/dh1.jpg}
 	\caption{Positionnement des repères selon la convention des paramètres \textit{DH}}
 	\label{fig:dh1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-\note{Repère attachés au lien rigide précédent}{ Il est à noter que avec cette convention, chaque repère est attaché au lien rigide précédent le joint associé à son axe 3, ce qui diffère de la méthode présentée à la section \ref{sec:cinedirectmethod}. Par exemple à la figure \ref{fig:dh1}, le repère $A$ est fixe et le repère $B$ bouge seulement en fonction de la rotation du 1er joint autour de l'axe $\hat{a}_3$.}
+\note{Repères attachés au lien rigide précédent}{ Il est à noter qu’avec cette convention, chaque repère est attaché au lien rigide précédent le joint associé à son axe 3, ce qui diffère de la méthode présentée à la section \ref{sec:cinedirectmethod}. Par exemple à la figure \ref{fig:dh1}, le repère $A$ est fixe et le repère $B$ bouge seulement en fonction de la rotation du 1er joint autour de l'axe $\hat{a}_3$.}
 
 \subsubsection{Les quatre paramètres \textit{DH} }
-Avec la convention de positionnement des repères, seuls quatre scalaires (deux distance et deux angles) sont suffisants pour décrire la pose relative des deux repères sur deux joints adjacents. Les quatre paramètres sont illustrés à la Figure \ref{fig:dh2}, pour le premier joint d'un robot ou le repère $A$ est fixe et aligné avec l'axe du joint 1, et le le repère $B$ bouge avec le premier lien rigide et est aligné avec le joint 2. Un repère intermédiaire $A'$ est défini à l'intersection de la normale commune et l'axe 3 du repère $A$ pour bien illustrer le sens des 4 paramètres. Le paramètre $d$ représente la distance entre le point d'origine du premier repère $A_o$ et l'intersection de l'axe $\hat{a}_3$ avec la normale commune ($A'_o$).  Le paramètre $\theta$ est l'angle entre le vecteur unitaire $\hat{a}_1$ et la normale commune. Le paramètre $r$ est la longueur de la normale commune. Le paramètre $\alpha$ est l'angle de rotation autour de la normale entre les deux axes des joints $\hat{a}_3$ et $\hat{b}_3$.
+Avec la convention de positionnement des repères, seuls quatre scalaires (deux distances et deux angles) sont suffisants pour décrire la pose relative des deux repères sur deux joints adjacents. Les quatre paramètres sont illustrés à la Figure \ref{fig:dh2}, pour le premier joint d'un robot où le repère $A$ est fixe et aligné avec l'axe du joint 1, et le repère $B$ bouge avec le premier lien rigide et est aligné avec le joint 2. Un repère intermédiaire $A'$ est défini à l'intersection de la normale commune et l'axe 3 du repère $A$ pour bien illustrer le sens des 4 paramètres. Le paramètre $d$ représente la distance entre le point d'origine du premier repère $A_o$ et l'intersection de l'axe $\hat{a}_3$ avec la normale commune ($A'_o$).  Le paramètre $\theta$ est l'angle entre le vecteur unitaire $\hat{a}_1$ et la normale commune. Le paramètre $r$ est la longueur de la normale commune. Le paramètre $\alpha$ est l'angle de rotation autour de la normale entre les deux axes des joints $\hat{a}_3$ et $\hat{b}_3$.
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/dh2.jpg}
+	\includegraphics[width=0.80\textwidth]{fig/dh2.jpg}
 	\caption{Les quatre paramètres \textit{DH}}
 	\label{fig:dh2}
 \end{figure}
@@ -2734,91 +2743,91 @@ Avec la convention de positionnement des repères, seuls quatre scalaires (deux 
 % %%%%%%%%%%%%%%%%%%%
 % \begin{align}
 % \vec{r}_{B_o/A_o} = r \hat{b}_1 + d \hat{a}_3
-% \end{align} 
+% \end{align}
 % %%%%%%%%%%%%%%%%%%%%
 % et l'orientation relative entre les deux bases vectorielles est donnée par:
 
-\note{Consultez une animation vidéo}{ Les paramètres \textit{DH} sont plus facile à comprendre en visualisant une animation 3D, il est fortement conseillé de consulter un vidéo explicatif pour solidifier vos connaissances.}
+\note{Consultez une animation vidéo}{ Les paramètres \textit{DH} sont plus faciles à comprendre en visualisant une animation 3D, il est fortement conseillé de consulter une vidéo explicative pour solidifier vos connaissances.}
 
 
 \subsubsection{Pose relative des repères selon les 4 paramètres}
 
-La matrice de rotation qui relie la pose des deux repère associés à deux joints successifs peut être paramétrée par les quatre paramètres $d$, $\theta$, $r$ et $\alpha$. Le vecteur position qui relie les origines est:
+La matrice de rotation qui relie la pose des deux repères associés à deux joints successifs peut être paramétrée par les quatre paramètres $d$, $\theta$, $r$ et $\alpha$. Le vecteur position qui relie les origines est:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{B_o/A_o} &=  d \, \hat{a}_3 + r \, \hat{b}_1
-\end{align} 
+	\vec{r}_{B_o/A_o} &=  d \, \hat{a}_3 + r \, \hat{b}_1
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
-L'orientation relative peut être exprimée comme la combinaison de deux rotation selon les axes $\hat{a}_3$ et $\hat{b}_1$:
+L'orientation relative peut être exprimée comme la combinaison de deux rotations selon les axes $\hat{a}_3$ et $\hat{b}_1$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^aR^b &= {}^aR_3^{a'}(\theta) {}^{a'}R_1^b(\alpha) \\
 {}^aR_3^{a'}(\theta)  &=
 \left[ \begin{array}{c c c}
-	c\theta & -s\theta & 0 \\
-	s\theta & c\theta & 0 \\
-	0 & 0 & 1 
+		   c\theta & -s\theta & 0 \\
+		   s\theta & c\theta & 0 \\
+		   0 & 0 & 1
 \end{array}  \right]  \\
 {}^{a'}R_1^b(\alpha)  &=
 \left[ \begin{array}{c c c}
-	1 & 0 & 0 \\
-	0 & c\alpha & -s\alpha \\
-	0 & s\alpha & c\alpha 
-\end{array}  \right]  
-\end{align} 
+		   1 & 0 & 0 \\
+		   0 & c\alpha & -s\alpha \\
+		   0 & s\alpha & c\alpha
+\end{array}  \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Les composantes du vecteur position dans la base $a$ sont donc:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}_{B_o/A_o}^a &=  
-\left[ \begin{array}{c}
-0 \\
-0 \\
-d
-\end{array}  \right]  + {}^aR^{a'} \left[ \begin{array}{c}
-r \\
-0 \\
-0
-\end{array}  \right]  = \left[ \begin{array}{c}
-r c\theta \\
-r s\theta \\
-d
-\end{array}  \right] 
-\end{align} 
+	\col{r}_{B_o/A_o}^a &=
+	\left[ \begin{array}{c}
+			   0 \\
+			   0 \\
+			   d
+	\end{array}  \right]  + {}^aR^{a'} \left[ \begin{array}{c}
+												  r \\
+												  0 \\
+												  0
+	\end{array}  \right]  = \left[ \begin{array}{c}
+									   r c\theta \\
+									   r s\theta \\
+									   d
+	\end{array}  \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 La matrice de transformation peut alors être assemblée:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
 {}^AT^{B}(d,\theta,r,\alpha) &=
 \left[ \begin{array}{c c c c }
-c\theta & -s\theta c\alpha & s\theta s\alpha & r c\theta\\
-s\theta & c\theta c\alpha  & -c\theta s\alpha  & r s\theta\\
-0 & s\alpha & c\alpha  &  d\\
-0 & 0 & 0 & 1 
-\end{array}  \right]  
+		   c\theta & -s\theta c\alpha & s\theta s\alpha & r c\theta\\
+		   s\theta & c\theta c\alpha  & -c\theta s\alpha  & r s\theta\\
+		   0 & s\alpha & c\alpha  &  d\\
+		   0 & 0 & 0 & 1
+\end{array}  \right]
 \label{eq:Tdh}
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
-Donc lorsque la convention est utilisée, la matrice de transformation entre deux repères successifs a toujours la forme ci-dessus, et il suffit d'identifier les quatre paramètres DH de chaque joints. 
+Donc lorsque la convention est utilisée, la matrice de transformation entre deux repères successifs a toujours la forme ci-dessus, et il suffit d'identifier les quatre paramètres \textit{DH} de chaque joint.
 
 
 \subsubsection{Exemple pour un robot anthropomorphique avec les paramètres \textit{DH}}
 \label{sec:dhex}
 
-La Figure \ref{fig:dh3} illustre l'utilisation de la convention \textit{DH} pour déterminer la matrice de transformation qui représente la pose de l'effecteur. 
+La Figure \ref{fig:dh3} illustre l'utilisation de la convention \textit{DH} pour déterminer la matrice de transformation qui représente la pose de l'effecteur.
 %
-\textbf{Joint 1} Premièrement l'axe de rotation du 1er joint doit être repéré, et le repère fixe $A$ doit être placé de sorte à aligner sont vecteur unitaire $\hat{a}_3$ avec cet axe. Les autres variables sont arbitraires, ici on a choisi de position l'origine au sol et l'aligner le vecteur unitaire $\hat{a}_1$ avec les autres liens du robot pour la configuration nominale. Ensuite l'axe de rotation du 2e joint doit être repéré et le repère $B$ doit être fixé de sorte à aligner sont vecteur $\hat{b}_3$. L'orientation de $\hat{b}_1$ doit être alignée avec la normale commune entre $\hat{a}_3$ et $\hat{b}_3$, ici comme les axes se croisent la normale est réduite à un seul point et donc l'orientation de $\hat{b}_1$ est arbitraire, il a donc été choisi de l'aligner avec les liens rigides en position neutre. Avec les repères $A$ et $B$ positionnés selon la convention, il est maintenant possible de déterminer les quatre paramètres de la première matrice de transformation. La distance entre l'origine $A_o$ et la normale commune (réduite au point $B_o$) est ici la longueur du premier lien $d= l_1$ et la longueur de la normale commune est nulle $r = 0$. L'angle $\theta$ entre les vecteurs unitaires $\hat{a}_1$ et $\hat{b}_1$ est nul pour la position neutre, mais lorsque le joint 1 va tourner l'angle correspond en fait à la position active $\theta_1$. Finalement l'angle entre $\hat{a}_3$ et $\hat{b}_3$ autour de l'axe $\hat{b}_1$ est égale à $\pi/2$ radians. 
+\textbf{Joint 1} Premièrement l'axe de rotation du 1er joint doit être repéré, et le repère fixe $A$ doit être placé de sorte à aligner sont vecteur unitaire $\hat{a}_3$ avec cet axe. Les autres variables sont arbitraires, ici on a choisi de positionner l'origine au sol et d'aligner le vecteur unitaire $\hat{a}_1$ avec les autres liens du robot pour la configuration nominale. Ensuite l'axe de rotation du 2e joint doit être repéré et le repère $B$ doit être fixé de sorte à aligner son vecteur $\hat{b}_3$. L'orientation de $\hat{b}_1$ doit être aligné avec la normale commune entre $\hat{a}_3$ et $\hat{b}_3$. Ici, comme les axes se croisent, la normale est réduite à un seul point et donc l'orientation de $\hat{b}_1$ est arbitraire, il a donc été choisi de l'aligner avec les liens rigides en position neutre. Avec les repères $A$ et $B$ positionnés selon la convention, il est maintenant possible de déterminer les quatre paramètres de la première matrice de transformation. La distance entre l'origine $A_o$ et la normale commune (réduite au point $B_o$) est ici la longueur du premier lien $d= l_1$ et la longueur de la normale commune est nulle $r = 0$. L'angle $\theta$ entre les vecteurs unitaires $\hat{a}_1$ et $\hat{b}_1$ est nul pour la position neutre, mais lorsque le joint 1 va tourner l'angle correspond en fait à la position active $\theta_1$. Finalement l'angle entre $\hat{a}_3$ et $\hat{b}_3$ autour de l'axe $\hat{b}_1$ est égal à $\pi/2$ radians.
 %
-\textbf{Joint 2 } Pour la prochaine transformation qui caractérise le joint 2, il faut d'abord positionner le repère $C$ selon la convention. Le vecteur unitaire $\hat{c}_3$ est aligné avec l'axe de rotation du 2e joint, et le vecteur unitaire $\hat{c}_1$ est aligné avec la normale commune qui est directement alignée avec $\hat{b}_1$. Donc ici l'orientation de la base $c$ est complètement fixée par la convention. Toutefois comme les axes de rotation du joint 2 et 3 sont parallèle, c'est l'origine $C_o$ qui pourrait être placée n'importe ou sur l'axe de rotation du joint 3 (il y a une infinité de normales communes entre deux axes parallèles). Par simplicité ici on fixe arbitrairement l'origine $C_o$ directement dans l'axe formé par $\hat{b}_1$. Avec le repère $C$ positionné selon la convention il est maintenant possible de déterminer les quatre paramètres \textit{DH}. Le paramètre $d$ est ici nul car le point $B_o$ est coïncident avec la normale commune choisie et le paramètre $r=l_2$ car la normale commune coïncide directement avec le 2e lien rigide. Ensuite, l'angle $\theta$ entre les vecteurs unitaires $\hat{b}_1$ et $\hat{c}_1$ est nul pour la position neutre, mais lorsque le joint 1 va tourner l'angle correspond en fait à la position active du 2e joint $\theta_2$. Finalement l'angle entre $\hat{b}_3$ et $\hat{c}_3$ est nul donc $\alpha=0$. 
+\textbf{Joint 2 } Pour la prochaine transformation qui caractérise le joint 2, il faut d'abord positionner le repère $C$ selon la convention. Le vecteur unitaire $\hat{c}_3$ est aligné avec l'axe de rotation du 2e joint, et le vecteur unitaire $\hat{c}_1$ est aligné avec la normale commune qui est directement alignée avec $\hat{b}_1$. Donc ici l'orientation de la base $c$ est complètement fixée par la convention. Toutefois comme les axes de rotation du joint 2 et 3 sont parallèles, c'est l'origine $C_o$ qui pourrait être placée n'importe où sur l'axe de rotation du joint 3 (il y a une infinité de normales communes entre deux axes parallèles). Par simplicité ici on fixe arbitrairement l'origine $C_o$ directement dans l'axe formé par $\hat{b}_1$. Avec le repère $C$ positionné selon la convention il est maintenant possible de déterminer les quatre paramètres \textit{DH}. Le paramètre $d$ est ici nul car le point $B_o$ est coïncident avec la normale commune choisie et le paramètre, $r=l_2$ car la normale commune coïncide directement avec le 2e lien rigide. Ensuite, l'angle $\theta$ entre les vecteurs unitaires $\hat{b}_1$ et $\hat{c}_1$ est nul pour la position neutre, mais lorsque le joint 1 va tourner l'angle correspond en fait à la position active du 2e joint $\theta_2$. Finalement l'angle entre $\hat{b}_3$ et $\hat{c}_3$ est nul donc $\alpha=0$.
 %
-\textbf{Joint 3 } Pour la dernière transformation, il n'y a pas d'axe de rotation de joint puisque que c'est l'effecteur qui reste à localiser, on choisi ici arbitrairement de garder la même orientation que la base précédente. Avec ce choix, la pose du repère $D$ par rapport au repère $C$ a exactement la même structure que celle du repère $C$ par rapport au repère $B$. La seule différence est les variables impliquées qui sont $\theta_3$ et $l_3$. On trouve donc $d=0$, $\theta= \theta_3$, $r=l_3$ et $\alpha=0$ comme paramètres \textit{DH} pour le joint 3.
+\textbf{Joint 3 } Pour la dernière transformation, il n'y a pas d'axe de rotation de joint puisque c'est l'effecteur qui reste à localiser, on choisit ici arbitrairement de garder la même orientation que la base précédente. Avec ce choix, la pose du repère $D$ par rapport au repère $C$ a exactement la même structure que celle du repère $C$ par rapport au repère $B$. La seule différence est les variables impliquées qui sont $\theta_3$ et $l_3$. On trouve donc $d=0$, $\theta= \theta_3$, $r=l_3$ et $\alpha=0$ comme paramètres \textit{DH} pour le joint 3.
 %
-Ensuite, il suffit d'utiliser la formule donnée à l'équation \eqref{eq:Tdh} pour calculer les matrices de transformation entre chaque repère, et de les multiplier ensemble pour calculer la matrice de transformation totale. Avec la méthode des paramètres \textit{DH}, le plus long de la démarche est donc de bien positionner et déterminer les paramètres.  
+Ensuite, il suffit d'utiliser la formule donnée à l'équation \eqref{eq:Tdh} pour calculer les matrices de transformation entre chaque repère, et de les multiplier ensemble pour calculer la matrice de transformation totale. Avec la méthode des paramètres \textit{DH}, le plus long de la démarche est donc de bien positionner et déterminer les paramètres.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.90\textwidth]{fig/dh3.jpg}
+	\includegraphics[width=0.90\textwidth]{fig/dh3.jpg}
 	\caption{Exemple de modélisation de la cinématique d'un robot manipulateur anthropomorphique avec la convention des paramètres \textit{DH}}
 	\label{fig:dh3}
 \end{figure}
@@ -2841,17 +2850,17 @@ Les chaînes cinématiques fermées, sont des assemblages mécaniques où les li
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.50\textwidth]{closed_chain.png}
-	\caption{Chaine cinématique fermée (robot parallèle)}
+	\includegraphics[width=0.50\textwidth]{closed_chain.png}
+	\caption{Chaîne cinématique fermée (robot parallèle)}
 	\label{fig:closed_chain}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Le calcul de la cinématique directe de ce type de mécanisme peux être plus compliqué car chaque chemin parallèle qui relie l'effecteur à la base d'un robot rajoute une contrainte au système. Les mouvements des joints ne sont alors pas nécessairement indépendants. Pour une configuration $\col{q}$ des joints, il peut ne pas y avoir aucune pose de l'effecteur qui satisfait toutes les contraintes ou potentiellement plusieurs poses de l'effecteur qui satisfont les contraintes.
+Le calcul de la cinématique directe de ce type de mécanisme peut être plus compliqué, car chaque chemin parallèle qui relie l'effecteur à la base d'un robot rajoute une contrainte au système. Les mouvements des joints ne sont alors pas nécessairement indépendants. Pour une configuration $\col{q}$ des joints, il peut ne pas y avoir aucune pose de l'effecteur qui satisfait toutes les contraintes ou potentiellement plusieurs poses de l'effecteur qui satisfont les contraintes.
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.50\textwidth]{closed_chain_fwd_2_sol.png}
+	\includegraphics[width=0.50\textwidth]{closed_chain_fwd_2_sol.png}
 	\caption{Chaîne cinématique fermée avec deux solutions (théoriques) pour la pose de l'effecteur selon une configuration $q_1$, $q_2$ et $q_3$ des joints. }
 	\label{fig:closed_chain_fwd_2_sol}
 \end{figure}
@@ -2872,17 +2881,17 @@ Détails à venir!
 La cinématique inverse consiste à calculer des coordonnées de l'espace des joints $\col{q}$ qui mènent à une position désirée de l'effecteur. Par exemple, pour la translation, la cinématique inverse est le calcul de la fonction inverse de l'équation \eqref{eq:kinfwdtrans}:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{q} = f^{-1}_{Trans}( \col{r} )
-\label{eq:kininv}
-\end{align} 
+	\col{q} = f^{-1}_{Trans}( \col{r} )
+	\label{eq:kininv}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 
 \subsection{Chaîne cinématique ouverte}
 
-Pour les chaînes cinématiques ouvertes, comme la plupart des robots manipulateurs, le calcul de la cinématique directe est sans ambiguïté: une configuration $\col{q}$ mène toujours à une seule position de l'effecteur possible. Toutefois, il existe plusieurs configurations $\col{q}$ qui peuvent mener à la même position de l'effecteur, voir figure \ref{fig:invkin2} par exemple. De plus, pour certaines positions de l'effecteur (ceux qui ne sont pas dans l'espace de travail), l'équation \eqref{eq:kininv} n'aura pas de solutions. La cinématique inverse est donc généralement plus compliquée que la cinématique directe, elle consiste à résoudre une fonction hautement non-linéaire qui possède potentiellement aucune ou plusieurs solutions. De plus, même lorsque qu'une ou plusieurs solutions existent, il n'est pas toujours possible de résoudre analytiquement l'équation \eqref{eq:kininv}. Il est alors nécessaire d'utiliser des méthodes numériques pour trouver des solutions, comme la méthode de Newton-Raphson par exemple. Pour la plupart des architectures de robots industriels, la cinématique inverse peut être résolue analytiquement. Pour les bras manipulateurs à 6 DLL, le critère pour que la cinématique inverse puisse être résolue analytiquement est que l'axe de trois joints rotatifs séquentiels se croise en un point. La plupart des robots industriels ont leurs 3 derniers DDL configurés en un poignet (\textit{wrist} en anglais) qui consiste en trois joints rotatifs avec leurs trois axes qui se croisent en un seul point, et ils rencontrent donc ce critère.
+Pour les chaînes cinématiques ouvertes, comme la plupart des robots manipulateurs, le calcul de la cinématique directe est sans ambiguïté: une configuration $\col{q}$ mène toujours à une seule position de l'effecteur possible. Toutefois, il existe plusieurs configurations $\col{q}$ qui peuvent mener à la même position de l'effecteur, voir figure \ref{fig:invkin2} par exemple. De plus, pour certaines positions de l'effecteur (ceux qui ne sont pas dans l'espace de travail), l'équation \eqref{eq:kininv} n'aura pas de solutions. La cinématique inverse est donc généralement plus compliquée que la cinématique directe, elle consiste à résoudre une fonction hautement non linéaire qui possède potentiellement aucune ou plusieurs solutions. De plus, même lorsqu'une ou plusieurs solutions existent, il n'est pas toujours possible de résoudre analytiquement l'équation \eqref{eq:kininv}. Il est alors nécessaire d'utiliser des méthodes numériques pour trouver des solutions, comme la méthode de Newton-Raphson par exemple. Pour la plupart des architectures de robots industriels, la cinématique inverse peut être résolue analytiquement. Pour les bras manipulateurs à 6 DDL, le critère pour que la cinématique inverse puisse être résolue analytiquement est que l'axe de trois joints rotatifs séquentiels se croise en un point. La plupart des robots industriels ont leurs 3 derniers DDL configurés en un poignet (\textit{wrist} en anglais) qui consiste en trois joints rotatifs avec leurs trois axes qui se croisent en un seul point, et ils satisfont donc ce critère.
 
-En pratique, les contrôleurs de robot trouvent généralement indirectement les solutions à l'équation \eqref{eq:kininv}. Une méthode standard est de contrôler les déplacement locaux de l'effecteur en direction de la position $\col{r}$ désirée, voir section \ref{sec:positioncontrol}, une méthode qui revient à faire une descente du gradient itérative comme avec la méthode de Newton-Raphson mais en temps réel avec le vrai système.
+En pratique, les contrôleurs de robot trouvent généralement indirectement les solutions à l'équation \eqref{eq:kininv}. Une méthode standard est de contrôler les déplacements locaux de l'effecteur en direction de la position $\col{r}$ désirée, voir section \ref{sec:positioncontrol}, une méthode qui revient à faire une descente du gradient itérative comme avec la méthode de Newton-Raphson, mais en temps réel avec le vrai système.
 
 
 \subsection{Exemple: cinématique inverse d'un robot à deux joints rotatifs}
@@ -2891,86 +2900,87 @@ Cet exemple illustre une résolution analytique de la cinématique inverse d'un 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Bases et points de références]{
-				\includegraphics[width=0.35\textwidth]{invkin1.png}
-				\label{fig:invkin1}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-				\subfloat[Deux configurations possible pour une position ($x$,$y$) désirée]{
-				\includegraphics[width=0.35\textwidth]{invkin2.png}
-				\label{fig:invkin2}}
-        \caption{Cinématique inverse d'un robot à deux joints rotatif }
-				\label{fig:invkin}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Bases et points de références]{
+		\includegraphics[width=0.35\textwidth]{invkin1.png}
+		\label{fig:invkin1}}
+	%%%%
+	\hspace{10pt}
+	%%%%
+	\subfloat[Deux configurations possibles pour une position ($x$,$y$) désirée]{
+		\includegraphics[width=0.35\textwidth]{invkin2.png}
+		\label{fig:invkin2}}
+	\caption{Cinématique inverse d'un robot à deux joints rotatif }
+	\label{fig:invkin}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 L'objectif est ici de calculer la fonction de cinématique inverse:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{q} = f^{-1}_{Trans}\left( \col{r}^a_{D_o/B_o} \right) \\
-\left[ \begin{array}{c}
-\theta_1 \\ \theta_2
- \end{array} \right] 
-= f^{-1}_{Trans}\left( \left[ \begin{array}{c }
-x \\ y
- \end{array} \right]  \right)
-\end{align} 
+	\col{q} = f^{-1}_{Trans}\left( \col{r}^a_{D_o/B_o} \right) \\
+	\left[ \begin{array}{c}
+			   \theta_1 \\ \theta_2
+	\end{array} \right]
+	= f^{-1}_{Trans}\left( \left[ \begin{array}{c }
+									  x \\ y
+	\end{array} \right]  \right)
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Premièrement la relation vectorielle est établie:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{D_o/B_o} &=  \vec{r}_{D_o/C_o} + \vec{r}_{C_o/B_o} \\
-\vec{r}_{D_o/B_o} &=  l_3 \hat{c}_1     + l_2 \hat{b}_1
-\end{align} 
+	\vec{r}_{D_o/B_o} &=  \vec{r}_{D_o/C_o} + \vec{r}_{C_o/B_o} \\
+	\vec{r}_{D_o/B_o} &=  l_3 \hat{c}_1     + l_2 \hat{b}_1
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Ensuite il est possible de relier la position $x$ et $y$ de l'effecteur avec l'angle $\theta_2$ en calculant la longueur du vecteur $\vec{r}_{D_o/B_o}$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\| \vec{r}_{D_o/B_o} \|^2  &=  \| \vec{r}_{D_o/C_o} + \vec{r}_{C_o/B_o} \|^2 \\
-x^2 + y^2 &=  (l_3 \hat{c}_1 + l_2 \hat{b}_1) \bullet (l_3 \hat{c}_1+ l_2 \hat{b}_1) \\
-x^2 + y^2 &=  l_2^2 + l_3^2 + 2 l_2 l_3 ( \hat{c}_1 \bullet \hat{b}_1 ) \\
-x^2 + y^2 &=  l_2^2 + l_3^2 + 2 l_2 l_3 \cos \theta_2
-\end{align} 
+	\| \vec{r}_{D_o/B_o} \|^2  &=  \| \vec{r}_{D_o/C_o} + \vec{r}_{C_o/B_o} \|^2 \\
+	x^2 + y^2 &=  (l_3 \hat{c}_1 + l_2 \hat{b}_1) \bullet (l_3 \hat{c}_1+ l_2 \hat{b}_1) \\
+	x^2 + y^2 &=  l_2^2 + l_3^2 + 2 l_2 l_3 ( \hat{c}_1 \bullet \hat{b}_1 ) \\
+	x^2 + y^2 &=  l_2^2 + l_3^2 + 2 l_2 l_3 \cos \theta_2
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
-À noter que la dérivation ci-dessus est équivalente à utiliser la loi des \textit{cosinus}. Il est donc possible d'obtenir l'angle $\theta_2$ comme une fonctions des coordonnées désirées de l'effecteur et des paramètres géométriques du robot:
+À noter que la dérivation ci-dessus est équivalente à utiliser la loi des \textit{cosinus}. Il est donc possible d'obtenir l'angle $\theta_2$ comme une fonction des coordonnées désirées de l'effecteur et des paramètres géométriques du robot:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\cos \theta_2 = \frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3}
-\label{eq:invkintheta2}
-\end{align} 
+	\cos \theta_2 = \frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3}
+	\label{eq:invkintheta2}
+\end{align}
 %%%%%%%%%%%%%%%%%%%
 L'équation \eqref{eq:invkintheta2} peut avoir 0, 1 ou 2 solutions. Si la position désirée ($x$,$y$) est hors de l'espace de travail, il n'y a pas de solution:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\frac{ (x^2 + y^2) - (l_2^2 + l_3^2)}{2 l_2 l_3} \; > 1 \quad\Rightarrow\quad \text{Aucune solution}
-\end{align} 
+	\frac{ (x^2 + y^2) - (l_2^2 + l_3^2)}{2 l_2 l_3} \; > 1 \quad\Rightarrow\quad \text{Aucune solution}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Si la position désirée ($x$,$y$) est sur la limite de l'espace de travail, il y a une seule solution où les deux liens rigides sont alignés:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3} \; = 1 \quad\Rightarrow\quad \text{Une solution:} \quad  \theta_2 = 0
-\end{align} 
+	\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3} \; = 1 \quad\Rightarrow\quad \text{Une solution:} \quad  \theta_2 = 0
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Si la position désirée ($x$, $y$) est dans l'espace de travail, il y a deux solutions comme illustré à la figure \ref{fig:invkin2}:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3} \; < 1 \quad\Rightarrow\quad \text{Deux solutions:} \quad  \theta_2 = \pm \arccos \left(\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3}\right)
-\end{align} 
+	\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3} \; < 1 \quad\Rightarrow\quad \text{Deux solutions:} \quad  \theta_2 = \pm \arccos \left(\frac{ (x^2 + y^2) - (l_2^2 + l_3^2) }{2 l_2 l_3}\right)
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 Il est aussi possible d'isoler l'angle $\theta_1$ sous forme explicite, comme illustré à la figure \ref{fig:invkin_theta1}:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\theta_1 = \arctan \left( \frac{y}{x} \right) + \arctan \left( \frac{l_2 s\theta_2}{l_1 + l_2 c\theta_2} \right)
-\end{align} 
+	\theta_1 = \arctan \left( \frac{y}{x} \right) + \arctan \left( \frac{l_3 s\theta_2}{l_2 + l_3 c\theta_2} \right)
+\end{align}
 %%%%%%%%%%%%%%%%%%%%s
 
+%%TODO: Ajuster l'image pour utiliser les l2 et l3 de l'exemple en cours.%%
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.60\textwidth]{invkin_theta1.png}
+	\includegraphics[width=0.60\textwidth]{invkin_theta1.png}
 	\caption{Calcul de $\theta_1$}
 	\label{fig:invkin_theta1}
 \end{figure}
@@ -2982,31 +2992,31 @@ Il est aussi possible d'isoler l'angle $\theta_1$ sous forme explicite, comme il
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Chaîne cinématique fermée}
 
-Contrairement aux chaînes cinématiques ouvertes, la cinématique inverse d'une chaîne cinématique fermée est généralement plus facile à calculer que la cinématique ouverte. Par exemple, comme illustré à la figure \ref{fig:closed_chain_invkin} pour un robot parallèle simple, si la pose de l'effecteur est précisée, alors les variables de joints $q_i$ peuvent être facilement calculés et il y a une seule solution. L'état des joints prismatique peut être calculée sachant la longueurs des vecteurs $\vec{r}_{B_i/A_i}$:
+Contrairement aux chaînes cinématiques ouvertes, la cinématique inverse d'une chaîne cinématique fermée est généralement plus facile à calculer que la cinématique ouverte. Par exemple, comme illustré à la figure \ref{fig:closed_chain_invkin} pour un robot parallèle simple, si la pose de l'effecteur est précisée, alors les variables de joints $q_i$ peuvent être facilement calculées et il y a une seule solution. L'état des joints prismatique peut être calculé sachant la longueur des vecteurs $\vec{r}_{B_i/A_i}$:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-q_i + l_i &= \| \vec{r}_{B_i/A_i} \|
-\end{align} 
+	q_i + l_i &= \| \vec{r}_{B_i/A_i} \|
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 et la position des points $B_i$ et $A_i$ peut être déterminée avec la géométrie du robot et la pose de l'effecteur. Les variables $q_i$ pourraient donc être calculées ainsi:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-q_i &= \| \vec{r}_{B_i/A_i} \| - l_i \\
-q_i &= \| \vec{r}_{B_i/T_o} +  \vec{r}_{T_o/W_o} - \vec{r}_{A_i/W_o} \| - l_i \\
-q_i &= \sqrt{\left[  \col{r}_{B_i/T_o}^w + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
-\right]^T \left[  \col{r}_{B_i/T_o}^w + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
-\right]} - l_i \\
-q_i &= \sqrt{\left[  {}^wR^t \, \col{r}_{B_i/T_o}^t + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
-\right]^T \left[  {}^wR^t \, \col{r}_{B_i/T_o}^t + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w \right]} - l_i
-\end{align} 
+	q_i &= \| \vec{r}_{B_i/A_i} \| - l_i \\
+	q_i &= \| \vec{r}_{B_i/T_o} +  \vec{r}_{T_o/W_o} - \vec{r}_{A_i/W_o} \| - l_i \\
+	q_i &= \sqrt{\left[  \col{r}_{B_i/T_o}^w + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
+		\right]^T \left[  \col{r}_{B_i/T_o}^w + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
+		\right]} - l_i \\
+	q_i &= \sqrt{\left[  {}^wR^t \, \col{r}_{B_i/T_o}^t + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w
+		\right]^T \left[  {}^wR^t \, \col{r}_{B_i/T_o}^t + \col{r}_{T_o/W_o}^w - \col{r}_{A_i/W_o}^w \right]} - l_i
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
-où ${}^wR^t$ et $\col{r}_{T_o/W_o}^w$ sont des fonctions de la pose de l'effecteur et $\col{r}_{B_i/T_o}^t$ et $\col{r}_{A_i/W_o}^w$ sont des vecteur-colonnes constants et seulement fonction de la géométrie du robot. 
+où ${}^wR^t$ et $\col{r}_{T_o/W_o}^w$ sont des fonctions de la pose de l'effecteur et $\col{r}_{B_i/T_o}^t$ et $\col{r}_{A_i/W_o}^w$ sont des vecteurs-colonne constants et seulement fonction de la géométrie du robot.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.50\textwidth]{closed_chain_invkin.png}
-	\caption{Cinématique inverse d'un chaine cinématique fermée (robot parallèle)}
+	\includegraphics[width=0.50\textwidth]{closed_chain_invkin.png}
+	\caption{Cinématique inverse d'une chaîne cinématique fermée (robot parallèle)}
 	\label{fig:closed_chain_invkin}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%
@@ -3022,69 +3032,69 @@ où ${}^wR^t$ et $\col{r}_{T_o/W_o}^w$ sont des fonctions de la pose de l'effect
 Cinématique des robots manipulateurs:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{
-\col{r} 
-}_{\text{Coordonnées dans l'espace de la tâche}}
-= f( 
-\underbrace{
-\col{q} 
-}_{\text{Coordonnées dans l'espace des joints}}
-) 
-\end{align} 
+	\underbrace{
+		\col{r}
+	}_{\text{Coordonnées dans l'espace de la tâche}}
+	= f(
+	\underbrace{
+		\col{q}
+	}_{\text{Coordonnées dans l'espace des joints}}
+	)
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 Vecteurs de position:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r}_{B/A}  &=  \quad \text{Vecteur position du point $B$ par rapport au point $A$} \\
-\vec{r}_{Z/A}  &=   \vec{r}_{Z/Y} + \vec{r}_{Y/X} + ... + \vec{r}_{C/B} + \vec{r}_{B/A}  \\
-\vec{r}_{B/A}  &= - \vec{r}_{A/B}
-\end{align} 
+	\vec{r}_{B/A}  &=  \quad \text{Vecteur position du point $B$ par rapport au point $A$} \\
+	\vec{r}_{Z/A}  &=   \vec{r}_{Z/Y} + \vec{r}_{Y/X} + ... + \vec{r}_{C/B} + \vec{r}_{B/A}  \\
+	\vec{r}_{B/A}  &= - \vec{r}_{A/B}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Bases vectorielle:
+Bases vectorielles:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Base } a = \{ \hat{a}_{1} , \hat{a}_{2} , \hat{a}_{3} \}
-\end{align} 
+	\text{Base } a = \{ \hat{a}_{1} , \hat{a}_{2} , \hat{a}_{3} \}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Vecteur géométrique vs. vecteur-colonne de composantes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
-\quad & \quad
-\col{r}^{a} = \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right]  \\
-\vec{r} = \sum_{i} r_i^a \hat{a}_i 
-\quad & \quad
-r_i^a = \vec{r} \bullet \hat{a}_i
-\end{align} 
+	\vec{r} = r_1^a \, \hat{a}_{1} + r_2^a \, \hat{a}_{2} + r_3^a \, \hat{a}_{3}
+	\quad & \quad
+	\col{r}^{a} = \left[ \begin{array}{c} r_1^a \\ r_2^a \\ r_3^a  \end{array} \right]  \\
+	\vec{r} = \sum_{i} r_i^a \hat{a}_i
+	\quad & \quad
+	r_i^a = \vec{r} \bullet \hat{a}_i
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Matrice de rotation:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^aR^b &= 
-\left[ \begin{array}{c c c} 
-\hat{a}_1 \bullet \hat{b}_1 & \hat{a}_2 \bullet \hat{b}_1 & \hat{a}_3 \bullet \hat{b}_1 \\
-\hat{a}_1 \bullet \hat{b}_2 & \hat{a}_2 \bullet \hat{b}_2 & \hat{a}_3 \bullet \hat{b}_2 \\
-\hat{a}_1 \bullet \hat{b}_3 & \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_3 \bullet \hat{b}_3 
-\end{array} \right] = 
-\left[ \begin{array}{c c c} 
-	\left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
+{}^aR^b &=
+\left[ \begin{array}{c c c}
+		   \hat{a}_1 \bullet \hat{b}_1 & \hat{a}_2 \bullet \hat{b}_1 & \hat{a}_3 \bullet \hat{b}_1 \\
+		   \hat{a}_1 \bullet \hat{b}_2 & \hat{a}_2 \bullet \hat{b}_2 & \hat{a}_3 \bullet \hat{b}_2 \\
+		   \hat{a}_1 \bullet \hat{b}_3 & \hat{a}_2 \bullet \hat{b}_3 & \hat{a}_3 \bullet \hat{b}_3
+\end{array} \right] =
+\left[ \begin{array}{c c c}
+		   \left[ \begin{array}{c} \\ \col{b}_1^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_2^a \\  \\ \end{array}  \right] & \left[ \begin{array}{c} \\ \col{b}_3^a \\  \\ \end{array}  \right]
 \end{array} \right]
-\end{align} 
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Propriétés des matrices de rotation:
 %%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r}^a &= {}^aR^b \, \col{r}^b \\
-{}^aR^c &=  {}^aR^b \, {}^bR^c \\
-{}^aR^b_{ij} &= \hat{a}_i \bullet \hat{b}_j \\
-R(\theta)^{-1} &= R(-\theta) \\
-R^{-1} &= R^T \\
-({}^bR^a)^{-1} &= {}^aR^b
+	\col{r}^a &= {}^aR^b \, \col{r}^b \\
+	{}^aR^c &=  {}^aR^b \, {}^bR^c \\
+	{}^aR^b_{ij} &= \hat{a}_i \bullet \hat{b}_j \\
+	R(\theta)^{-1} &= R(-\theta) \\
+	R^{-1} &= R^T \\
+	({}^bR^a)^{-1} &= {}^aR^b
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -3092,32 +3102,32 @@ R^{-1} &= R^T \\
 Repère:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Repère } A  = \text{Base } a + \text{Origine } A_o = \{ A_o , \hat{a}_{1} , \hat{a}_{2} , \hat{a}_{3} \} 
-\end{align} 
+	\text{Repère } A  = \text{Base } a + \text{Origine } A_o = \{ A_o , \hat{a}_{1} , \hat{a}_{2} , \hat{a}_{3} \}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Matrice de transformation:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-{}^AT^B &= 
-\left[ \begin{array}{c c } 
-^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
-\end{array} \right] 
-\end{align} 
+{}^AT^B &=
+\left[ \begin{array}{c c }
+		   ^aR^b & \col{r}_{B_o/A_o}^a \\ 0 \; 0 \; 0 & 1
+\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-Transformation avec les paramètres DH:
+Transformation avec les paramètres \textit{DH}:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-T(d,\theta,r,\alpha) &=
-\left[ \begin{array}{c c c c }
-c\theta & -s\theta c\alpha & s\theta s\alpha & r c\theta\\
-s\theta & c\theta c\alpha  & -c\theta s\alpha  & r s\theta\\
-0 & s\alpha & c\alpha  &  d\\
-0 & 0 & 0 & 1 
-\end{array}  \right]  
-\label{eq:Tdh}
-\end{align} 
+	T(d,\theta,r,\alpha) &=
+	\left[ \begin{array}{c c c c }
+			   c\theta & -s\theta c\alpha & s\theta s\alpha & r c\theta\\
+			   s\theta & c\theta c\alpha  & -c\theta s\alpha  & r s\theta\\
+			   0 & s\alpha & c\alpha  &  d\\
+			   0 & 0 & 0 & 1
+	\end{array}  \right]
+	\label{eq:Tdh}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%
 

--- a/src/manip/dynamic.tex
+++ b/src/manip/dynamic.tex
@@ -11,8 +11,8 @@ Chapitre en construction!
 The general form of the equations of motion of robotic systems (interconnected rigid body driven by motors) is:
 %
 \begin{align}
-H(\col{q}) \col{\ddot{q}} + C(\col{q},\col{\dot{q}}) \col{\dot{q}} + D \col{\dot{q}} + \col{g}(\col{q}) = B(\col{q}) \col{\tau} 
-\label{eq:manipulator}
+	H(\col{q}) \col{\ddot{q}} + C(\col{q},\col{\dot{q}}) \col{\dot{q}} + D \col{\dot{q}} + \col{g}(\col{q}) = B(\col{q}) \col{\tau}
+	\label{eq:manipulator}
 \end{align}
 %
 where $\col{q}$ is the generalized coordinates vector, $H$ is the inertia matrix, $C$ is the Coriolis/centrifugal force matrix, $D$ is a damping matrix, $\col{g}$ is the gravitational forces vector and $B$ is a matrix mapping motor torques $\col{\tau}$ into generalized forces.
@@ -20,32 +20,32 @@ where $\col{q}$ is the generalized coordinates vector, $H$ is the inertia matrix
 Kinetic energy is given by:
 %
 \begin{align}
-\frac{1}{2} \col{\dot{q}}^T H(\col{q}) \col{\dot{q}} 
-\label{eq:kinetic}
+	\frac{1}{2} \col{\dot{q}}^T H(\col{q}) \col{\dot{q}}
+	\label{eq:kinetic}
 \end{align}
 %
-Conservation of energy also give the following relation:
+Conservation of energy also gives the following relation:
 %
 \begin{align}
-\dot{H} = C + C^T
-\label{eq:cener}
+	\dot{H} = C + C^T
+	\label{eq:cener}
 \end{align}
 %
 On occasion, dependence notation is dropped and $\col{c}$ is used to represent all state dependent forces, leading to the short form:
 %
 \begin{align}
-H \col{\ddot{q}} + \col{c} = B \col{\tau} 
-\label{eq:manipulator_short}
+	H \col{\ddot{q}} + \col{c} = B \col{\tau}
+	\label{eq:manipulator_short}
 \end{align}
 
 \subsection{Coordinate systems}
 \label{sec:coord}
 
-%Fig. \ref{fig:coord} shows all the used coordinates systems. 
+%Fig. \ref{fig:coord} shows all the used coordinates systems.
 %
 \begin{figure}[t]
 	\centering
-		\includegraphics[width=0.99\textwidth]{coord.jpg}
+	\includegraphics[width=0.99\textwidth]{coord.jpg}
 	\caption{Coordinate systems}%
 	\label{fig:coord}
 \end{figure}
@@ -53,17 +53,17 @@ H \col{\ddot{q}} + \col{c} = B \col{\tau}
 The following equation represents the most general case:
 %
 \begin{align}
-H \col{\ddot{q}} + C \col{\dot{q}} + D \col{\dot{q}} + \col{g} =  \underbrace{ J_a^T(\col{q}) R^T }_{B(\col{q})}  \col{\tau} + J_e^T(\col{q}) \col{f}_e + J_c^T(\col{q}) \col{f}_c
-\label{eq:manipulator_gen}
+	H \col{\ddot{q}} + C \col{\dot{q}} + D \col{\dot{q}} + \col{g} =  \underbrace{ J_a^T(\col{q}) R^T }_{B(\col{q})}  \col{\tau} + J_e^T(\col{q}) \col{f}_e + J_c^T(\col{q}) \col{f}_c
+	\label{eq:manipulator_gen}
 \end{align}
 %
 Where coordinates transforms are defined by:
 %
 \begin{align}
-\col{\dot{r}}   &= J_e( \col{q} ) \col{\dot{q} }  \quad \text{ from joint-space to end-effector   } \\
-\col{\dot{a}}   &= J_a( \col{q} ) \col{\dot{q} }  \quad \text{ from joint-space to actuator-space } \\
-\col{w }        &= R              \col{\dot{a} }  \quad\quad \text{ from actuator-space to rotor-space } 
-\label{eq:coord_transform2}
+	\col{\dot{r}}   &= J_e( \col{q} ) \col{\dot{q} }  \quad \text{ from joint-space to end-effector   } \\
+	\col{\dot{a}}   &= J_a( \col{q} ) \col{\dot{q} }  \quad \text{ from joint-space to actuator-space } \\
+	\col{w }        &= R              \col{\dot{a} }  \quad\quad \text{ from actuator-space to rotor-space }
+	\label{eq:coord_transform2}
 \end{align}
 %
 
@@ -76,24 +76,24 @@ This section presents equations for representing contact situations.
 \subsubsection{Kinematic constraints}
 \label{sec:constraints}
 %
-If a robotic manipulator enter contact with a fixed object, then some DoF are constrained. In the case of a bilateral constraint, the constraint can be expressed as:
+If a robotic manipulator enters in contact with a fixed object, then some DoF are constrained. In the case of a bilateral constraint, the constraint can be expressed as:
 \begin{align}
-\col{\phi}( \col{ q } ) = 0
-\label{eq:constraint}
+	\col{\phi}( \col{ q } ) = 0
+	\label{eq:constraint}
 \end{align}
 %
 The time-derivative of the constraint must also be equal to zero, which gives some constraints in terms of velocity and acceleration:
 \begin{align}
-\frac{d \col{\phi}( \col{ q } ) }{dt}     &= J_c( \col{ q } ) \col{\dot{q}}  = 0 \\
-\frac{d^2 \col{\phi}( \col{ q } ) }{dt^2} &= J_c( \col{ q } ) \col{\ddot{q}}  + \dot{J}_c( \col{ q } ) \col{\dot{q}} = 0 
-\label{eq:constraint_diff}
+	\frac{d \col{\phi}( \col{ q } ) }{dt}     &= J_c( \col{ q } ) \col{\dot{q}}  = 0 \\
+	\frac{d^2 \col{\phi}( \col{ q } ) }{dt^2} &= J_c( \col{ q } ) \col{\ddot{q}}  + \dot{J}_c( \col{ q } ) \col{\dot{q}} = 0
+	\label{eq:constraint_diff}
 \end{align}
 %
 when $J_c$ is the constraint Jacobian:
 %
 \begin{align}
-J_c( \col{ q } )                    &= \frac{d \col{\phi}( \col{ q } ) }{d\col{ q }}
-\label{eq:constraint_jaco}
+	J_c( \col{ q } )                    &= \frac{d \col{\phi}( \col{ q } ) }{d\col{ q }}
+	\label{eq:constraint_jaco}
 \end{align}
 
 \subsubsection{Constraint forces}
@@ -102,22 +102,22 @@ J_c( \col{ q } )                    &= \frac{d \col{\phi}( \col{ q } ) }{d\col{ 
 The constraint Jacobian can be used to map constraint forces $\col{f}_c$ to generalized forces in the EoM:
 %
 \begin{align}
-H \col{\ddot{q}} + \col{c} = B \col{\tau} + J_c( \col{ q } )^T  \col{f}_c
-\label{eq:manipulator_constraint}
+	H \col{\ddot{q}} + \col{c} = B \col{\tau} + J_c( \col{ q } )^T  \col{f}_c
+	\label{eq:manipulator_constraint}
 \end{align}
 %
-Solving for $\col{\ddot{q}}$ in eq. \eqref{eq:manipulator_constraint} and substituting in eq. \eqref{eq:constraint_diff}, it is possible to get and expression for the constraint forces $\col{f}_c$ as a function of states and applied torques:
+Solving for $\col{\ddot{q}}$ in eq. \eqref{eq:manipulator_constraint} and substituting in eq. \eqref{eq:constraint_diff}, it is possible to get an expression for the constraint forces $\col{f}_c$ as a function of states and applied torques:
 %
 \begin{align}
-\col{f}_c = \left( J_c H^{-1} J_c^T \right)^{-1} \left(  J_c H^{-1} [\col{c} - B \col{\tau} ] - \dot{J}_c( \col{ q } ) \col{\dot{q}}   \right)
-\label{eq:const_forces}
+	\col{f}_c = \left( J_c H^{-1} J_c^T \right)^{-1} \left(  J_c H^{-1} [\col{c} - B \col{\tau} ] - \dot{J}_c( \col{ q } ) \col{\dot{q}}   \right)
+	\label{eq:const_forces}
 \end{align}
 %
-Alternatively, it possible to solve for acceleration $\col{\ddot{q}}$ and constraints forces $\col{f}_c$ simultaneously by solving the following system of equations:
+Alternatively, it is possible to solve for acceleration $\col{\ddot{q}}$ and constraints forces $\col{f}_c$ simultaneously by solving the following system of equations:
 %
 \begin{align}
-\left[ \begin{array}{c c } 	H & -J_c^T  \\ J_c 	& 0  	\end{array} \right] \left[ \begin{array}{c} \col{\ddot{q}}  \\ \col{f}_c \end{array} \right] = \left[ \begin{array}{c}  B \col{\tau} - \col{c}   \\ -\dot{J}_c \col{\dot{q}}  \end{array} \right]
-\label{eq:manipulator_constraint_eom}
+	\left[ \begin{array}{c c }     H & -J_c^T  \\ J_c     & 0    \end{array} \right] \left[ \begin{array}{c} \col{\ddot{q}}  \\ \col{f}_c \end{array} \right] = \left[ \begin{array}{c}  B \col{\tau} - \col{c}   \\ -\dot{J}_c \col{\dot{q}}  \end{array} \right]
+	\label{eq:manipulator_constraint_eom}
 \end{align}
 
 
@@ -127,83 +127,83 @@ Alternatively, it possible to solve for acceleration $\col{\ddot{q}}$ and constr
 When the robot first enters contact with a fixed object, impulsive contact forces will act on the system. Integrating eq. \eqref{eq:manipulator_constraint} over the short impact interval gives:
 %
 \begin{align}
-\int{ ( H \col{\ddot{q}} + \col{c} ) dt } &= \int{ ( B \col{\tau} + J_c( \col{ q } )^T  \col{f}_c ) dt } \\
-H \col{\dot{q}}^+ - H \col{\dot{q}}^- &= J_c( \col{ q } )^T  \int{  \col{f}_c dt }
-\label{eq:manipulator_impact}
+	\int{ ( H \col{\ddot{q}} + \col{c} ) dt } &= \int{ ( B \col{\tau} + J_c( \col{ q } )^T  \col{f}_c ) dt } \\
+	H \col{\dot{q}}^+ - H \col{\dot{q}}^- &= J_c( \col{ q } )^T  \int{  \col{f}_c dt }
+	\label{eq:manipulator_impact}
 \end{align}
 %
 where any non-impulsive forces are neglected during the short impact interval. Projecting onto constrained coordinates (multiplying by $J_c H^{-1}$) gives:
 %
 \begin{align}
-J_c \col{\dot{q}}^+ - J_c \col{\dot{q}}^- &= J_c H^{-1} J_c^T  \int{  \col{f}_c dt }
-\label{eq:manipulator_impact2}
+	J_c \col{\dot{q}}^+ - J_c \col{\dot{q}}^- &= J_c H^{-1} J_c^T  \int{  \col{f}_c dt }
+	\label{eq:manipulator_impact2}
 \end{align}
 %
 Then assuming a sticky inelastic impact (no bouncing), then the constraint is respected after the impact ($J_c \col{\dot{q}}^+=0$) and it is possible to solve for the impact force:
 %
 \begin{align}
-\int{  \col{f}_c dt } &= - \left( J_c H^{-1} J_c^T \right)^{-1}  J_c \col{\dot{q}}^-
-\label{eq:manipulator_impact_force}
+	\int{  \col{f}_c dt } &= - \left( J_c H^{-1} J_c^T \right)^{-1}  J_c \col{\dot{q}}^-
+	\label{eq:manipulator_impact_force}
 \end{align}
 %
 and also for the velocity after the impact:
 %
 \begin{align}
-\col{\dot{q}}^+ &= - \Big[ I - H^{-1} J_c^T \left( J_c H^{-1} J_c^T \right)^{-1} J_c \Big] \col{\dot{q}}^-
-\label{eq:manipulator_impact_velocity}
+	\col{\dot{q}}^+ &= - \Big[ I - H^{-1} J_c^T \left( J_c H^{-1} J_c^T \right)^{-1} J_c \Big] \col{\dot{q}}^-
+	\label{eq:manipulator_impact_velocity}
 \end{align}
 %
 Or change in velocity:
 %
 \begin{align}
-\Delta \col{\dot{q}} &=  \Big[ H^{-1} J_c^T \left( J_c H^{-1} J_c^T \right)^{-1} J_c \Big] \col{\dot{q}}^-
-\label{eq:manipulator_impact_velocity_delta}
+	\Delta \col{\dot{q}} &=  \Big[ H^{-1} J_c^T \left( J_c H^{-1} J_c^T \right)^{-1} J_c \Big] \col{\dot{q}}^-
+	\label{eq:manipulator_impact_velocity_delta}
 \end{align}
 %
 
-Alternatively, it possible to solve for velocity $\col{\dot{q}}^+$ and impulsive forces $\int{ \col{f}_c dt }$ simultaneously by solving the following system of $n+c$ equations:
+Alternatively, it is possible to solve for velocity $\col{\dot{q}}^+$ and impulsive forces $\int{ \col{f}_c dt }$ simultaneously by solving the following system of $n+c$ equations:
 %
 \begin{align}
-\left[ \begin{array}{c c } 	H & -J_c^T  \\ J_c 	& 0  	\end{array} \right] \left[ \begin{array}{c} \col{\dot{q}}^+  \\ \int{ \col{f}_c dt }\end{array} \right] = \left[ \begin{array}{c}  	H \col{\dot{q}}^-   \\ 0  \end{array} \right]
-\label{eq:manipulator_impact_eom}
+	\left[ \begin{array}{c c }     H & -J_c^T  \\ J_c     & 0    \end{array} \right] \left[ \begin{array}{c} \col{\dot{q}}^+  \\ \int{ \col{f}_c dt }\end{array} \right] = \left[ \begin{array}{c}      H \col{\dot{q}}^-   \\ 0  \end{array} \right]
+	\label{eq:manipulator_impact_eom}
 \end{align}
 
 \begin{table}[htbp]
 	\centering
-	\caption{Nomenclature pour la dynamique dans l'espace des joints}	% Table caption must be placed on top of the table %
-		\begin{tabular}{ c c l r }
-        \hline \hline
-				\multicolumn{4}{c}{Scalars} \\
-				\hline \hline
-			$n$             &  :  & number of DoF                                              & \\
-			$m$             &  :  & number of actuators                                        & \\
-			$c$             &  :  & number of contact constraints                              & \\
-			$o$             &  :  & number of end-effector coordinates                         & \\ 
-			$i$             &  :  & index for DoF                                              & \\ 
-			\hline \hline
-			\multicolumn{4}{c}{Vectors} \\
-			\hline \hline
-			$\col{\tau}$    &  :  & Actuator forces/torques                                    & $m$  \\
-			$\col{q}$       &  :  & Joint coordinates position vector                          & $n$  \\
-			$\col{w}$       &  :  & Actuator coordinates velocity vector                          & $m$  \\ 
-			$\col{g}$       &  :  & Gravitational forces vector                                & $n$  \\
-			$\col{c}$       &  :  & Sum of state-dependent generalized forces                  & $n$  \\
-			$\col{\phi}$    &  :  & Constraint vector                                          & $c$  \\
-			$\col{f}_c$     &  :  & Contact forces vector                                      & $c$  \\
-			$\col{f}_e$     &  :  & End-effector external forces vector                        & $o$  \\
-			$\col{r}$       &  :  & End-effector position vector                               & $o$  \\
-			\hline \hline
-			\multicolumn{4}{c}{Matrices} \\
-			\hline \hline
-			$H$             &  :  & Inertia matrix                                             & $n$ x $n$ \\
-			$D$             &  :  & Damping matrix                                             & $n$ x $n$ \\
-			$C$             &  :  & Coriolis/Centrifugal forces matrix                         & $n$ x $n$ \\
-			$B$             &  :  & Generalized forces matrix                                  & $n$ x $m$ \\
-			$J_a$           &  :  & Actuator coordinates / joint coordinates Jacobian matrix   & $m$ x $n$ \\
-			$J_e$           &  :  & Task-space coordinates / joint coordinates Jacobian matrix & $o$ x $n$ \\
-			$J_c$           &  :  & Contact constraints Jacobian matrix                        & $c$ x $n$  \\
+	\caption{Nomenclature pour la dynamique dans l'espace des joints}  % Table caption must be placed on top of the table %
+	\begin{tabular}{ c c l r }
 		\hline \hline
-        \end{tabular}		
+		\multicolumn{4}{c}{Scalars} \\
+		\hline \hline
+		$n$             &  :  & number of DoF                                              & \\
+		$m$             &  :  & number of actuators                                        & \\
+		$c$             &  :  & number of contact constraints                              & \\
+		$o$             &  :  & number of end-effector coordinates                         & \\
+		$i$             &  :  & index for DoF                                              & \\
+		\hline \hline
+		\multicolumn{4}{c}{Vectors} \\
+		\hline \hline
+		$\col{\tau}$    &  :  & Actuator forces/torques                                    & $m$  \\
+		$\col{q}$       &  :  & Joint coordinates position vector                          & $n$  \\
+		$\col{w}$       &  :  & Actuator coordinates velocity vector                          & $m$  \\
+		$\col{g}$       &  :  & Gravitational forces vector                                & $n$  \\
+		$\col{c}$       &  :  & Sum of state-dependent generalized forces                  & $n$  \\
+		$\col{\phi}$    &  :  & Constraint vector                                          & $c$  \\
+		$\col{f}_c$     &  :  & Contact forces vector                                      & $c$  \\
+		$\col{f}_e$     &  :  & End-effector external forces vector                        & $o$  \\
+		$\col{r}$       &  :  & End-effector position vector                               & $o$  \\
+		\hline \hline
+		\multicolumn{4}{c}{Matrices} \\
+		\hline \hline
+		$H$             &  :  & Inertia matrix                                             & $n$ x $n$ \\
+		$D$             &  :  & Damping matrix                                             & $n$ x $n$ \\
+		$C$             &  :  & Coriolis/Centrifugal forces matrix                         & $n$ x $n$ \\
+		$B$             &  :  & Generalized forces matrix                                  & $n$ x $m$ \\
+		$J_a$           &  :  & Actuator coordinates / joint coordinates Jacobian matrix   & $m$ x $n$ \\
+		$J_e$           &  :  & Task-space coordinates / joint coordinates Jacobian matrix & $o$ x $n$ \\
+		$J_c$           &  :  & Contact constraints Jacobian matrix                        & $c$ x $n$  \\
+		\hline \hline
+	\end{tabular}
 	\label{tab:nom}
 \end{table}
 
@@ -213,22 +213,22 @@ Alternatively, it possible to solve for velocity $\col{\dot{q}}^+$ and impulsive
 \newpage
 \section{Hybrid system dynamics}
 
-Hybrid dynamical system can be represented in the general form:
+Hybrid dynamical systems can be represented in the general form:
 %
 \begin{align}
-\text{Continuous evolution: } \left(  \dot{\col{x}} , \dot{k} \right) &=  \left( \, f_k( \col{x} , \col{u} , \col{d} ) \, , \, 0 \, \right) \\
-\text{Discrete jumps: } \left(  \col{x}^+ , k^+ \right) &=  \left( h_{ij}( \col{x}^- , \col{u}^- ) , j \right) \quad\text{if}\quad \left(  \col{x} , k , \col{u} \right) \in D_{ij}  
+	\text{Continuous evolution: } \left(  \dot{\col{x}} , \dot{k} \right) &=  \left( \, f_k( \col{x} , \col{u} , \col{d} ) \, , \, 0 \, \right) \\
+	\text{Discrete jumps: } \left(  \col{x}^+ , k^+ \right) &=  \left( h_{ij}( \col{x}^- , \col{u}^- ) , j \right) \quad\text{if}\quad \left(  \col{x} , k , \col{u} \right) \in D_{ij}
 \end{align}
 %
-where $\col{x}$ is a continuous state vector, and $k$ is a discrete mode and $D_{ij}$ is the domain mapping conditions leading to a transition $k:i \rightarrow j$. For robotic systems, the discrete mode can represent discrete configurations of the robot , like discrete modes in the control law or contact/non-contact conditions. The jump map then represents the impulsive response when contact is made. 
+where $\col{x}$ is a continuous state vector, and $k$ is a discrete mode and $D_{ij}$ is the domain mapping conditions leading to a transition $k:i \rightarrow j$. For robotic systems, the discrete mode can represent discrete configurations of the robot , like discrete modes in the control law or contact/non-contact conditions. The jump map then represents the impulsive response when contact is made.
 
 \subsection{Switched system}
 
 A restricted class of hybrid system, called switched system, are hybrid systems for which the jump map for continuous state is the identify function:
 %
 \begin{align}
-\text{Continuous evolution: } \left(  \dot{\col{x}} , \dot{k} \right) &=  \left( \, f_k( \col{x} , \col{u} , \col{d} ) \, , \, 0 \, \right) \\
-\text{Discrete jumps: } \left(  \col{x}^+ , k^+ \right) &=  \left( \col{x}^- , j \right) \quad\text{if}\quad \left(  \col{x} , k , \col{u} \right) \in D_{ij} 
+	\text{Continuous evolution: } \left(  \dot{\col{x}} , \dot{k} \right) &=  \left( \, f_k( \col{x} , \col{u} , \col{d} ) \, , \, 0 \, \right) \\
+	\text{Discrete jumps: } \left(  \col{x}^+ , k^+ \right) &=  \left( \col{x}^- , j \right) \quad\text{if}\quad \left(  \col{x} , k , \col{u} \right) \in D_{ij}
 \end{align}
 %
 
@@ -237,7 +237,8 @@ A restricted class of hybrid system, called switched system, are hybrid systems 
 In the situation where the discrete operating mode $k$ is a control input, then there is no need to keep track of discrete mode evolution and only the piece-wise continuous differential equations are sufficient to model the system evolution:
 %
 \begin{align}
-\dot{\col{x}} = f_k( \col{x} , \col{u} , \col{d} ) 
+	\dot{\col{x}} = f_k( \col{x} , \col{u} , \col{d} )
 \end{align}
 %
-A robot with a continuous dynamics but with a control law using discrete modes of operation would be of this category. 
+A robot with a continuous dynamics but with a control law using discrete modes of operation would be of this category.
+

--- a/src/manip/manip-intro.tex
+++ b/src/manip/manip-intro.tex
@@ -1,8 +1,8 @@
 \chapter{Introduction}
 
-La première partie de ces notes discute de la science pour modéliser et analyser le mouvement des robots manipulateurs. Dans un contexte d'ingénierie, modéliser un système robotique est essentiel lors de la phase de conception, par exemple pour valider qu'une géométrie de bras permet d'atteindre plusieurs positions désirées avec son effecteur (i.e. l'outil au bout du bras), et aussi lors de la programmation pour coordonner les différents moteurs et articulations d'un robot. Les outils présentés dans ces notes sont pertinents pour toute machine et/ou système avec plusieurs articulations, on parlera toutefois de \textit{robot} dans ces notes pour alléger le texte.
+La première partie de ces notes discute de la science pour modéliser et analyser le mouvement des robots manipulateurs. Dans un contexte d'ingénierie, modéliser un système robotique est essentiel lors de la phase de conception, par exemple pour valider qu'une géométrie de bras permet d'atteindre plusieurs positions désirées avec son effecteur (c.-à-d. l'outil au bout du bras), et aussi lors de la programmation pour coordonner les différents moteurs et articulations d'un robot. Les outils présentés dans ces notes sont pertinents pour toute machine et/ou système avec plusieurs articulations, on parlera toutefois de \textit{robot} dans ces notes pour alléger le texte.
 
-%Les methodes presentes ici ne sont pas exclusive aux robots, 
+%Les methodes presentes ici ne sont pas exclusive aux robots,
 
 \section{Modélisation et analyse des robots manipulateurs}
 
@@ -11,43 +11,43 @@ Comme illustré à la figure \ref{fig:fields}, la modélisation des robots peut 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.95\textwidth]{fields.png}
+	\includegraphics[width=0.95\textwidth]{fields.png}
 	\caption{Quatre grands domaines de base de l'analyse de robots manipulateurs  }
 	\label{fig:fields}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les méthodes de \textbf{cinématique directe} visent à calculer la position finale de l'effecteur d'un robot en fonction du positionnement des articulations. Lorsqu'on parle de \textbf{cinématique inverse}, l'objectif est de déterminer le positionnement des articulations qui mène à une position désirée de l'effecteur du robot. Mathématiquement, l'analyse consiste à construire et solutionner la fonction non-linéaire qui relie les coordonnées de l'effecteur, groupées dans un vecteur-colonne $\col{r}$, aux coordonnées des joints, groupées dans un vecteur-colonne $\col{q}$:
+Les méthodes de \textbf{cinématique directe} visent à calculer la position finale de l'effecteur d'un robot en fonction du positionnement des articulations. Lorsqu'on parle de \textbf{cinématique inverse}, l'objectif est de déterminer le positionnement des articulations qui mène à une position désirée de l'effecteur du robot. Mathématiquement, l'analyse consiste à construire et résoudre la fonction non linéaire qui relie les coordonnées de l'effecteur, groupées dans un vecteur-colonne $\col{r}$, aux coordonnées des joints, groupées dans un vecteur-colonne $\col{q}$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Cinématique directe:}  \quad \col{r} = f\left( \, \col{q} \, \right)  \quad  \text{inverse:} \quad \col{q} = f^{-1}\left( \, \col{r}  \, \right) 
+	\text{Cinématique directe:}  \quad \col{r} = f\left( \, \col{q} \, \right)  \quad  \text{inverse:} \quad \col{q} = f^{-1}\left( \, \col{r}  \, \right)
 \end{equation}
 %%%%%%%%%%%%%%%
-Un des grands défis est que la fonction inverse $f^{-1}\left( \, \col{r}  \, \right)$ peut avoir plusieurs ou aucune solution, selon les coordonnées de l'effecteur qui sont visées. 
+Un des grands défis est que la fonction inverse $f^{-1}\left( \, \col{r}  \, \right)$ peut avoir plusieurs ou aucune solution, selon les coordonnées de l'effecteur qui sont visées.
 
-Le domaine appelé la \textbf{cinématique différentielle} vise à calculer la vitesse de l'effecteur du robot en fonction de la vitesse des moteurs qui actionnent les articulations, ou vice-versa. Mathématiquement, l'analyse consiste à construire la matrice Jacobienne $J(\col{q})$, qui permet de relier le vecteur-colonne $\col{\dot{r}}$ des vitesses de l'effecteur (la dérivée temporelle des coordonnées $\col{r}$) et le le vecteur-colonne $\col{\dot{q}}$ des vitesses des joints (la dérivée temporelle des coordonnées $\col{q}$):
+Le domaine appelé la \textbf{cinématique différentielle} vise à calculer la vitesse de l'effecteur du robot en fonction de la vitesse des moteurs qui actionnent les articulations, ou vice-versa. Mathématiquement, l'analyse consiste à construire la matrice Jacobienne $J(\col{q})$, qui permet de relier le vecteur-colonne $\col{\dot{r}}$ des vitesses de l'effecteur (la dérivée temporelle des coordonnées $\col{r}$) et le vecteur-colonne $\col{\dot{q}}$ des vitesses des joints (la dérivée temporelle des coordonnées $\col{q}$):
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Cinématique différentielle directe:} \quad \col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}   \quad \text{inverse:} \quad \col{\dot{q}} = J^{\#}\left( \, \col{q} \, \right) \, \col{\dot{r}}
+	\text{Cinématique différentielle directe:} \quad \col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}   \quad \text{inverse:} \quad \col{\dot{q}} = J^{\#}\left( \, \col{q} \, \right) \, \col{\dot{r}}
 \end{equation}
 %%%%%%%%%%%%%%%
-Un des défis est que pour certaines configurations du manipulateur la matrice $J(\col{q})$ est singulière, i.e. son inverse $J^{-1}$ n'existe pas. On dit alors que le robot est sur une singularité cinématique où il est impossible de faire bouger l'effecteur dans certaines directions. Un autre défis est que lorsque le nombre de joints est différent du nombre de coordonnées de l'effecteur, la matrice $J$ est rectangulaire et on doit alors utiliser la notion de pseudo-inverse notée $J^{\#}$.
+Un des défis est que pour certaines configurations du manipulateur la matrice $J(\col{q})$ est singulière, c.-à-d. son inverse $J^{-1}$ n'existe pas. On dit alors que le robot est sur une singularité cinématique où il est impossible de faire bouger l'effecteur dans certaines directions. Un autre défi est que lorsque le nombre de joints est différent du nombre de coordonnées de l'effecteur, la matrice $J$ est rectangulaire et on doit alors utiliser la notion de pseudo-inverse notée $J^{\#}$.
 
 Pour les robots manipulateurs, les analyses de \textbf{statique} visent généralement à déterminer les forces/couples nécessaires aux moteurs/actionneurs d'un robot pour le maintenir en place en fonction des forces externes, ou vice-versa. Mathématique, l'analyse peut aussi utiliser la matrice Jacobienne pour faire la relation entre le vecteur-colonne de couples des moteurs $\col{\tau}$ et le vecteur-colonne des forces externes $\col{f}_{ext}$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Statique:} \quad \col{\tau} = J^T\left( \, \col{q} \, \right) \, \col{f}_{ext}   
+	\text{Statique:} \quad \col{\tau} = J^T\left( \, \col{q} \, \right) \, \col{f}_{ext}
 \end{equation}
 %%%%%%%%%%%%%%%
 
-Finalement, la \textbf{dynamique} est le domaine qui vise à déterminer les équations différentielles qui représentent la relation entre l'accélération des joints d'un robot et les forces appliquées. Mathématiquement, l'analyse consiste à construire et analyser une équation différentielle non-linéaire (reliant les coordonnées des joints $\col{q}$, la vitesse des joints $\col{\dot{q}}$, l'accélération des joints $\col{\ddot{q}}$, les couples appliqués $\col{\tau}$ et les forces externes $\col{f}_{ext}$) qui prend la forme:
+Finalement, la \textbf{dynamique} est le domaine qui vise à déterminer les équations différentielles qui représentent la relation entre l'accélération des joints d'un robot et les forces appliquées. Mathématiquement, l'analyse consiste à construire et analyser une équation différentielle non linéaire (reliant les coordonnées des joints $\col{q}$, la vitesse des joints $\col{\dot{q}}$, l'accélération des joints $\col{\ddot{q}}$, les couples appliqués $\col{\tau}$ et les forces externes $\col{f}_{ext}$) qui prend la forme:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\text{Dynamique:} \quad H(\col{q}) \col{\ddot{q}} + C(\col{q},\col{\dot{q}}) \col{\dot{q}} + D \col{\dot{q}} + \col{g}(\col{q}) = \col{\tau} - J^T(\col{q}) \, \col{f}_{ext}   
-\label{eq:manipulator}
+	\text{Dynamique:} \quad H(\col{q}) \col{\ddot{q}} + C(\col{q},\col{\dot{q}}) \col{\dot{q}} + D \col{\dot{q}} + \col{g}(\col{q}) = \col{\tau} - J^T(\col{q}) \, \col{f}_{ext}
+	\label{eq:manipulator}
 \end{align}
 %%%%%%%%%%%%%%%
-où les termes $H(\col{q}) \col{\ddot{q}}$ et $C(\col{q},\col{\dot{q}}) \col{\dot{q}}$ représentent des effets inertiels, le terme $D \col{\dot{q}}$ représente des forces dissipatives (ex.: friction) et le terme $\col{g}(\col{q})$ représente des forces gravitationnelles. Cette équation c'est $\vec{F}=m\vec{a}$ appliquée aux robots manipulateurs. 
+où les termes $H(\col{q}) \col{\ddot{q}}$ et $C(\col{q},\col{\dot{q}}) \col{\dot{q}}$ représentent des effets inertiels, le terme $D \col{\dot{q}}$ représente des forces dissipatives (ex.: friction) et le terme $\col{g}(\col{q})$ représente des forces gravitationnelles. Cette équation, c'est $\vec{F}=m\vec{a}$ appliqué aux robots manipulateurs.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -57,13 +57,13 @@ où les termes $H(\col{q}) \col{\ddot{q}}$ et $C(\col{q},\col{\dot{q}}) \col{\do
 
 \section{L'importance de l'algèbre linéaire pour la robotique}
 
-Contrairement à plusieurs machines et systèmes, les robots sont caractérisés par la présence de plusieurs dimensions. Les entrées sont multiples, par exemple les forces/vitesses des multiples moteurs, et les sorties aussi, par exemple la position $(x,y,z)$ de l'outil. Les quantités intéressantes en robotique (entrées et sorties des analyses) peuvent donc être représentées par des vecteur-colonnes, et les relations entre ceux-ci peuvent être représentées par des opérations matricielles qui simplifient grandement les analyses. L'algèbre linéaire est donc un des outils mathématiques les plus importants pour l'ingénieur roboticien. 
+Contrairement à plusieurs machines et systèmes, les robots sont caractérisés par la présence de plusieurs dimensions. Les entrées sont multiples, par exemple les forces/vitesses des multiples moteurs, et les sorties aussi, par exemple la position $(x,y,z)$ de l'outil. Les quantités intéressantes en robotique (entrées et sorties des analyses) peuvent donc être représentées par des vecteurs-colonne, et les relations entre ceux-ci peuvent être représentées par des opérations matricielles qui simplifient grandement les analyses. L'algèbre linéaire est donc un des outils mathématiques les plus importants pour l'ingénieur roboticien.
 
 
 \newpage
 \section{L'approche présentée dans ces notes}
 
-L'approche de modélisation mise de l'avant dans ces notes ce résume à la séquence:
+L'approche de modélisation mise de l'avant dans ces notes se résume à la séquence:
 \begin{enumerate}
 	\item Décrire le problème avec des vecteurs géométriques symboliques;
 	\item Choisir des bases appropriées;
@@ -71,12 +71,12 @@ L'approche de modélisation mise de l'avant dans ces notes ce résume à la séq
 	\item Déterminer la solution numérique avec les outils de l'algèbre linéaire.
 \end{enumerate}
 
-La Figure \ref{fig:approchemodelisation} donne une aperçu de cette approche pour un problème de cinématique directe.
+La Figure \ref{fig:approchemodelisation} donne un aperçu de cette approche pour un problème de cinématique directe.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.7\textwidth]{approchemodelisation.jpg}
+	\includegraphics[width=0.7\textwidth]{approchemodelisation.jpg}
 	\caption{Aperçu des grandes lignes de l'approche de modélisation présentée dans ces notes}
 	\label{fig:approchemodelisation}
 \end{figure}
@@ -84,12 +84,12 @@ La Figure \ref{fig:approchemodelisation} donne une aperçu de cette approche pou
 
 \section{Organisation des notes de cours (partie \ref{sec:manip})}
 
-Le chapitre \ref{sec:robotmanip} introduit la nomenclature et les concepts de base impliqués dans l'analyse et la modélisation des robots manipulateurs. 
+Le chapitre \ref{sec:robotmanip} introduit la nomenclature et les concepts de base impliqués dans l'analyse et la modélisation des robots manipulateurs.
 
-Le chapitre \ref{sec:cine1} présente des méthodes mathématiques pour modéliser la cinématique des robots manipulateurs. Premièrement, les systèmes de coordonnées importants pour les robots manipulateurs sont introduits. Ensuite, l'utilisation des vecteurs géométriques, des bases vectorielles et des repères pour représenter la position est présentée. Finalement, ces notions sont appliquées à la résolution des problèmes de cinématique pour les robots manipulateurs. 
+Le chapitre \ref{sec:cine1} présente des méthodes mathématiques pour modéliser la cinématique des robots manipulateurs. Premièrement, les systèmes de coordonnées importants pour les robots manipulateurs sont introduits. Ensuite, l'utilisation des vecteurs géométriques, des bases vectorielles et des repères pour représenter la position est présentée. Finalement, ces notions sont appliquées à la résolution des problèmes de cinématique pour les robots manipulateurs.
 
-Le chapitre \ref{sec:cinediff} présente des méthodes pour analyser la cinématique différentielle des robots manipulateurs. 
+Le chapitre \ref{sec:cinediff} présente des méthodes pour analyser la cinématique différentielle des robots manipulateurs.
 
-Le chapitre \ref{sec:static} présente des méthodes pour analyser la statique des robots manipulateurs. 
+Le chapitre \ref{sec:static} présente des méthodes pour analyser la statique des robots manipulateurs.
 
-Le chapitre \ref{sec:dynamic} présente des méthodes pour analyser la dynamique des robots manipulateurs. 
+Le chapitre \ref{sec:dynamic} présente des méthodes pour analyser la dynamique des robots manipulateurs.

--- a/src/manip/manip-lexique.tex
+++ b/src/manip/manip-lexique.tex
@@ -3,129 +3,130 @@
 \section{Lexique}
 
 \begin{center}
-\begin{tabular}{  p{3.5cm} p{3.5cm} p{7cm} }
+	\begin{tabular}{  p{3.5cm} p{3.5cm} p{7cm} }
 %\caption{Définitions techniques }
 %\label{def}
-\hline 
-\textbf{Terme technique} & \textbf{En anglais} & \textbf{Définition} \\ \hline\hline \\
+		\hline
+		\textbf{Terme technique} & \textbf{En anglais} & \textbf{Définition} \\ \hline\hline \\
 %%
-Robot Manipulateur &  Manipulator Robot &
-Robot avec une base fixe qui a comme tâche de positionner dans l'espace un objet ou un outil.
-\\  &  \\ 
-Actionneur &  Actuator &
-Dispositif qui transforme l'énergie en travail mécanique. Typiquement des moteurs électriques et des vérins pneumatiques ou hydrauliques pour les robots.
-\\  &  \\ 
-Effecteur  & End-effector &
-L'endroit où est situé l'objet ou l'outil manipulé par un robot.
-\\   &  \\
-Corps rigide & Rigid body &
-Un modèle idéal d'un objet qui ne se déforme pas même lorsque soumis à des forces externes.
-\\   &  \\ 
-Joint & Joint &
-Jonction mécanique permettant un mouvement relatif entre deux pièces. 
-\\  &  \\ 
-Système de coordonnées &  Coordinate system &
-Ensemble de scalaires (angles ou positions) qui permettent de paramétrer la position/configuration d'un système. 
-\\  &  \\ 
-Degrés-de-Liberté (DDL) & Degree-of-Freedom (DoF) &
-Le nombre de variable indépendante qui permettent de paramétrer dans l'espace la position/configuration d'un système. 
-\\  &  \\ 
-Base vectorielle  & Vector basis &
-Trois vecteurs unitaires qui définissent une orientation. 
-\\  &  \\ 
-Base vectorielle orthonormée & Orthogonal Vector basis &
-Trois vecteurs unitaires orthogonaux qui définissent une orientation. 
-\\  &  \\ 
-Origine &  Origin &
-Un point de référence pour la mesure des positions.
-\\  &  \\ 
-Repère &  Frame &
-Combinaison d'une origine et d'une base vectorielle orthonormée.
-\\  &  \\ 
-Système de coordonnées cartésiennes & Cartesian coordinate system &
-Ensemble de trois scalaires qui déterminent la position d'un point par rapport à une origine et trois axes orthogonaux. %(définis par une base vectorielle orthonormée)
-\\   &  \\  
-Référentiel & Reference frame &
-Point de vue choisi pour analyser/observer un mouvement.
-\\  &  \\ 
-\hline
-\label{tab}
-\end{tabular}
+		Robot Manipulateur &  Manipulator Robot &
+		Robot avec une base fixe qui a comme tâche de positionner dans l'espace un objet ou un outil.
+		\\  &  \\
+		Actionneur &  Actuator &
+		Dispositif qui transforme l'énergie en travail mécanique. Typiquement des moteurs électriques et des vérins pneumatiques ou hydrauliques pour les robots.
+		\\  &  \\
+		Effecteur  & End-effector &
+		L'endroit où est situé l'objet ou l'outil manipulé par un robot.
+		\\   &  \\
+		Corps rigide & Rigid body &
+		Un modèle idéal d'un objet qui ne se déforme pas, même lorsque soumis à des forces externes.
+		\\   &  \\
+		Joint & Joint &
+		Jonction mécanique permettant un mouvement relatif entre deux pièces.
+		\\  &  \\
+		Système de coordonnées &  Coordinate system &
+		Ensemble de scalaires (angles ou positions) qui permettent de paramétrer la position/configuration d'un système.
+		\\  &  \\
+		Degrés-de-Liberté (DDL) & Degree-of-Freedom (DoF) &
+		Le nombre de variables indépendantes qui permettent de paramétrer dans l'espace la position/configuration d'un système.
+		\\  &  \\
+		Base vectorielle  & Vector basis &
+		Trois vecteurs unitaires qui définissent une orientation.
+		\\  &  \\
+		Base vectorielle orthonormée & Orthogonal Vector basis &
+		Trois vecteurs unitaires orthogonaux qui définissent une orientation.
+		\\  &  \\
+		Origine &  Origin &
+		Un point de référence pour la mesure des positions.
+		\\  &  \\
+		Repère &  Frame &
+		Combinaison d'une origine et d'une base vectorielle orthonormée.
+		\\  &  \\
+		Système de coordonnées cartésiennes & Cartesian coordinate system &
+		Ensemble de trois scalaires qui déterminent la position d'un point par rapport à une origine et trois axes orthogonaux. %(définis par une base vectorielle orthonormée)
+		\\   &  \\
+		Référentiel & Reference frame &
+		Point de vue choisi pour analyser/observer un mouvement.
+		\\  &  \\
+		\hline
+		\label{tab}
+	\end{tabular}
 \end{center}
 
 \section{Symboles et notations}
 
 \begin{center}
-\begin{tabular}{p{5cm}  p{9cm}}
+	\begin{tabular}{p{5cm}  p{9cm}}
 %\caption{Nomenclature}
 %\label{nom}
-\hline
-\textbf{Symbole} & \textbf{Définition} \\ \hline\hline \\
+		\hline
+		\textbf{Symbole} & \textbf{Définition} \\ \hline\hline \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\multicolumn{2}{l}{Vecteurs géométriques} \\ \hline \\
+		\multicolumn{2}{l}{Vecteurs géométriques} \\ \hline \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\vec{v}$            & Vecteur      \\   &  \\ 
+		$\vec{v}$            & Vecteur      \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\hat{a}$            & Vecteur unitaire   \\   &  \\ 
+		$\hat{a}$            & Vecteur unitaire   \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%$\vec{r}$            & Vecteur position     \\  &  \\ 
+%$\vec{r}$            & Vecteur position     \\  &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%$\vec{a}$            & Vecteur accélération \\   &  \\ 
+%$\vec{a}$            & Vecteur accélération \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%$\dot{\vec{r}}$      & Dérivée du vecteur $\vec{r}$ par rapport au temps \\   &  \\  
+%$\dot{\vec{r}}$      & Dérivée du vecteur $\vec{r}$ par rapport au temps \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%$^{i}\dot{\vec{r}}$  & Dérivée partielle du vecteur $\vec{r}$ par rapport au temps vue dans le référentiel $i$ \\   &  \\ 
+%$^{i}\dot{\vec{r}}$  & Dérivée partielle du vecteur $\vec{r}$ par rapport au temps vue dans le référentiel $i$ \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\vec{r}_{A/B}$      & Vecteur position du point $A$ par rapport au point $B$ \\   &  \\ 
+		$\vec{r}_{A/B}$      & Vecteur position du point $A$ par rapport au point $B$ \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\multicolumn{2}{l}{Vecteur-colonnes et composantes scalaires} \\ \hline \\
+		\multicolumn{2}{l}{Vecteur-colonnes et composantes scalaires} \\ \hline \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\col{c} = \left[ \begin{array}{c}
-	c_1 \\ c_2 \\ c_3
-\end{array}  \right] = \left[\begin{array}{ccc} c_1 & c_2 & c_3 \end{array}\right]^T $    
- & Vecteur-colonne \\   &  \\
+		$\col{c} = \left[ \begin{array}{c}
+							  c_1 \\ c_2 \\ c_3
+		\end{array}  \right] = \left[\begin{array}{ccc} c_1 & c_2 & c_3 \end{array}\right]^T $
+		& Vecteur-colonne \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %$\col{v}^{T} = \left[v_1,v_2,v_3\right]$
 %& Vecteur-rangé  \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\col{v}^{a}  = \left[ \begin{array}{c}
-	v_1^a \\ v_2^a \\ v_3^a
-\end{array}  \right]$   & Vecteur-colonne des composantes du vecteur $\vec{v}$ dans la base vectorielle $a$  \\   &  \\
+		$\col{v}^{a}  = \left[ \begin{array}{c}
+								   v_1^a \\ v_2^a \\ v_3^a
+		\end{array}  \right]$   & Vecteur-colonne des composantes du vecteur $\vec{v}$ dans la base vectorielle $a$  \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$v^{a}_i$        & Composante du vecteur $\vec{v}$ selon le vecteur unitaire $i$ de la base vectorielle $a$ \\   &  \\
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\col{q} = \left[ \begin{array}{c}
-	q_1 \\  \vdots \\ q_n
-\end{array}  \right] $            & Vecteur-colonne qui regroupe $n$ scalaires représentant la configuration d'un robot à $n$ DDL dans l'espace des joints. \\   &  \\
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\multicolumn{2}{l}{Bases et repères} \\ \hline \\
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\left\{ \hat{a}_1 , \hat{a}_2 , \hat{a}_3 \right\}$  & Base vectorielle $a$ définie par un ensemble de trois vecteur unitaires orthogonaux \\   &  \\ 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$\left\{ A_O , \hat{a}_1 , \hat{a}_2 , \hat{a}_3 \right\}$  & Repère $A$ défini par un point d'origine $A_O$ et la base vectorielle $a$ \\   &  \\
+		$v^{a}_i$        & Composante du vecteur $\vec{v}$ selon le vecteur unitaire $i$ de la base vectorielle $a$ \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\multicolumn{2}{l}{Matrices} \\ \hline \\
+		$\col{q} = \left[ \begin{array}{c}
+							  q_1 \\  \vdots \\ q_n
+		\end{array}  \right] $            & Vecteur-colonne qui regroupe $n$ scalaires représentant la configuration d'un robot à $n$ DDL dans l'espace des joints. \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$M=\left[ \begin{array}{c c c}
-	M_{1,1} & \hdots & M_{1,n}  \\ \vdots & \ddots & \vdots \\ M_{m,1}  & \hdots & M_{m,n}
-\end{array}  \right] $   
-& Matrice de $m$ rangées et $n$ colonnes ($m \times n$) \\   &  \\
+		\multicolumn{2}{l}{Bases et repères} \\ \hline \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-${}^aR^b = \left[ \begin{array}{c c c}
-	\col{b}_1^a  & \col{b}_2^a & \col{b}_3^a
-\end{array}  \right]$            & Matrice de rotation (3$\times$3) qui représente l'orientation de la base vectorielle $b$ par rapport à la base vectorielle $a$. %Un changement de base est effectué ainsi $ \col{v}^b={}^{b}R^a \col{v}^a$  
- \\   &  \\
+		$\left\{ \hat{a}_1 , \hat{a}_2 , \hat{a}_3 \right\}$  & Base vectorielle $a$ définie par un ensemble de trois vecteurs unitaires orthogonaux \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-$^{A}T^B = \left[ \begin{array}{c c}
-	{}^aR^b  & \col{r}^a_{B_o/A_o} \\ 0 \; 0 \; 0 & 1
-\end{array}  \right] $           & Matrice de transformation homogène (4$\times$4) du repère $B$ vers le repère $A$\\   &  \\
+		$\left\{ A_O , \hat{a}_1 , \hat{a}_2 , \hat{a}_3 \right\}$  & Repère $A$ défini par un point d'origine $A_O$ et la base vectorielle $a$ \\   &  \\
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+		\multicolumn{2}{l}{Matrices} \\ \hline \\
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+		$M=\left[ \begin{array}{c c c}
+					  M_{1,1} & \hdots & M_{1,n}  \\ \vdots & \ddots & \vdots \\ M_{m,1}  & \hdots & M_{m,n}
+		\end{array}  \right] $
+		& Matrice de $m$ rangées et $n$ colonnes ($m \times n$) \\   &  \\
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+		${}^aR^b = \left[ \begin{array}{c c c}
+							  \col{b}_1^a  & \col{b}_2^a & \col{b}_3^a
+		\end{array}  \right]$            & Matrice de rotation (3$\times$3) qui représente l'orientation de la base vectorielle $b$ par rapport à la base vectorielle $a$. %Un changement de base est effectué ainsi $ \col{v}^b={}^{b}R^a \col{v}^a$
+		\\   &  \\
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+		$^{A}T^B = \left[ \begin{array}{c c}
+		{}^aR^b  & \col{r}^a_{B_o/A_o} \\ 0 \; 0 \; 0 & 1
+		\end{array}  \right] $           & Matrice de transformation homogène (4$\times$4) du repère $B$ vers le repère $A$\\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %$\underline{v}^{\times}= \left[ \begin{array}{c c c}
-%	0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
+%  0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
 %\end{array}  \right] $   & Matrice antisymétrique correspondant aux composantes du vecteur $\vec{v}$ pour calculer un %produit vectoriel : $\vec{v} \times \vec{w} \; \leftrightarrow \; \col{v}^{\times}\col{w}$ \\   &  \\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\hline
-\end{tabular}
+		\hline
+	\end{tabular}
 \end{center}
+

--- a/src/manip/manip.tex
+++ b/src/manip/manip.tex
@@ -1,68 +1,68 @@
 \chapter{Les robots manipulateurs}
 \label{sec:robotmanip}
 
-Les robots manipulateurs correspondent à des bras artificiels, généralement plusieurs liens rigides connectés par des articulations. La grande majorité des robots industriels sont des robots manipulateurs qui ont comme tâche de positionner des outils pour la soudure, la peinture, etc. La figure \ref{fig:nom} présente les composants principaux d'un robot manipulateur. La figure \ref{fig:robotmanipex} illustre des exemples concrets de mécanismes et composants pour un robot manipulateur prototype. 
+Les robots manipulateurs correspondent à des bras artificiels, généralement plusieurs liens rigides connectés par des articulations. La grande majorité des robots industriels sont des robots manipulateurs qui ont comme tâche de positionner des outils pour la soudure, la peinture, etc. La figure \ref{fig:nom} présente les composants principaux d'un robot manipulateur. La figure \ref{fig:robotmanipex} illustre des exemples concrets de mécanismes et composants pour un robot manipulateur prototype.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.55\textwidth]{nom.png}
-	\caption{Nomenclature pour l'analyse d'un robot manipulateurs}
+	\includegraphics[width=0.55\textwidth]{nom.png}
+	\caption{Nomenclature pour l'analyse d'un robot manipulateur}
 	\label{fig:nom}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \section{Mécanismes et composants}
 
-Cette section présente les différents composants d'un robot manipulateur ainsi que la nomenclature utilisée. 
+Cette section présente les différents composants d'un robot manipulateur ainsi que la nomenclature utilisée.
 
 \subsection{Liens rigides}
 
-Un lien rigide d'un robot, c'est un ensemble de pièces fixes les unes par rapport aux autres qui forment un corps rigide. D'un point de vu de cinématique, deux pièces fixées de telle façon qu'aucun mouvement relatif n'est possible vont être considérées comme un seul lien. Par exemple, plusieurs tubes qui seraient soudés ensembles seraient considérés comme un seul lien rigide. 
+Un lien rigide d'un robot, c'est un ensemble de pièces fixes les unes par rapport aux autres qui forment un corps rigide. D'un point de vue de cinématique, deux pièces fixées de telle façon qu'aucun mouvement relatif n'est possible vont être considérées comme un seul lien. Par exemple, plusieurs tubes qui seraient soudés ensemble seraient considérés comme un seul lien rigide.
 
 \subsection{Joints (articulations)}
 
-Les joints sont les articulations d'un robot. Un \textbf{joint prismatique} (articulation linéaire), permet la translation selon un axe entre deux pièces, et contraint les rotations relatives. Un \textbf{joint rotatif} (articulation angulaire), permet à deux pièces de pivoter relativement selon un axe. La variable $q_i$ utilisée pour décrire la configuration d'un joint $i$ est une distance pour un joint prismatique et un angle pour un joint rotatif.
+Les joints sont les articulations d'un robot. Un \textbf{joint prismatique} (articulation linéaire) permet la translation selon un axe entre deux pièces, et contraint les rotations relatives. Un \textbf{joint rotatif} (articulation angulaire) permet à deux pièces de pivoter relativement selon un axe. La variable $q_i$ utilisée pour décrire la configuration d'un joint $i$ est une distance pour un joint prismatique et un angle pour un joint rotatif.
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Joint prismatique:} \quad q_i &= x_i      \quad [m] \\
-\text{Joint rotatif    :} \quad q_i &= \theta_i \quad [rad]
-\end{align} 
+	\text{Joint prismatique:} \quad q_i &= x_i      \quad [m] \\
+	\text{Joint rotatif    :} \quad q_i &= \theta_i \quad [rad]
+\end{align}
 %%%%%%%%%%%%%%%%%%%
 
-Les joints prismatiques et révolus ont une configuration décrite avec une seule variable, chacun des joints de ce type produit donc un degré de liberté (DDL) pour le robot manipulateur. Un robot utilisant seulement ces types de joints a donc un nombre total de DDL qui est égale au nombre de joints. Toutefois, des mécanismes plus complexes (ex.: joint sphérique comme illustré à la figure \ref{fig:nom}) peuvent produire plusieurs DDL en une seule articulation. Par contre, contrairement au corps humain, les robots utilisent généralement des joints prismatiques et rotatifs seulement pour simplifier la mécanique. Un joint sera dit actif si sa configuration est contrôlée par un actionneur, et passif si sa configuration est libre.
+Les joints prismatiques et révolus ont une configuration décrite avec une seule variable, chacun des joints de ce type produit donc un degré de liberté (DDL) pour le robot manipulateur. Un robot utilisant seulement ces types de joints a donc un nombre total de DDL qui est égal au nombre de joints. Toutefois, des mécanismes plus complexes (ex.: joint sphérique comme illustré à la figure \ref{fig:nom}) peuvent produire plusieurs DDL en une seule articulation. Par contre, contrairement au corps humain, les robots utilisent généralement des joints prismatiques et rotatifs seulement pour simplifier la mécanique. Un joint sera dit actif si sa configuration est contrôlée par un actionneur, et passif si sa configuration est libre.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Joint prismatique]{
-				\includegraphics[width=0.48\textwidth]{jointpris}
-				\label{fig:jointpris}}
-				\subfloat[Joint rotatif]{
-				\includegraphics[width=0.48\textwidth]{jointrev}
-				\label{fig:jointrev}}
-        \caption{Joints à un degré de liberté}
-				\label{fig:joint}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Joint prismatique]{
+		\includegraphics[width=0.48\textwidth]{jointpris}
+		\label{fig:jointpris}}
+	\subfloat[Joint rotatif]{
+		\includegraphics[width=0.48\textwidth]{jointrev}
+		\label{fig:jointrev}}
+	\caption{Joints à un degré de liberté}
+	\label{fig:joint}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \subsection{Effecteur}
 
-L'effecteur est un terme générique qui réfère à la position de l'outil d'un robot manipulateur (ex.: une pince, une tête de soudure, une caméra, etc.). Dans un espace tri-dimensionnel, la position d'un objet nécessite au plus six variables pour être complètement décrite (voir section \ref{sec:corps}). L'effecteur d'un robot aura donc au plus 6 DDL. 
+L'effecteur est un terme générique qui réfère à la position de l'outil d'un robot manipulateur (ex.: une pince, une tête de soudure, une caméra, etc.). Dans un espace tridimensionnel, la position d'un objet nécessite au plus six variables pour être complètement décrite (voir section \ref{sec:corps}). L'effecteur d'un robot aura donc au plus 6 DDL.
 
 \subsection{Actionneurs}
 
-Les actionneurs sont les muscles des bras robotiques. Un actionneur est fondamentalement un dispositif qui transforme de l'énergie en travail mécanique. La plupart des robots industriels utilisent des moteurs électriques pour actionner leurs joints, toutefois les actionneurs pourraient aussi être des vérins pneumatiques ou hydrauliques. 
+Les actionneurs sont les muscles des bras robotiques. Un actionneur est fondamentalement un dispositif qui transforme de l'énergie en travail mécanique. La plupart des robots industriels utilisent des moteurs électriques pour actionner leurs joints, toutefois les actionneurs pourraient aussi être des vérins pneumatiques ou hydrauliques.
 
 \subsection{Capteurs}
 
-Les capteurs sont les dispositifs qui collectent de l'information sur l'état interne d'un robot et/ou l’environnement. Pour la cinématique, les capteurs très régulièrement utilisés sont les encodeurs, qui mesurent directement la position des joints (variables $q_i$), et les systèmes de visions, qui mesurent la position de points dans le repère de la caméra. 
+Les capteurs sont les dispositifs qui collectent de l'information sur l'état interne d'un robot et/ou l’environnement. Pour la cinématique, les capteurs très régulièrement utilisés sont les encodeurs, qui mesurent directement la position des joints (variables $q_i$), et les systèmes de visions, qui mesurent la position de points dans le repère de la caméra.
 
 
 %%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.80\textwidth]{robotmanipex.png}
+	\includegraphics[width=0.80\textwidth]{robotmanipex.png}
 	\caption{Prototype de robot manipulateur avec trois degrés de liberté}
 	\label{fig:robotmanipex}
 \end{figure}
@@ -75,23 +75,23 @@ Cette section introduit les notions en lien avec la configuration d'un robot man
 
 \subsection{Degrés de liberté}
 
-Le nombre de degrés de liberté (DDL), c'est le nombre de variables nécessaires pour complètement décrire la configuration d'un robot ou un mécanisme. La plupart des robots industriels ont six DDL, ce qui est suffisant pour pouvoir contrôler indépendamment les six DDL de l'effecteur. Pour des robots qui utilisent seulement des joints rotatifs comme illustré à la figure \ref{fig:ddl}, le nombre de DDL est égale au nombre de joints. Si le nombre de DDL est supérieur à six, le robot est dit \textbf{redondant}. Un robot redondant a plusieurs options de configuration des joints pour atteindre une position et une orientation désirées de l'effecteur. 
+Le nombre de degrés de liberté (DDL), c'est le nombre de variables nécessaires pour complètement décrire la configuration d'un robot ou un mécanisme. La plupart des robots industriels ont six DDL, ce qui est suffisant pour pouvoir contrôler indépendamment les six DDL de l'effecteur. Pour des robots qui utilisent seulement des joints rotatifs comme illustré à la figure \ref{fig:ddl}, le nombre de DDL est égal au nombre de joints. Si le nombre de DDL est supérieur à six, le robot est dit \textbf{redondant}. Un robot redondant a plusieurs options de configuration des joints pour atteindre une position et une orientation désirées de l'effecteur.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[1 DDL]{
-				\includegraphics[width=0.20\textwidth]{1ddl}
-				\label{fig:1ddl}}
-				\subfloat[2 DDL]{
-				\includegraphics[width=0.25\textwidth]{2ddl}
-				\label{fig:2ddl}}
-				\subfloat[3 DDL]{
-				\includegraphics[width=0.25\textwidth]{3ddl}
-				\label{fig:3ddl}}
-        \caption{Manipulateurs planaires avec des joints rotatifs}
-				\label{fig:ddl}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[1 DDL]{
+		\includegraphics[width=0.20\textwidth]{1ddl}
+		\label{fig:1ddl}}
+	\subfloat[2 DDL]{
+		\includegraphics[width=0.25\textwidth]{2ddl}
+		\label{fig:2ddl}}
+	\subfloat[3 DDL]{
+		\includegraphics[width=0.25\textwidth]{3ddl}
+		\label{fig:3ddl}}
+	\caption{Manipulateurs planaires avec des joints rotatifs}
+	\label{fig:ddl}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -102,13 +102,13 @@ L'espace de travail c'est le volume qui comprend toutes les positions atteignabl
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.45\textwidth]{workspace.png}
+	\includegraphics[width=0.45\textwidth]{workspace.png}
 	\caption{Exemple de l'espace de travail d'un robot manipulateur à deux joints}
 	\label{fig:workspace}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%Parfois, des sous-ensembles de l'espace de travail 
+%Parfois, des sous-ensembles de l'espace de travail
 
 
 %\subsection{Serie vs parallele}
@@ -116,7 +116,7 @@ L'espace de travail c'est le volume qui comprend toutes les positions atteignabl
 
 
 
-\subsection{Configurations classiques}  
+\subsection{Configurations classiques}
 
 À venir!
 

--- a/src/manip/mouvement.tex
+++ b/src/manip/mouvement.tex
@@ -3,79 +3,79 @@
 
 
 
-Dans le chapitre \ref{sec:cine1}, les méthodes pour modéliser la position, l'orientation ont été présentée. Ce chapitre présente les méthodes associés pour représenter leurs variation dans le temps, c'est-à-dire la vitesse. Les premières sections décrivent les principes généraux et ensuite des méthodes spécifiques pour les robots manipulateurs sont présentées. 
+Dans le chapitre \ref{sec:cine1}, les méthodes pour modéliser la position et l'orientation ont été présentées. Ce chapitre présente les méthodes associées pour représenter leurs variations dans le temps, c'est-à-dire la vitesse. Les premières sections décrivent les principes généraux et ensuite des méthodes spécifiques pour les robots manipulateurs sont présentées.
 
 Chapitre en construction!
 
 
 \newpage
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Référentiel} 
+\section{Référentiel}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Un référentiel est un solide ou un ensemble de points par rapport auquel un observateur qui mesure un mouvement est fixe. Une position ou un mouvement ne peut être défini par rapport au vide et il n'y a pas de référentiel absolu, le choix du référentiel est donc un choix arbitraire de point de vue. Il est à noter que \textbf{contrairement au choix d'un repère, le choix du référentiel influence "la physique" du problème}, par exemple l'énergie cinétique d'un objet n'est pas la même selon le référentiel alors que cette quantité est indépendante du système de coordonnées. Un référentiel dit inertiel ou Galiléen (vitesse et orientation constante) est préférable si on souhaite éventuellement appliquer les équations de Newtons, car des facteurs correctifs (ex.: la force centrifuge) doivent être ajoutés aux équations dynamiques si un référentiel non-inertiel est utilisé. La notion de référentiel est critique pour le calcul de vitesses et accélérations, mais on peut en faire abstraction pour les problèmes de cinématique et statique qui n'impliquent pas la notion d'évolution dans le temps. 
+Un référentiel est un solide ou un ensemble de points par rapport auquel un observateur qui mesure un mouvement est fixe. Une position ou un mouvement ne peut être défini par rapport au vide et il n'y a pas de référentiel absolu, le choix du référentiel est donc un choix arbitraire de point de vue. Il est à noter que \textbf{contrairement au choix d'un repère, le choix du référentiel influence "la physique" du problème}, par exemple l'énergie cinétique d'un objet n'est pas la même selon le référentiel alors que cette quantité est indépendante du système de coordonnées. Un référentiel dit inertiel ou Galiléen (vitesse et orientation constante) est préférable si on souhaite éventuellement appliquer les équations de Newtons, car des facteurs correctifs (ex.: la force centrifuge) doivent être ajoutés aux équations dynamiques si un référentiel non-inertiel est utilisé. La notion de référentiel est critique pour le calcul de vitesses et accélérations, mais on peut en faire abstraction pour les problèmes de cinématique et statique qui n'impliquent pas la notion d'évolution dans le temps.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Référentiel vs. repère}
-Pour décrire le mouvement d'un objet, les concepts de référentiel, origine et base vectorielle sont important à distinguer. En quelques mots, un \textbf{référentiel} est un point de vue utilisé pour décrire un phénomène, une \textbf{origine} c'est un point par rapport auquel les mesures de position sont faites et une \textbf{base} vectorielle représente l'orientation du système d'axe utilisé. Ces trois éléments peuvent être choisi indépendamment.  Ensuite, un \textbf{repère} c'est la combinaison d'une base et d'une origine. Par exemple, pour décrire la position d'un bateau, typiquement le référentiel utilisé serait la Terre, l'origine des mesures de position pourrait être le port le plus près, et la base pour exprimer cette position serait le système d'axe nord-sud/est-ouest. Il est important de noter que tous ces choix sont indépendants et les confondre est une source d'erreur courante en cinématique. Le reste de cette section discute de ce qui les distingue.
+Pour décrire le mouvement d'un objet, les concepts de référentiel, d'origine et de base vectorielle sont importants à distinguer. En quelques mots, un \textbf{référentiel} est un point de vue utilisé pour décrire un phénomène, une \textbf{origine} c'est un point par rapport auquel les mesures de position sont faites et une \textbf{base} vectorielle représente l'orientation du système d'axe utilisé. Ces trois éléments peuvent être choisis indépendamment.  Ensuite, un \textbf{repère} c'est la combinaison d'une base et d'une origine. Par exemple, pour décrire la position d'un bateau, typiquement le référentiel utilisé serait la Terre, l'origine des mesures de position pourrait être le port le plus près, et la base pour exprimer cette position serait le système d'axe nord-sud/est-ouest. Il est important de noter que tous ces choix sont indépendants et les confondre est une source d'erreur courante en cinématique. Le reste de cette section discute de ce qui les distingue.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.90\textwidth]{train.png}
+	\includegraphics[width=0.90\textwidth]{train.png}
 	\caption{Exemple de référentiels, points d'origine et bases vectorielles}
 	\label{fig:train}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La figure \ref{fig:train} illustre ces concepts par un exemple où un train descend une pente à vitesse constante et un ballon rebondit sur le sol du troisième wagon. Deux bases vectorielles sont définies, une alignée avec l'horizontale et une alignée avec le train. Plusieurs points d'origine pour les mesures de position sont aussi disponibles. Finalement, deux référentiels sont définis, un référentiel attaché à la Terre (fixe) et un référentiel qui est attaché au train. Les coordonnées d'un vecteur-colonne qui décris la position du ballon:
+La figure \ref{fig:train} illustre ces concepts par un exemple où un train descend une pente à vitesse constante et un ballon rebondit sur le sol du troisième wagon. Deux bases vectorielles sont définies, une alignée avec l'horizontale et une alignée avec le train. Plusieurs points d'origine pour les mesures de position sont aussi disponibles. Finalement, deux référentiels sont définis, un référentiel attaché à la Terre (fixe) et un référentiel qui est attaché au train. Les coordonnées d'un vecteur-colonne qui décrit la position du ballon:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\col{r}_{Ball} = \left[ \begin{array}{c} r_1 \\ r_2 \end{array} \right]
+	\col{r}_{Ball} = \left[ \begin{array}{c} r_1 \\ r_2 \end{array} \right]
 \end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-sont illustrés pour différents choix d'origine et de base vectorielle, lorsque que le référentiel fixe est utilisé (figure \ref{fig:refex1}) et lorsque que le référentiel du train est utilisé (figure \ref{fig:refex2}). Il est à noter que les points d'origine sont ici fixés à la Terre lorsque le référentiel fixe est utilisé, et fixés au train lorsque que le référentiel du train est utilisé. Comme illustré pour cet exemple, \textbf{un changement d'origine est analogue à une translation} de la trajectoire, \textbf{un changement de base vectorielle est analogue à une rotation} de la trajectoire, et \textbf{un changement de référentiel est ici analogue à une dilatation} de la trajectoire dans la direction $\hat{b}_1$, qui correspond à la direction de la vitesse du train. 
+sont illustrés pour différents choix d'origine et de base vectorielle, lorsque que le référentiel fixe est utilisé (figure \ref{fig:refex1}) et lorsque que le référentiel du train est utilisé (figure \ref{fig:refex2}). Il est à noter que les points d'origine sont ici fixés à la Terre lorsque le référentiel fixe est utilisé, et fixés au train lorsque le référentiel du train est utilisé. Comme illustré pour cet exemple, \textbf{un changement d'origine est analogue à une translation} de la trajectoire, \textbf{un changement de base vectorielle est analogue à une rotation} de la trajectoire, et \textbf{un changement de référentiel est ici analogue à une dilatation} de la trajectoire dans la direction $\hat{b}_1$, qui correspond à la direction de la vitesse du train.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Repère $\{ A, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
-				\includegraphics[width=0.23\textwidth]{ref_fixe_r_a_A.png}
-				} \hspace{20pt}
-				\subfloat[Repère $\{ B, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
-				\includegraphics[width=0.24\textwidth]{ref_fixe_r_a_B.png}
-				} \hspace{190pt}
-				\subfloat[Repère $\{ A, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
-				\includegraphics[width=0.22\textwidth]{ref_fixe_r_b_A.png}
-				} \hspace{20pt}
-				\subfloat[Repère $\{ B, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
-				\includegraphics[width=0.24\textwidth]{ref_fixe_r_b_B.png}
-				}
-        \caption{Trajectoire du ballon avec un repère attaché au \textbf{référentiel fixe}}
-				\label{fig:refex1}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Repère $\{ A, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
+		\includegraphics[width=0.23\textwidth]{ref_fixe_r_a_A.png}
+	} \hspace{20pt}
+	\subfloat[Repère $\{ B, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
+		\includegraphics[width=0.24\textwidth]{ref_fixe_r_a_B.png}
+	} \hspace{190pt}
+	\subfloat[Repère $\{ A, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
+		\includegraphics[width=0.22\textwidth]{ref_fixe_r_b_A.png}
+	} \hspace{20pt}
+	\subfloat[Repère $\{ B, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
+		\includegraphics[width=0.24\textwidth]{ref_fixe_r_b_B.png}
+	}
+	\caption{Trajectoire du ballon avec un repère attaché au \textbf{référentiel fixe}}
+	\label{fig:refex1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Repère $\{ A, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
-				\includegraphics[width=0.22\textwidth]{ref_train_r_a_A.png}
-				} \hspace{20pt}
-				\subfloat[Repère $\{ B, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
-				\includegraphics[width=0.25\textwidth]{ref_train_r_a_B.png}
-				} \hspace{190pt}
-				\subfloat[Repère $\{ A, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
-				\includegraphics[width=0.22\textwidth]{ref_train_r_b_A.png}
-				} \hspace{20pt}
-				\subfloat[Repère $\{ B, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
-				\includegraphics[width=0.25\textwidth]{ref_train_r_a_B.png}
-				}
-        \caption{Trajectoire du ballon avec un repère attaché au \textbf{référentiel du train}}
-				\label{fig:refex2}
+	%\vspace{-10pt}
+	\centering
+	\subfloat[Repère $\{ A, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
+		\includegraphics[width=0.22\textwidth]{ref_train_r_a_A.png}
+	} \hspace{20pt}
+	\subfloat[Repère $\{ B, \hat{a}_1, \hat{a}_2, \hat{a}_3\}$]{
+		\includegraphics[width=0.25\textwidth]{ref_train_r_a_B.png}
+	} \hspace{190pt}
+	\subfloat[Repère $\{ A, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
+		\includegraphics[width=0.22\textwidth]{ref_train_r_b_A.png}
+	} \hspace{20pt}
+	\subfloat[Repère $\{ B, \hat{b}_1, \hat{b}_2, \hat{b}_3\}$]{
+		\includegraphics[width=0.25\textwidth]{ref_train_r_a_B.png}
+	}
+	\caption{Trajectoire du ballon avec un repère attaché au \textbf{référentiel du train}}
+	\label{fig:refex2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -85,42 +85,42 @@ sont illustrés pour différents choix d'origine et de base vectorielle, lorsque
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newpage
-\section{Vitesse et dérivée d'un vecteur position} 
+\section{Vitesse et dérivée d'un vecteur position}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Un vecteur de vitesse est définit comme la dérivée temporelle d'une vecteur de position:
+Un vecteur de vitesse est défini comme la dérivée temporelle d'un vecteur de position:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{v}_{B/A} = \frac{d}{dt} \vec{r}_{B/A}
+	\vec{v}_{B/A} = \frac{d}{dt} \vec{r}_{B/A}
 \end{equation}
 %%%%%%%%%%%%%%%
-Toutefois, pour avoir la notion de vitesse précise qui correspond à un quantité de mouvement (momentum) qui peut être utilisée dans les divers lois de la physique (ex. conservation du mouvement, conservation de l'énergie, etc.), la dérivée doit être faite par rapport à un observateur Galiléen, aussi appelé un référentiel inertiel. Donc pour avoir la vitesse $\vec{v}_{B}$ d'un point $B$ il faut 1) que la dérivée soit faite par rapport à une base vectorielle avec un orientation fixe dans le référentiel Galiléen, et 2) que le vecteur position dérivé soit par rapport à un point d'origine fixe dans le référentiel Galiléen.
+Toutefois, pour avoir la notion de vitesse précise qui correspond à une quantité de mouvement (momentum) qui peut être utilisée dans les diverses lois de la physique (ex. conservation du mouvement, conservation de l'énergie, etc.), la dérivée doit être faite par rapport à un observateur Galiléen, aussi appelé un référentiel inertiel. Donc pour avoir la vitesse $\vec{v}_{B}$ d'un point $B$ il faut 1) que la dérivée soit faite par rapport à une base vectorielle avec une orientation fixe dans le référentiel Galiléen, et 2) que le vecteur position dérivé soit par rapport à un point d'origine fixe dans le référentiel Galiléen.
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\underbrace{
-\vec{v}_{B}
-}_{\text{ Vitesse du point B}}
-= \underbrace{ 
-\frac{d}{dt} 
-}_{\text{observateur Galiléen}}
-\vec{r}_{B/
-\underbrace{A
-}_{\text{Point fixe}}
-}
+	\underbrace{
+		\vec{v}_{B}
+	}_{\text{ Vitesse du point B}}
+	= \underbrace{
+		\frac{d}{dt}
+	}_{\text{observateur Galiléen}}
+	\vec{r}_{B/
+		\underbrace{A
+		}_{\text{Point fixe}}
+	}
 \end{equation}
 %%%%%%%%%%%%%%%
 Avec cette définition, le vecteur vitesse est défini seulement par un seul point contrairement au vecteur position qui prend un sens seulement avec une origine.
-La méthode la plus simple pour déterminer le vecteur vitesse d'un point basé sur une expression connue pour son vecteur position est d'exprimer le vecteur position dans un repère fixe, et ensuite de dériver chaque composante. Donc si il est possible d'exprimer le vecteur position d'un point $B$ par rapport à un point fixe $A$ et en utilisant une base vectorielle fixe $a$:
+La méthode la plus simple pour déterminer le vecteur vitesse d'un point basé sur une expression connue pour son vecteur position est d'exprimer le vecteur position dans un repère fixe, et ensuite de dériver chaque composante. Donc s’il est possible d'exprimer le vecteur position d'un point $B$ par rapport à un point fixe $A$ et en utilisant une base vectorielle fixe $a$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{B/A} = x \hat{a}_1 +  y \hat{a}_2 +  z \hat{a}_3
+	\vec{r}_{B/A} = x \hat{a}_1 +  y \hat{a}_2 +  z \hat{a}_3
 \end{equation}
 %%%%%%%%%%%%%%%
 il suffit de dériver l'expression de chaque composante dans cette base pour déterminer le vecteur vitesse du point $B$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{v}_{B} = \frac{d}{dt} \vec{r}_{B/A} = 
-\dot{x} \hat{a}_1 +  \dot{y} \hat{a}_2 +  \dot{z} \hat{a}_3
+	\vec{v}_{B} = \frac{d}{dt} \vec{r}_{B/A} =
+	\dot{x} \hat{a}_1 +  \dot{y} \hat{a}_2 +  \dot{z} \hat{a}_3
 \end{equation}
 %%%%%%%%%%%%%%%
 
@@ -128,43 +128,43 @@ il suffit de dériver l'expression de chaque composante dans cette base pour dé
 \subsection{Dérivée d'un vecteur position exprimé avec une base mobile}
 \label{sec:diffposmobilebase}
 
-\note{Notation pour les repère fixes et mobiles}{ Pour les sections suivantes, les expressions sont développé en considérante que les repères notés $A$ (base $a$ et origine $A$) sont fixes dans le référentiel inertiel et que les repères notés $B$ (base $b$ et origine $B$) sont arbitraires donc potentiellement mobiles.}
+\note{Notation pour les repères fixes et mobiles}{ Pour les sections suivantes, les expressions sont développées en considérant que les repères notés $A$ (base $a$ et origine $A$) sont fixes dans le référentiel inertiel et que les repères notés $B$ (base $b$ et origine $B$) sont arbitraires donc potentiellement mobiles.}
 
-Dans certaines situations, le vecteur position est plus naturellement exprimé dans un repère mobile, cette section développe des expressions qui peuvent être utilisée pour déterminer le vecteur vitesse sans avoir à tout transférer dans un repère inertiel. Si on connaît les composantes un vecteur position dans une base mobile $b$:
+Dans certaines situations, le vecteur position est plus naturellement exprimé dans un repère mobile. Cette section développe des expressions qui peuvent être utilisées pour déterminer le vecteur vitesse sans avoir à tout transférer dans un repère inertiel. Si l'on connaît les composantes d'un vecteur position dans une base mobile $b$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{r}_{B/A} = x \hat{b}_1 +  y \hat{b}_2 +  z \hat{b}_3
+	\vec{r}_{B/A} = x \hat{b}_1 +  y \hat{b}_2 +  z \hat{b}_3
 \end{equation}
 %%%%%%%%%%%%%%%
 Lorsqu'on dérive par rapport au temps, il faut tenir compte que les vecteurs unitaires de la base $b$ on une direction qui change dans le temps, et donc une dérivée temporelle non-nulle:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{v}_{B} &= \frac{d}{dt} \vec{r}_{B/A} = 
-\underbrace{
-\dot{x} \hat{b}_1 +  \dot{y} \hat{b}_2 +  \dot{z} \hat{b}_3 
-}_{ {}^{b}\frac{d}{dt} \vec{r}_{B/A}  }
-+ 
-\underbrace{
-x \dot{\hat{b}}_1 +  y \dot{\hat{b}}_2 +  z \dot{\hat{b}}_3
-}_{  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}  } 
-\label{eq:speedvec}
+	\vec{v}_{B} &= \frac{d}{dt} \vec{r}_{B/A} =
+	\underbrace{
+		\dot{x} \hat{b}_1 +  \dot{y} \hat{b}_2 +  \dot{z} \hat{b}_3
+	}_{ {}^{b}\frac{d}{dt} \vec{r}_{B/A}  }
+	+
+	\underbrace{
+		x \dot{\hat{b}}_1 +  y \dot{\hat{b}}_2 +  z \dot{\hat{b}}_3
+	}_{  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}  }
+	\label{eq:speedvec}
 \end{align}
 %%%%%%%%%%%%%%%
 Il y a donc deux sources de contribution au vecteur vitesse, le taux de variation des composantes et le taux de variation de la direction des vecteurs unitaires. La dérivée temporelle des vecteurs unitaires est directement reliée à la vitesse angulaire de la base $b$ (voir section \ref{sec:angularspeed}, et cette contribution peut être calculée avec le produit vectoriel d'un vecteur de vitesse angulaire de la base $b$ par rapport à une base fixe $a$ fois le vecteur de position:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{v}_{B} &= 
-\underbrace{
-{}^{b}\frac{d}{dt} \vec{r}_{B/A} 
-}_{\text{Observateur mobile}}
-+  
-\underbrace{
-\vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
-}_{\text{Effet de la vitesse angulaire}}
-\label{eq:speedprodvec}
+	\vec{v}_{B} &=
+	\underbrace{
+		{}^{b}\frac{d}{dt} \vec{r}_{B/A}
+	}_{\text{Observateur mobile}}
+	+
+	\underbrace{
+		\vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
+	}_{\text{Effet de la vitesse angulaire}}
+	\label{eq:speedprodvec}
 \end{align}
 %%%%%%%%%%%%%%%
-où $b$ est une base mobile, $a$ est une base fixe dans le référentiel inertiel, le terme ${}^{b}\frac{d}{dt}$ représente le taux de variation vu par un observateur dans le référentiel non-inertiel qui tourne avec la base $b$ et $\vec{w}_{b/a}$ est la vitesse angulaire de la base $b$ p/r à une base $a$ inertielle.
+où $b$ est une base mobile, $a$ est une base fixe dans le référentiel inertiel, le terme ${}^{b}\frac{d}{dt}$ représente le taux de variation vu par un observateur dans le référentiel non-inertiel qui tourne avec la base $b$ et $\vec{w}_{b/a}$ est la vitesse angulaire de la base $b$ par rapport à une base $a$ inertielle.
 
 
 \paragraph{Équation matricielle équivalente avec les composantes}:
@@ -172,32 +172,32 @@ où $b$ est une base mobile, $a$ est une base fixe dans le référentiel inertie
 On peut trouver une relation équivalente qui implique les vecteur-colonnes de composantes et les matrices de rotation. Le vecteur vitesse est la dérivée temporelle des composantes dans la base fixe $a$, on peut donc substituer par le vecteur-colonne de composantes dans la base $b$ fois la matrice de rotation ${}^{a}R^b$ et prendre la dérivée:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}_{B}^a &= \frac{d}{dt} \col{r}_{B/A}^a = 
-\frac{d}{dt} \left( {}^{a}R^b \, \col{r}_{B/A}^b \right) 
+	\col{v}_{B}^a &= \frac{d}{dt} \col{r}_{B/A}^a =
+	\frac{d}{dt} \left( {}^{a}R^b \, \col{r}_{B/A}^b \right)
 \end{align}
 %%%%%%%%%%%%%%%
-Ici on applique la règle de dérivé d'un produit et comme avec la relation vectorielle de l'équation \eqref{eq:speedvec}, on trouve deux termes:
+Ici on applique la règle de la dérivée d'un produit et comme avec la relation vectorielle de l'équation \eqref{eq:speedvec}, on trouve deux termes:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}_{B/A}^a &=
-{}^{a}R^b \, \col{\dot{r}}_{B/A}^b + {}^{a}\dot{R}^b \, \col{r}_{B/A}^b 
+	\col{v}_{B/A}^a &=
+	{}^{a}R^b \, \col{\dot{r}}_{B/A}^b + {}^{a}\dot{R}^b \, \col{r}_{B/A}^b
 \end{align}
 %%%%%%%%%%%%%%%
 Toutefois ici le taux de variation de la direction de la base mobile $b$ est représenté par la dérivée temporelle de la matrice de rotation ${}^{a}R^b$ (voir section \ref{sec:angularspeed}). On peut utiliser une expression qui utilise les composantes de la vitesse angulaire de la base $b$ pour déterminer la dérivée de la matrice de rotation
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}_{B}^a &=
-{}^{a}R^b \, \col{\dot{r}}_{B/A}^b + (\col{w}_{b/a}^a)^{\times} \, {}^{a}R^b \, \col{r}_{B/A}^b \\
-\col{v}_{B}^a &=
-{}^{a}R^b \, \col{\dot{r}}_{B/A}^b +  {}^{a}R^b \, (\col{w}_{b/a}^b)^{\times} \, \col{r}_{B/A}^b
+	\col{v}_{B}^a &=
+	{}^{a}R^b \, \col{\dot{r}}_{B/A}^b + (\col{w}_{b/a}^a)^{\times} \, {}^{a}R^b \, \col{r}_{B/A}^b \\
+	\col{v}_{B}^a &=
+	{}^{a}R^b \, \col{\dot{r}}_{B/A}^b +  {}^{a}R^b \, (\col{w}_{b/a}^b)^{\times} \, \col{r}_{B/A}^b
 \end{align}
 %%%%%%%%%%%%%%%
-pour obtenir une forme équivalente à l'expression vectorielle précédemment obtenue (eq. \eqref{eq:speedprodvec}, mais impliquant les vecteurs-colonnes de composantes et la matrice de rotation:
+pour obtenir une forme équivalente à l'expression vectorielle précédemment obtenue (éq. \eqref{eq:speedprodvec}, mais impliquant les vecteurs-colonnes de composantes et la matrice de rotation:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{v}_{B} = {}^{b}\frac{d}{dt} \vec{r}_{B/A} +  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
-\quad \Leftrightarrow \quad 
-\col{v}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{r}}^b_{B/A} +  (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  \right] 
+	\vec{v}_{B} = {}^{b}\frac{d}{dt} \vec{r}_{B/A} +  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
+	\quad \Leftrightarrow \quad
+	\col{v}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{r}}^b_{B/A} +  (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  \right]
 \end{align}
 %%%%%%%%%%%%%%%
 
@@ -209,75 +209,75 @@ pour obtenir une forme équivalente à l'expression vectorielle précédemment o
 \label{sec:angularspeed}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La représentation de l'orientation a plusieurs difficultés mathématiques: pour représenter seulement 3 DDL les matrices de rotation ont 9 paramètres, les rotation ne sont pas commutative, etc. Toutefois, les petites rotations infinitésimales peuvent être représentées par un vecteur de trois paramètres et sont commutatives. Un vecteur rotation infinitésimale a comme direction l'axe de rotation et comme amplitude un angle autour de cet axe. Lorsque qu'on divise un vecteur rotation infinitésimal par $dt$ ont obtient le concept de vecteur de vitesse angulaire:
+La représentation de l'orientation a plusieurs difficultés mathématiques: pour représenter seulement 3 DDL, les matrices de rotation ont 9 paramètres, les rotations ne sont pas commutatives, etc. Toutefois, les petites rotations infinitésimales peuvent être représentées par un vecteur de trois paramètres et sont commutatives. Un vecteur rotation infinitésimal a comme direction l'axe de rotation et comme amplitude un angle autour de cet axe. Lorsque qu'on divise un vecteur rotation infinitésimal par $dt$ ont obtient le concept de vecteur de vitesse angulaire:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{w} = \underbrace{
-w \left[ \frac{rad}{sec} \right] 
-}_{\text{Taux de variation d'un angle}}
-\,
-\underbrace{
-\hat{a}
-}_{\text{axe de rotation instantané}}
+	\vec{w} = \underbrace{
+		w \left[ \frac{rad}{sec} \right]
+	}_{\text{Taux de variation d'un angle}}
+	\,
+	\underbrace{
+		\hat{a}
+	}_{\text{axe de rotation instantané}}
 \end{equation}
 %%%%%%%%%%%%%%%
-Le vecteur de vitesse angulaire $\vec{w}$ a comme direction l'axe de rotation instantané  $\hat{a}$ et comme amplitude un taux de variation $w$ d'un angle autour de cet axe. D'un point de vue matricielle, le vecteur de vitesse angulaire est associé à la dérivée temporelle d'une matrice de rotation:
+Le vecteur de vitesse angulaire $\vec{w}$ a comme direction l'axe de rotation instantané  $\hat{a}$ et comme amplitude un taux de variation $w$ d'un angle autour de cet axe. D'un point de vue matriciel, le vecteur de vitesse angulaire est associé à la dérivée temporelle d'une matrice de rotation:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\dot{R} = \frac{d}{dt} R = (\col{w})^x \, R   \quad \quad \text{avec} \quad
-(\col{w})^x = 
-\left[ \begin{array}{c c c}
-0    & -w_3 & w_2 \\
-w_3  & 0    & -w_1 \\
--w_2 & w_1  & 0 
-\end{array}  \right]  
+	\dot{R} = \frac{d}{dt} R = (\col{w})^x \, R   \quad \quad \text{avec} \quad
+	(\col{w})^x =
+	\left[ \begin{array}{c c c}
+			   0    & -w_3 & w_2 \\
+			   w_3  & 0    & -w_1 \\
+			   -w_2 & w_1  & 0
+	\end{array}  \right]
 \end{equation}
 %%%%%%%%%%%%%%%
-et du point de vue vectorielle, de façon équivalente à la dérivée temporelle des vecteurs unitaires de la base mobile peut être calculé avec un produit vectoriel du vecteur de vitesse angulaire et les vecteurs unitaires:
+et du point de vue vectoriel, de façon équivalente à la dérivée temporelle, des vecteurs unitaires de la base mobile peuvent être calculés avec un produit vectoriel du vecteur de vitesse angulaire et les vecteurs unitaires:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\dot{\hat{b}}_i = \vec{w} \times \hat{b}_i
+	\dot{\hat{b}}_i = \vec{w} \times \hat{b}_i
 \end{equation}
 %%%%%%%%%%%%%%%
- Lorsqu'on utilise la représentation des angles de Euler, le vecteur de vitesse angulaire est définie directement avec la dérivée temporelle des trois angles de Euler et leur axe de rotation respectif:
- %%%%%%%%%%%%%%%%
+Lorsqu'on utilise la représentation des angles de Euler, le vecteur de vitesse angulaire est défini directement avec la dérivée temporelle des trois angles de Euler et leur axe de rotation respectif:
+%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{w}_{d/a} = \dot{\phi} \hat{a}_3 + \dot{\theta} \hat{b}_1 + \dot{\psi} \hat{c}_3
+	\vec{w}_{d/a} = \dot{\phi} \hat{a}_3 + \dot{\theta} \hat{b}_1 + \dot{\psi} \hat{c}_3
 \end{equation}
 %%%%%%%%%%%%%%%
-voir la définition des angles et axes à la section \ref{sec:angeuler}. Comme la base vectorielle de l'équation vectorielle précédente n'est pas orthogonale, il faut faire attention car:
- %%%%%%%%%%%%%%%%
+voir la définition des angles et axes à la section \ref{sec:angeuler}. Comme la base vectorielle de l'équation vectorielle précédente n'est pas orthogonale, il faut faire attention, car:
+%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}
-\dot{w}_1  \\
-\dot{w}_2  \\
-\dot{w}_3
-\end{array}  \right]  \neq 
-\left[ \begin{array}{c}
-\dot{\phi}  \\
-\dot{\theta}   \\
-\dot{\psi}
-\end{array}  \right]
+	\left[ \begin{array}{c}
+			   \dot{w}_1  \\
+			   \dot{w}_2  \\
+			   \dot{w}_3
+	\end{array}  \right]  \neq
+	\left[ \begin{array}{c}
+			   \dot{\phi}  \\
+			   \dot{\theta}   \\
+			   \dot{\psi}
+	\end{array}  \right]
 \end{align}
 %%%%%%%%%%%%%%%
-Il faut convertir le vecteur $\vec{w}_{d/a}$ dans la base approprié pour déterminer ses composantes.
+Il faut convertir le vecteur $\vec{w}_{d/a}$ dans la base appropriée pour déterminer ses composantes.
 
 \subsection{Propriétés}
 
-Premièrement, une vitesse angulaire est le taux de variation d'une orientation relative entre deux bases. Tout comme les matrices de rotation pour être précis il faut donc noter les bases associés pour bien définir un vecteur de vitesse angulaire:
+Premièrement, une vitesse angulaire est le taux de variation d'une orientation relative entre deux bases. Tout comme les matrices de rotation pour être précis il faut donc noter les bases associées pour bien définir un vecteur de vitesse angulaire:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{w}_{b/a}
+	\vec{w}_{b/a}
 \end{equation}
 %%%%%%%%%%%%%%%
-est le taux de variation de l'orientation de la base $b$ par rapport à la base $a$. Selon si le vecteur $\vec{w}_{b/a}$ est exprimé dans la base $a$ ou $b$ deux expressions permettre de calculer la dérivée temporelle de la matrice de rotation associée:
+est le taux de variation de l'orientation de la base $b$ par rapport à la base $a$. Selon si le vecteur $\vec{w}_{b/a}$ est exprimé dans la base $a$ ou $b$, deux expressions permettent de calculer la dérivée temporelle de la matrice de rotation associée:
 %%%%%%%%%%%%%%%%
 \begin{equation}
 {}^{a}\dot{R}^b =  (\col{w}_{b/a}^a)^{\times} \, {}^{a}R^b =   {}^{a}R^b \, (\col{w}_{b/a}^b)^{\times}
 \end{equation}
 %%%%%%%%%%%%%%%
 
-Ensuite, il est à noter lors du calcul des dérivées temporelles des vecteurs unitaires, que la drivée obtenue est selon un observateur dans la base d'origine pour laquelle le vecteur de vitesse angulaire est calculé:
+Ensuite, il est à noter lors du calcul des dérivées temporelles des vecteurs unitaires, que la dérivée obtenue est selon un observateur dans la base d'origine pour laquelle le vecteur de vitesse angulaire est calculé:
 %%%%%%%%%%%%%%%%
 \begin{equation}
 {}^{a}\frac{d}{dt}\hat{b}_i = \vec{w}_{b/a} \times \hat{b}_i
@@ -285,14 +285,14 @@ Ensuite, il est à noter lors du calcul des dérivées temporelles des vecteurs 
 %%%%%%%%%%%%%%%
 donc pour obtenir une dérivée temporelle de $\hat{b}_i$ dans un référentiel inertiel, la base $a$ du vecteur de vitesse angulaire doit être inertielle.
 
-\paragraph{Addition} Une propriété utile pour calculer une vitesse angulaire totale, i.e. par rapport au référentiel inertiel, lorsqu'on a plusieurs vitesse angulaire relative (par exemple pour chacun des joints d'un robot), est qu'il suffit d'additionner les vecteur de vitesse angulaire. 
+\paragraph{Addition} Une propriété utile pour calculer une vitesse angulaire totale, c.-à-d. par rapport au référentiel inertiel, lorsqu'on a plusieurs vitesses angulaires relatives (par exemple pour chacun des joints d'un robot), est qu'il suffit d'additionner les vecteurs de vitesse angulaire.
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{w}_{d/a} = \vec{w}_{d/a}  + \vec{w}_{c/b} + \vec{w}_{b/a} 
-\label{eq:angspeedadd}
+	\vec{w}_{d/a} = \vec{w}_{d/a}  + \vec{w}_{c/b} + \vec{w}_{b/a}
+	\label{eq:angspeedadd}
 \end{equation}
 %%%%%%%%%%%%%%%
-\paragraph{Commutativité} Contrairement aux rotations, la combinaison de vecteurs de vitesses angulaires est commutative, i.e. l'ordre n'a pas d'importance:
+\paragraph{Commutativité} Contrairement aux rotations, la combinaison de vecteurs de vitesses angulaires est commutative, c.-à-d. l'ordre n'a pas d'importance:
 %%%%%%%%%%%%%%%%
 \begin{align}
 {}^aR^b \, {}^bR^c  &\neq {}^bR^c \, {}^aR^b  \\
@@ -312,47 +312,47 @@ donc pour obtenir une dérivée temporelle de $\hat{b}_i$ dans un référentiel 
 
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{a}_{B} = {}^{b}\frac{d}{dt} \vec{v}_{B} +  \vec{w}_{b/a} \, \times \, \vec{v}_{B}
-\quad \Leftrightarrow \quad 
-\col{a}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{v}}^b_{B} +  (\col{w}_{b/a}^b)^{\times} \col{v}^b_{B}  \right] 
+	\vec{a}_{B} = {}^{b}\frac{d}{dt} \vec{v}_{B} +  \vec{w}_{b/a} \, \times \, \vec{v}_{B}
+	\quad \Leftrightarrow \quad
+	\col{a}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{v}}^b_{B} +  (\col{w}_{b/a}^b)^{\times} \col{v}^b_{B}  \right]
 \end{align}
 %%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{a}_{B} = 
-{}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A} 
-+  
-{}^{b}\frac{d}{dt} \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
-+
-\underbrace{
-2 \vec{w}_{b/a} \, \times \, {}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
-}_{\text{Coriolis}}
-+
-\underbrace{
-\vec{w}_{b/a} \, \times \vec{w}_{b/a} \, \times \,
-\vec{r}_{B/A}
-}_{\text{Centrifuge}}
+	\vec{a}_{B} =
+	{}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
+	+
+	{}^{b}\frac{d}{dt} \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
+	+
+	\underbrace{
+		2 \vec{w}_{b/a} \, \times \, {}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
+	}_{\text{Coriolis}}
+	+
+	\underbrace{
+		\vec{w}_{b/a} \, \times \vec{w}_{b/a} \, \times \,
+		\vec{r}_{B/A}
+	}_{\text{Centrifuge}}
 \end{align}
 %%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{a}_{B}^{a} 
-= 
-{}^{a}R^b \left[ 
-\col{\ddot{r}}^b_{B/A}
-+ 
-(\col{\dot{w}}_{b/a}^b)^{\times} \col{r}^b_{B/A}  
-+
-\underbrace{
-2 (\col{w}_{b/a}^b)^{\times} \col{\dot{r}}^b_{B/A}  
-}_{\text{Coriolis}}
-+
-\underbrace{
-(\col{w}_{b/a}^b)^{\times} (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  
-}_{\text{Centrifuge}}
-\right] 
+	\col{a}_{B}^{a}
+	=
+	{}^{a}R^b \left[
+		\col{\ddot{r}}^b_{B/A}
+		+
+		(\col{\dot{w}}_{b/a}^b)^{\times} \col{r}^b_{B/A}
+		+
+		\underbrace{
+			2 (\col{w}_{b/a}^b)^{\times} \col{\dot{r}}^b_{B/A}
+		}_{\text{Coriolis}}
+		+
+		\underbrace{
+			(\col{w}_{b/a}^b)^{\times} (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}
+		}_{\text{Centrifuge}}
+		\right]
 \end{align}
 %%%%%%%%%%%%%%%
 
@@ -370,93 +370,93 @@ donc pour obtenir une dérivée temporelle de $\hat{b}_i$ dans un référentiel 
 La cinématique différentielle c'est l'étude de la relation entre le mouvement des joints et le mouvement associé de l'effecteur. Dans le chapitre \ref{sec:cine1}, les fonctions reliant la position de l'effecteur $\col{r}$ et la configuration du robot dans l'espace des joints $\col{q}$ ont été étudiées:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Cinématique directe:}  \quad \col{r} = f\left( \, \col{q} \, \right)  \quad  \text{inverse:} \quad \col{q} = f^{-1}\left( \, \col{r}  \, \right) 
+	\text{Cinématique directe:}  \quad \col{r} = f\left( \, \col{q} \, \right)  \quad  \text{inverse:} \quad \col{q} = f^{-1}\left( \, \col{r}  \, \right)
 \end{equation}
 %%%%%%%%%%%%%%%
 
 Plusieurs méthodes en robotique sont plutôt basées sur les fonctions qui relient la vitesse de l'effecteur $\col{\dot{r}}$ à la vitesse des joints $\col{\dot{q}}$. Ces fonctions prennent la forme suivante:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Cinématique différentielle directe:} \quad \col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}   \quad \text{inverse:} \quad \col{\dot{q}} = J^{-1}\left( \, \col{q} \, \right) \, \col{\dot{r}}
-\label{eq:diffkinrel}
+	\text{Cinématique différentielle directe:} \quad \col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}   \quad \text{inverse:} \quad \col{\dot{q}} = J^{-1}\left( \, \col{q} \, \right) \, \col{\dot{r}}
+	\label{eq:diffkinrel}
 \end{equation}
 %%%%%%%%%%%%%%%
-Les fonctions de cinématique différentielle impliquent une matrice Jacobienne qui relit des déplacements infinitésimales des joints aux déplacements infinitésimales de l'effecteur:
+Les fonctions de cinématique différentielle impliquent une matrice Jacobienne qui relit des déplacements infinitésimaux des joints aux déplacements infinitésimaux de l'effecteur:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Matrice Jacobienne:} \quad J\left( \col{q} \right) = \frac{\partial \col{r}}{\partial \col{q}} = 
-\left[ \begin{array}{c c c} 
-\frac{\partial r_1 }{\partial q_1}   &  \hdots & \frac{\partial r_1 }{\partial q_n} \\ 
-\vdots                               &  \ddots & \vdots                             \\
-\frac{\partial r_m }{\partial q_1}   &  \hdots & \frac{\partial r_m }{\partial q_n}
-\end{array} \right]_{m \times n}
-\label{eq:matricejaco}
+	\text{Matrice Jacobienne:} \quad J\left( \col{q} \right) = \frac{\partial \col{r}}{\partial \col{q}} =
+	\left[ \begin{array}{c c c}
+			   \frac{\partial r_1 }{\partial q_1}   &  \hdots & \frac{\partial r_1 }{\partial q_n} \\
+			   \vdots                               &  \ddots & \vdots                             \\
+			   \frac{\partial r_m }{\partial q_1}   &  \hdots & \frac{\partial r_m }{\partial q_n}
+	\end{array} \right]_{m \times n}
+	\label{eq:matricejaco}
 \end{equation}
 %%%%%%%%%%%%%%%%
-ou $n$ est le nombre de joints, i.e. le nombre de DDL du robot, et $m$ est le nombre de coordonnées de l'espace sortie, par exemple la pose de l'effecteur.  D'un point de vue mathématique, la matrice Jacobienne $J$ correspond au gradient de la fonction multi-variable $\col{r} = f\left( \, \col{q} \, \right)$. Plus de détails sur la dérivation dans un contexte multi-variable sont disponibles à la section \ref{sec:vecmatdifferentiation}.
+où $n$ est le nombre de joints, c.-à-d. le nombre de DDL du robot, et $m$ est le nombre de coordonnées de l'espace sortie, par exemple la pose de l'effecteur.  D'un point de vue mathématique, la matrice Jacobienne $J$ correspond au gradient de la fonction multi-variable $\col{r} = f\left( \, \col{q} \, \right)$. Plus de détails sur la dérivation dans un contexte multi-variable sont disponibles à la section \ref{sec:vecmatdifferentiation}.
 
-La composante $J_{ij}$ de la matrice correspond à la variation de la coordonnée $r_i$ de l'effecteur, due à un déplacement unitaire du joint $q_j$. La relation entre les déplacements infinitésimales est données par:
+La composante $J_{ij}$ de la matrice correspond à la variation de la coordonnée $r_i$ de l'effecteur, due à un déplacement unitaire du joint $q_j$. La relation entre les déplacements infinitésimaux est donnée par:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
 %%%%%%%%%%%%%%%%%%%%
 %d\col{r}  = J(\col{q}) d\col{q}
-\left[ \begin{array}{c}  \\ d\col{r} \\ \\
-\end{array} \right]_{m \times 1}
-&= 
-\left[ \begin{array}{c c c} 
-&&\\
-& J(\col{q}) &\\
-&&
-\end{array} \right]_{m \times n}
-\left[ \begin{array}{c} 
-\\ d\col{q} \\ \\
-\end{array} \right]_{n \times 1}
+	\left[ \begin{array}{c}  \\ d\col{r} \\ \\
+	\end{array} \right]_{m \times 1}
+	&=
+	\left[ \begin{array}{c c c}
+			   &&\\
+			   & J(\col{q}) &\\
+			   &&
+	\end{array} \right]_{m \times n}
+	\left[ \begin{array}{c}
+			   \\ d\col{q} \\ \\
+	\end{array} \right]_{n \times 1}
 %%%%%%%%%%%%%%%%%%%%
-\quad \Leftrightarrow \quad
+	\quad \Leftrightarrow \quad
 %%%%%%%%%%%%%%%%%%%%
 %\underbrace{
-dr_j
+	dr_j
 %}_{mouvement de l'effecteur selon l'axe $j$}
 %\underbrace{
-= \sum_i^n{
+	= \sum_i^n{
 %}_{somme des contributions des joints}
 %\underbrace{
-J_{ji} 
+		J_{ji}
 %}_{bras de levier}
 %\underbrace{
-dq_i
+		dq_i
 %}_{mouvement du joint $i$}
-}
-\quad \quad j \in \left\{ 1 , ... , m \right\}
-\label{eq:diffkin1}
+	}
+	\quad \quad j \in \left\{ 1 , ... , m \right\}
+	\label{eq:diffkin1}
 %%%%%%%%%%%%%%%%%%%%
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
 
 
-La relation qui relit les vitesses est relié à la relation entre les déplacements infinitésimales par le principe des dérivées en chaînes:
+La relation qui relit les vitesses est reliée à la relation entre les déplacements infinitésimaux par le principe des dérivées en chaînes:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Dérivées en chaînes:} 
-\underbrace{
-\frac{d \col{r}}{dt}
-}_{\col{\dot{r}}}
-= 
-\underbrace{
-\left( \frac{\partial \col{r}}{\partial \col{q}} \right)
-}_{J(\col{q})}
-\underbrace{
-\frac{d \col{q}}{dt}
-}_{\col{\dot{q}}}
+	\text{Dérivées en chaînes:}
+	\underbrace{
+		\frac{d \col{r}}{dt}
+	}_{\col{\dot{r}}}
+	=
+	\underbrace{
+		\left( \frac{\partial \col{r}}{\partial \col{q}} \right)
+	}_{J(\col{q})}
+	\underbrace{
+		\frac{d \col{q}}{dt}
+	}_{\col{\dot{q}}}
 \end{equation}
 %%%%%%%%%%%%%%%%
-autrement dit, il suffit de diviser l'équation \eqref{eq:diffkin1} par $dt$ pour obtenir la relation entres les vitesses. 
+autrement dit, il suffit de diviser l'équation \eqref{eq:diffkin1} par $dt$ pour obtenir la relation entres les vitesses.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.5\textwidth]{diff_kin.jpg}
-	\caption{Le Jacobien décrit la relation entre des déplacements infinitésimal}
+	\includegraphics[width=0.5\textwidth]{diff_kin.jpg}
+	\caption{Le Jacobien décrit la relation entre des déplacements infinitésimaux}
 	\label{fig:diff_kin_variation}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -466,22 +466,22 @@ autrement dit, il suffit de diviser l'équation \eqref{eq:diffkin1} par $dt$ pou
 \subsection{La matrice Jacobienne}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\paragraph{Unités} Typiquement pour les analyse de cinématique différentielle, les variables de sortie sont les DDL de translation de l'effecteur, la pose complète de l'effecteur ou bien des variables qui décrivent les DDL de l'espace de la tâche; et les variables d'entrée sont les vitesse angulaire ou linéaire des joints du robot. Les unités des composantes $J_{ij}$ de la matrice Jacobienne associée sont donc typiquement soit des unités de distance qui correspondent à des \textit{bras de levier}, ou bien des ratios adimensionnels. 
+\paragraph{Unités} Typiquement pour les analyses de cinématique différentielle, les variables de sortie sont les DDL de translation de l'effecteur, la pose complète de l'effecteur ou bien des variables qui décrivent les DDL de l'espace de la tâche; et les variables d'entrée sont les vitesses angulaires ou linéaires des joints du robot. Les unités des composantes $J_{ij}$ de la matrice Jacobienne associée sont donc typiquement soit des unités de distance qui correspondent à des \textit{bras de levier}, ou bien des ratios adimensionnels.
 
-\paragraph{Non-linéarité} Il est important de noter que généralement la matrice Jacobienne est une fonction de la configuration $\col{q}$ du robot. Comme la fonction de cinématique directe est généralement hautement non-linéaire, l'effet d'un déplacement infinitésimal d'un joint sur l'effecteur dépend considérablement de la configuration initiale. La matrice Jacobienne est donc seulement valide pour décrire des petites variation déplacement autour de la configuration pour laquelle elle a été évaluée, ou bien pour la relation entre les vitesses momentanément à cette configuration. 
+\paragraph{Non-linéarité} Il est important de noter que généralement la matrice Jacobienne est une fonction de la configuration $\col{q}$ du robot. Comme la fonction de cinématique directe est généralement hautement non-linéaire, l'effet d'un déplacement infinitésimal d'un joint sur l'effecteur dépend considérablement de la configuration initiale. La matrice Jacobienne est donc seulement valide pour décrire de petites variations de déplacement autour de la configuration pour laquelle elle a été évaluée, ou bien pour la relation entre les vitesses momentanément à cette configuration.
 
-\paragraph{Colonnes de la matrice Jacobienne} Comme illustré à la Figure \ref{fig:jaco_graph}, dans le contexte de cinématique différentiel, la colonne $j$ de la matrice Jacobienne correspond à un vecteur déplacement infinitésimal de l'effecteur due au mouvement du joint $j$:
+\paragraph{Colonnes de la matrice Jacobienne} Comme illustré à la Figure \ref{fig:jaco_graph}, dans le contexte de cinématique différentiel, la colonne $j$ de la matrice Jacobienne correspond à un vecteur déplacement infinitésimal de l'effecteur dû au mouvement du joint $j$:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-J = \left[ \frac{\partial \col{r}}{\partial q_1}   \hdots \frac{\partial \col{r}}{\partial q_i} \hdots \frac{\partial \col{r}}{\partial q_n}  \right]
+	J = \left[ \frac{\partial \col{r}}{\partial q_1}   \hdots \frac{\partial \col{r}}{\partial q_i} \hdots \frac{\partial \col{r}}{\partial q_n}  \right]
 \end{equation}
 %%%%%%%%%%%%%%%%
 Chaque colonne a donc une interprétation vectorielle visuelle comme illustré à la Figure suivante.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-\vspace{-5pt}
+	\vspace{-5pt}
 	\centering
-		\includegraphics[width=0.75\textwidth]{jaco_graph.jpg}
+	\includegraphics[width=0.75\textwidth]{jaco_graph.jpg}
 	\caption{Illustration vectorielle du Jacobian du manipulateur (relation de translation)}
 	\vspace{-5pt}
 	\label{fig:jaco_graph}
@@ -492,118 +492,118 @@ Chaque colonne a donc une interprétation vectorielle visuelle comme illustré �
 
 \paragraph{Produits vectoriels}
 
-Lorsque l'espace de la tâche associé à un Jacobien correspond à la position cartésienne de l'effecteur d'un robot, chaque colonne du Jacobien peut aussi être déterminée basé sur un calcul vectoriel avec l'axe de rotation du joint associé. Si on considère d'abord un joint prismatique $i$, l'effet infinitésimal de son déplacement est une translation d'amplitude $\partial q_i$ dans une direction qui correspond à l'axe de translation du joint $\hat{z}_i$. Pour un joint rotatif $i$, l'effet est plutôt une rotation des membrures en aval du joint $i$ autour de l'axe de rotation du joint $\hat{z}_i$. Si on utile un repère mobile qui tourne avec toute les membrures en aval du joint $i$, les composantes de vecteurs position en aval ne varie pas, c'est la vitesse angulaire de la base vectorielle mobile qui explique la vitesse. Donc comme vue à la section \ref{sec:diffposmobilebase}, cet effet peut être représenté mathématiquement par un produit vectoriel. Le mouvement à l'effecteur (résultant de la rotation d'un axe seulement) peut donc ici être calculé par le produit vectoriel du vecteur de vitesse angulaire (l'axe de rotation fois le taux de variation de l'angle de rotation) avec le vecteur position entre l'effecteur et le centre de rotation du joint. En termes de déplacements infinitésimal de l'effecteur dus aux déplacements de joints, la relation est
+Lorsque l'espace de la tâche associé à un Jacobien correspond à la position cartésienne de l'effecteur d'un robot, chaque colonne du Jacobien peut aussi être déterminée basé sur un calcul vectoriel avec l'axe de rotation du joint associé. Si l'on considère d'abord un joint prismatique $i$, l'effet infinitésimal de son déplacement est une translation d'amplitude $\partial q_i$ dans une direction qui correspond à l'axe de translation du joint $\hat{z}_i$. Pour un joint rotatif $i$, l'effet est plutôt une rotation des membrures en aval du joint $i$ autour de l'axe de rotation du joint $\hat{z}_i$. Si l'on utilise un repère mobile qui tourne avec toute les membrures en aval du joint $i$, les composantes des vecteurs position en aval ne varient pas, c'est la vitesse angulaire de la base vectorielle mobile qui explique la vitesse. Donc comme vue à la section \ref{sec:diffposmobilebase}, cet effet peut être représenté mathématiquement par un produit vectoriel. Le mouvement à l'effecteur (résultant de la rotation d'un axe seulement) peut donc ici être calculé par le produit vectoriel du vecteur de vitesse angulaire (l'axe de rotation fois le taux de variation de l'angle de rotation) avec le vecteur position entre l'effecteur et le centre de rotation du joint. En termes de déplacements infinitésimaux de l'effecteur dus aux déplacements de joints, la relation est
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\partial \Vec{r} = \left\{ \begin{array}{c}
-\left( \partial q_i \right) \, \hat{z}_i \quad \text{pour un joint $i$ prismatique}
- \\ \\
-\left( \partial q_i \right) \, \hat{z}_i \, \times \, \vec{r}_{T_o/Z_i}
-\quad \text{pour un joint $i$ rotatif}
-\end{array}
-\right.
+	\partial \Vec{r} = \left\{ \begin{array}{c}
+								   \left( \partial q_i \right) \, \hat{z}_i \quad \text{pour un joint $i$ prismatique}
+								   \\ \\
+								   \left( \partial q_i \right) \, \hat{z}_i \, \times \, \vec{r}_{T_o/Z_i}
+								   \quad \text{pour un joint $i$ rotatif}
+	\end{array}
+	\right.
 \end{equation}
 %%%%%%%%%%%%%%%%
-où $q_i$ est la position du joint $i$, $\hat{z}_i$ est l'axe de rotation ou de translation du joint, $\vec{r}$ est le vecteur position de l'effecteur par rapport à une origine fixe et $\vec{r}_{T_o/Z_i}$ est le vecteur position de l'effecteur par rapport à un point d'origine $Z_i$ sur l'axe de rotation du joint $i$ (centre de rotation de ce mouvement). Cette relation vectorielle différentielle peut être utilisée pour obtenir une définition équivalente des colonnes du Jacobien: 
+où $q_i$ est la position du joint $i$, $\hat{z}_i$ est l'axe de rotation ou de translation du joint, $\vec{r}$ est le vecteur position de l'effecteur par rapport à une origine fixe et $\vec{r}_{T_o/Z_i}$ est le vecteur position de l'effecteur par rapport à un point d'origine $Z_i$ sur l'axe de rotation du joint $i$ (centre de rotation de ce mouvement). Cette relation vectorielle différentielle peut être utilisée pour obtenir une définition équivalente des colonnes du Jacobien:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Colonnes du Jacobien: } \quad
-\frac{\partial \col{r}}{\partial q_i} = \left\{ \begin{array}{c}
-\col{z}_i \quad \text{pour un joint $i$ prismatique}
- \\ \\
-\col{z}_i^{\times} \, \col{r}_{T_o/Z_i}
-\quad \text{pour un joint $i$ rotatif}
-\end{array}
-\right.
-\label{eq:jacocolprodvec}
+	\text{Colonnes du Jacobien: } \quad
+	\frac{\partial \col{r}}{\partial q_i} = \left\{ \begin{array}{c}
+														\col{z}_i \quad \text{pour un joint $i$ prismatique}
+														\\ \\
+														\col{z}_i^{\times} \, \col{r}_{T_o/Z_i}
+														\quad \text{pour un joint $i$ rotatif}
+	\end{array}
+	\right.
+	\label{eq:jacocolprodvec}
 \end{equation}
 %%%%%%%%%%%%%%%%
-ou toutes les composantes sont exprimée dans la base vectorielle fixe globale.
+où toutes les composantes sont exprimées dans la base vectorielle fixe globale.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-\vspace{-5pt}
+	\vspace{-5pt}
 	\centering
-		\includegraphics[width=0.40\textwidth]{jaco_vec.jpg}
-	\caption{Interprétation des colonnes du Jacobian comme un poduit vectoriel}
+	\includegraphics[width=0.40\textwidth]{jaco_vec.jpg}
+	\caption{Interprétation des colonnes du Jacobian comme un produit vectoriel}
 	\vspace{-5pt}
 	\label{fig:jaco_vec}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \note{Relation avec les paramètres \textit{DH}}{
-La définition des colonnes du Jacobien donnée à l'équation \eqref{eq:jacocolprodvec} est particulièrement utile pour calculer le Jacobien d'un robot manipulateur lorsqu'on a déjà déterminé les paramètres \textit{DH}. La convention de positionnement des repères fait que les axes de rotation $\col{z}_i$ et les vecteurs positions qui donnent la position des points $Z_i$ sont déjà calculés dans les matrices de transformation homogènes. Dans ce cas, cette technique peut être plus rapide que de calculer les dérivées partielles basée sur la définition donnée à l'équation \eqref{eq:matricejaco} pour construire la matrice Jacobienne.}
-%En effet, le vecteur-colonne $\col{z}_i$ correspond à la troisième colonne de la matrice de rotation $^{w}R^z$ qui donne l'orientation du lien rigide en aval du joint $i$ par rapport à la base vectorielle globale fixe. 
+	La définition des colonnes du Jacobien donnée à l'équation \eqref{eq:jacocolprodvec} est particulièrement utile pour calculer le Jacobien d'un robot manipulateur lorsqu'on a déjà déterminé les paramètres \textit{DH}. La convention de positionnement des repères fait que les axes de rotation $\col{z}_i$ et les vecteurs positions qui donnent la position des points $Z_i$ sont déjà calculés dans les matrices de transformation homogènes. Dans ce cas, cette technique peut être plus rapide que de calculer les dérivées partielles basées sur la définition donnée à l'équation \eqref{eq:matricejaco} pour construire la matrice Jacobienne.}
+%En effet, le vecteur-colonne $\col{z}_i$ correspond à la troisième colonne de la matrice de rotation $^{w}R^z$ qui donne l'orientation du lien rigide en aval du joint $i$ par rapport à la base vectorielle globale fixe.
 
 
 
 \paragraph{Cinématique différentielle pour l'orientation de l'effecteur}
 
-Lorsque ce n'est pas la position cartésienne de l'effecteur que l'on désire contrôler mais plutôt sont orientation, le vecteur sortie $\col{\dot{r}}$ contient alors les composantes du vecteur de vitesse angulaire de l'effecteur qui définie le taux de variation de l'orientation d'une base vectorielle $t$ fixée sur l'effecteur par rapport à une base fixe $a$ par rapport à la base du robot manipulateur. L'équation de cinématique différentiel est alors caractérisé par l'addition des vecteurs de vitesse angulaire relative pour chacun des joints d'un système, basée sur l'équation \eqref{eq:angspeedadd}, pour un robot à 6 joints:
+Lorsque ce n'est pas la position cartésienne de l'effecteur que l'on désire contrôler, mais plutôt son orientation, le vecteur sortie $\col{\dot{r}}$ contient alors les composantes du vecteur de vitesse angulaire de l'effecteur qui définie le taux de variation de l'orientation d'une base vectorielle $t$ fixée sur l'effecteur par rapport à une base fixe $a$ par rapport à la base du robot manipulateur. L'équation de cinématique différentielle est alors caractérisée par l'addition des vecteurs de vitesse angulaire relative pour chacun des joints d'un système, basé sur l'équation \eqref{eq:angspeedadd}, pour un robot à 6 joints:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{w}_{t/w} = \vec{w}_{t/f} + \vec{w}_{f/e} + \vec{w}_{e/d} + \vec{w}_{d/c} + \vec{w}_{c/b} + \vec{w}_{b/a} 
+	\vec{w}_{t/w} = \vec{w}_{t/f} + \vec{w}_{f/e} + \vec{w}_{e/d} + \vec{w}_{d/c} + \vec{w}_{c/b} + \vec{w}_{b/a}
 \end{align}
 %%%%%%%%%%%%%%%%
-où les base $b$, $c$, $d$, $e$ et $f$ sont des bases vectorielles intermédiaires sur les joints (voire Figure \ref{fig:serial_kin_3}).
-Donc le cas commun où le robot manipulateur a seulement des joints rotatifs à un degrée de liberté, chacun vecteur de vitesse angulaire est simplement l'axe de rotation $\hat{z}_i$ fois de taux de variation de l'angle: 
+où les bases $b$, $c$, $d$, $e$ et $f$ sont des bases vectorielles intermédiaires sur les joints (voire Figure \ref{fig:serial_kin_3}).
+Donc le cas commun où le robot manipulateur a seulement des joints rotatifs à un degré de liberté, chacun vecteur de vitesse angulaire est simplement l'axe de rotation $\hat{z}_i$ fois de taux de variation de l'angle:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{w}_{t/w} &= \hat{z}_6 \dot{q}_6 +  \hat{z}_5 \dot{q}_5 +  \hat{z}_4 \dot{q}_4 +  \hat{z}_3 \dot{q}_3 +  \hat{z}_2 \dot{q}_2 +  \hat{z}_1 \dot{q}_1 \\
-\col{w} &= 
-\underbrace{
-\left[ \, \col{z}_1 \, \col{z}_2 \, \col{z}_3 \, \col{z}_4 \, \col{z}_5 \, \col{z}_6 \, \right]  
-}_{J_{ori}}
-\, \col{\dot{q}} 
+	\vec{w}_{t/w} &= \hat{z}_6 \dot{q}_6 +  \hat{z}_5 \dot{q}_5 +  \hat{z}_4 \dot{q}_4 +  \hat{z}_3 \dot{q}_3 +  \hat{z}_2 \dot{q}_2 +  \hat{z}_1 \dot{q}_1 \\
+	\col{w} &=
+	\underbrace{
+		\left[ \, \col{z}_1 \, \col{z}_2 \, \col{z}_3 \, \col{z}_4 \, \col{z}_5 \, \col{z}_6 \, \right]
+	}_{J_{ori}}
+	\, \col{\dot{q}}
 \end{align}
 %%%%%%%%%%%%%%%%
 Dans ce cas, les colonnes du Jacobien sont simplement les axes de rotation de chacun des joints. Pour des joints prismatiques, ils n'influencent pas l'orientation de l'effecteur et les colonnes du Jacobien associées à un joint prismatique sont donc nulles:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\text{Colonnes du Jacobien (orientation): } \quad\left\{ \begin{array}{c}
-\col{0} \quad \text{pour un joint $i$ prismatique}
- \\ \\
-\col{z}_i \quad \text{pour un joint $i$ rotatif}
-\end{array}
-\right.
+	\text{Colonnes du Jacobien (orientation): } \quad\left\{ \begin{array}{c}
+																 \col{0} \quad \text{pour un joint $i$ prismatique}
+																 \\ \\
+																 \col{z}_i \quad \text{pour un joint $i$ rotatif}
+	\end{array}
+	\right.
 \end{equation}
 %%%%%%%%%%%%%%%%
 %
-Un exemple où on s'intéresserait plutôt à l'orientation de système robotique, serait pour asservir une antenne de communication qui doit toujours être alignée avec un satellite. Dans ce cas, l'effecteur du système est la parabole de l'antenne et c'est sont orientation spatiale qui est importante seulement. 
+Un exemple où l'on s'intéresserait plutôt à l'orientation de système robotique serait pour asservir une antenne de communication qui doit toujours être alignée avec un satellite. Dans ce cas, l'effecteur du système est la parabole de l'antenne et c'est son orientation spatiale qui est importante seulement.
 
 \paragraph{Cinématique différentielle pour la pose de l'effecteur}
 
-Si on désire décrire de taux de variation de la pose complète de l'effecteur, il suffit de combiner les systèmes linéaire la translation et l'orientation:
+Si l'on désire décrire de taux de variation de la pose complète de l'effecteur, il suffit de combiner les systèmes linéaires de la translation et l'orientation:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\dot{r}} &= \left[ J_{trans} \right]  \, \col{\dot{q}} \quad \quad 
-J_{trans} = \left[ \hdots \col{z}_i^{\times} \, \col{r}_{T_o/Z_i}  \hdots  \right] \\
-\col{w} &= \left[ J_{ori} \right]  \, \col{\dot{q}} \quad \quad 
-J_{ori}   = \left[ \hdots   \col{z}_i  \hdots  \right] \\
-\left[  \begin{array}{c}
-\col{\dot{r}} \\ \col{w}
-\end{array} \right] &= \left[ J_{pose} \right]  \, \col{\dot{q}} \quad \quad 
-J_{pose}  = \left[ \begin{array}{c}
-J_{trans} \\ J_{ori} 
-\end{array} \right] 
+	\col{\dot{r}} &= \left[ J_{trans} \right]  \, \col{\dot{q}} \quad \quad
+	J_{trans} = \left[ \hdots \col{z}_i^{\times} \, \col{r}_{T_o/Z_i}  \hdots  \right] \\
+	\col{w} &= \left[ J_{ori} \right]  \, \col{\dot{q}} \quad \quad
+	J_{ori}   = \left[ \hdots   \col{z}_i  \hdots  \right] \\
+	\left[  \begin{array}{c}
+				\col{\dot{r}} \\ \col{w}
+	\end{array} \right] &= \left[ J_{pose} \right]  \, \col{\dot{q}} \quad \quad
+	J_{pose}  = \left[ \begin{array}{c}
+						   J_{trans} \\ J_{ori}
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%
 
 
 \paragraph{Cinématique différentielle pour un espace de la tâche}
 
-Il est aussi possible de définir un matrice Jacobienne pour une relation spécifique à une tâche. Par exemple, voir Figure \ref{fig:spaces}, où il serait désirable d'obtenir les équations qui relit la position/vitesse des joints et celle de la tâche décrite en termes de $x$ et $y$ sur un plan particulier. Si on a un espace de la tâche de dimension $m$ (normalement égale ou inférieur au nombre de DDL de l'effecteur du robot), alors on peut déterminer matrice Jacobienne $m$ par $n$. 
+Il est aussi possible de définir une matrice Jacobienne pour une relation spécifique à une tâche. Par exemple, voir Figure \ref{fig:spaces}, où il serait désirable d'obtenir les équations qui relient la position/vitesse des joints et celle de la tâche décrite en termes de $x$ et $y$ sur un plan particulier. Si l'on a un espace de la tâche de dimension $m$ (normalement égale ou inférieur au nombre de DDL de l'effecteur du robot), alors on peut déterminer la matrice Jacobienne $m$ par $n$.
 %%%%%%%%%%%%%%%%
 \begin{align}
-\Big[ \col{r}_{task} \Big]_{m \times 1} = f_{task}( \col{q} )
-\quad \Rightarrow \quad 
-\Big[ \col{\dot{r}}\Big]_{m \times 1}_{task} &= \Big[ J_{task} \Big]_{m \times n}  \, \Big[ \col{\dot{q}} \Big]_{n \times 1}
+	\Big[ \col{r}_{task} \Big]_{m \times 1} = f_{task}( \col{q} )
+	\quad \Rightarrow \quad
+	\Big[ \col{\dot{r}}\Big]_{m \times 1}_{task} &= \Big[ J_{task} \Big]_{m \times n}  \, \Big[ \col{\dot{q}} \Big]_{n \times 1}
 \end{align}
 %%%%%%%%%%%%%%%%
 
 \note{Note de lecture}{
-Pour les sections suivantes, s'il n'est pas préciser autrement on va toujours travailler avec la relation cinématique de translation seulement de l'effecteur pour l'explication des concepts. Les exemples sont visuellement plus clair dans cette situation. Toutefois, tout les concepts présentés se généralisent à toutes les situations.
+	Pour les sections suivantes, s'il n'est pas précisé autrement on va toujours travailler avec la relation cinématique de translation seulement de l'effecteur pour l'explication des concepts. Les exemples sont visuellement plus clairs dans cette situation. Toutefois, tous les concepts présentés se généralisent à toutes les situations.
 }
 
 \newpage
@@ -613,12 +613,12 @@ Pour les sections suivantes, s'il n'est pas préciser autrement on va toujours t
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Cinématique différentielle d'un robot cartésien}
 
-La Figure \ref{fig:jaco_robot_cart} illustre un robot planaire constitué de deux actionneurs linéaires basé sur des vis à billes qui sont assemblés à 90 degrées. 
+La Figure \ref{fig:jaco_robot_cart} illustre un robot planaire constitué de deux actionneurs linéaires basé sur des vis à billes qui sont assemblés à 90 degrés.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\vspace{-5pt}
 	\centering
-		\includegraphics[width=0.65\textwidth]{jaco_robot_cart.jpg}
+	\includegraphics[width=0.65\textwidth]{jaco_robot_cart.jpg}
 	\caption{Jacobien pour un robot cartésien}
 	\vspace{-5pt}
 	\label{fig:jaco_robot_cart}
@@ -628,39 +628,39 @@ La Figure \ref{fig:jaco_robot_cart} illustre un robot planaire constitué de deu
 Pour ce robot, chaque actionneur linéaire contrôle de façon indépendante la translation $x$ et $y$ de l'effecteur, la fonction de cinématique directe est donnée par :
 %%%%%%%%%%%%%%%%
 \begin{align}
-\quad \col{r} &= f\left( \, \col{q} \, \right)  \\
-\left[ \begin{array}{c} x \\ y  \end{array} \right]  &= \left[ \begin{array}{c} a_1 q_1 \\ a_2 q_2  \end{array} \right]
-\label{eq:fwdkinlin}
+	\quad \col{r} &= f\left( \, \col{q} \, \right)  \\
+	\left[ \begin{array}{c} x \\ y  \end{array} \right]  &= \left[ \begin{array}{c} a_1 q_1 \\ a_2 q_2  \end{array} \right]
+	\label{eq:fwdkinlin}
 \end{align}
 %%%%%%%%%%%%%%%
-ou les variables $a_i$ sont des constantes qui relient la rotation angulaire des vis aux déplacements linéaires. La relation différentielle peut alors être calculée:
+où les variables $a_i$ sont des constantes qui relient la rotation angulaire des vis aux déplacements linéaires. La relation différentielle peut alors être calculée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{ \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right] }_{\dot{\col{r}}}
- &= 
-\underbrace{ \left[ \begin{array}{c c } 
-\frac{\partial x }{\partial q_1}   & \frac{\partial x }{\partial q_2} \\ 
-\frac{\partial y }{\partial q_1}   & \frac{\partial y }{\partial q_2}
-\end{array} \right]  }_{ J } 
-\underbrace{ \left[ \begin{array}{c} 
-\dot{q}_1 \\ 
-\dot{q}_2 
-\end{array} \right]}_{ \dot{\col{q}} } \\
+	\underbrace{ \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right] }_{\dot{\col{r}}}
+	&=
+	\underbrace{ \left[ \begin{array}{c c }
+							\frac{\partial x }{\partial q_1}   & \frac{\partial x }{\partial q_2} \\
+							\frac{\partial y }{\partial q_1}   & \frac{\partial y }{\partial q_2}
+	\end{array} \right]  }_{ J }
+	\underbrace{ \left[ \begin{array}{c}
+							\dot{q}_1 \\
+							\dot{q}_2
+	\end{array} \right]}_{ \dot{\col{q}} } \\
 %%%%%%%%%%%%%
-\underbrace{ \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right] }_{\dot{\col{r}}}
- &= 
-\underbrace{ \left[ \begin{array}{c c } 
-a_1 & 0 \\ 
-0   & a_2
-\end{array} \right]  }_{ J } 
-\underbrace{ \left[ \begin{array}{c} 
-\dot{q}_1 \\ 
-\dot{q}_2 
-\end{array} \right]}_{ \dot{\col{q}} } \\
-\end{align} 
+	\underbrace{ \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right] }_{\dot{\col{r}}}
+	&=
+	\underbrace{ \left[ \begin{array}{c c }
+							a_1 & 0 \\
+							0   & a_2
+	\end{array} \right]  }_{ J }
+	\underbrace{ \left[ \begin{array}{c}
+							\dot{q}_1 \\
+							\dot{q}_2
+	\end{array} \right]}_{ \dot{\col{q}} } \\
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Il est a noter ici que: \textbf{1)} la matrice Jacobienne est diagonale car chaque joint influence indépendamment un seul DDL de l'effecteur. \textbf{2)} la matrice Jacobienne est constante et indépendante de $\col{q}$ car la relation de cinématique directe, voir équation \eqref{eq:fwdkinlin}, est linéaire. 
+Il est à noter ici que: \textbf{1)} la matrice Jacobienne est diagonale, car chaque joint influence indépendamment un seul DDL de l'effecteur. \textbf{2)} la matrice Jacobienne est constante et indépendante de, $\col{q}$ car la relation de cinématique directe, voir équation \eqref{eq:fwdkinlin}, est linéaire.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -670,50 +670,50 @@ Il est a noter ici que: \textbf{1)} la matrice Jacobienne est diagonale car chaq
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.65\textwidth]{robot_2dof.png}
+	\includegraphics[width=0.65\textwidth]{robot_2dof.png}
 	\caption{Robot à deux joints}
 	\label{fig:robot_2dof}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Pour un robot manipulateur planaire à deux DDL, comme illustré à la Figure \ref{fig:robot_2dof}, la fonction de cinématique directe est données par:
+Pour un robot manipulateur planaire à deux DDL, comme illustré à la Figure \ref{fig:robot_2dof}, la fonction de cinématique directe est donnée par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{r} &= \left[ \begin{array}{c} x \\ y  \end{array} \right]  = \left[ \begin{array}{c} 
- l_1 c_1 + l_2 c_{12} \\ 
- l_1 s_1 + l_2 s_{12}  
-\end{array} \right] 
-\label{eq:kinfwd2dof}
-\end{align} 
+	\col{r} &= \left[ \begin{array}{c} x \\ y  \end{array} \right]  = \left[ \begin{array}{c}
+																				 l_1 c_1 + l_2 c_{12} \\
+																				 l_1 s_1 + l_2 s_{12}
+	\end{array} \right]
+	\label{eq:kinfwd2dof}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 avec
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-c_1    &= \cos( q_1 ) \\
-s_1    &= \sin( q_1 ) \\
-c_{12} &= \cos( q_1 + q_2 ) \\
-s_{12} &= \sin( q_1 + q_2 )
-\end{align} 
+	c_1    &= \cos( q_1 ) \\
+	s_1    &= \sin( q_1 ) \\
+	c_{12} &= \cos( q_1 + q_2 ) \\
+	s_{12} &= \sin( q_1 + q_2 )
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 On peut alors trouver la relation différentielle en dérivant par rapport au temps:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\dot{\col{r}} &= \frac{d\col{r}}{dt} = \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right]  = \left[ \begin{array}{c} 
--l_1 s_1 \dot{q}_1 - l_2 s_{12}( \dot{q}_1 + \dot{q}_2 ) \\ 
- l_1 c_1 \dot{q}_1 + l_2 c_{12}( \dot{q}_1 + \dot{q}_2 )  
-\end{array} \right] \\
-\dot{\col{r}}  &= 
-\underbrace{ \left[ \begin{array}{c c } 
--l_1 s_1 - l_2 s_{12} & - l_2 s_{12} \\ 
- l_1 c_1 + l_2 c_{12} &   l_2 c_{12}
-\end{array} \right]  }_{ J(\col{q}) } 
-\underbrace{ \left[ \begin{array}{c} 
-\dot{q}_1 \\ 
-\dot{q}_2 
-\end{array} \right]}_{ \dot{\col{q}} } \\
-\dot{\col{r}}  &= J(\col{q}) \dot{\col{q}}
-\end{align} 
+	\dot{\col{r}} &= \frac{d\col{r}}{dt} = \left[ \begin{array}{c} \dot{x} \\ \dot{y}  \end{array} \right]  = \left[ \begin{array}{c}
+																														 -l_1 s_1 \dot{q}_1 - l_2 s_{12}( \dot{q}_1 + \dot{q}_2 ) \\
+																														 l_1 c_1 \dot{q}_1 + l_2 c_{12}( \dot{q}_1 + \dot{q}_2 )
+	\end{array} \right] \\
+	\dot{\col{r}}  &=
+	\underbrace{ \left[ \begin{array}{c c }
+							-l_1 s_1 - l_2 s_{12} & - l_2 s_{12} \\
+							l_1 c_1 + l_2 c_{12} &   l_2 c_{12}
+	\end{array} \right]  }_{ J(\col{q}) }
+	\underbrace{ \left[ \begin{array}{c}
+							\dot{q}_1 \\
+							\dot{q}_2
+	\end{array} \right]}_{ \dot{\col{q}} } \\
+	\dot{\col{r}}  &= J(\col{q}) \dot{\col{q}}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -723,12 +723,12 @@ On peut alors trouver la relation différentielle en dérivant par rapport au te
 \subsubsection{Cinématique différentielle d'un robot à trois joints}
 \label{sec:diffkinrobot3dofex}
 
-Les Figures \pageref{fig:jaco_3dof_a} et \ref{fig:jaco_3dof_b} illustre la cinématique différentielle d'un robot à trois joints dans une configuration qui permet de bien visualiser indépendamment les effets du mouvement de chaque joint. 
+Les Figures \pageref{fig:jaco_3dof_a} et \ref{fig:jaco_3dof_b} illustre la cinématique différentielle d'un robot à trois joints dans une configuration qui permet de bien visualiser indépendamment les effets du mouvement de chaque joint.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.75\textwidth]{jaco_3dof_a.jpg}
+	\includegraphics[width=0.75\textwidth]{jaco_3dof_a.jpg}
 	\caption{Jacobien d'un robot à trois joints - partie a)}
 	\label{fig:jaco_3dof_a}
 \end{figure}
@@ -737,7 +737,7 @@ Les Figures \pageref{fig:jaco_3dof_a} et \ref{fig:jaco_3dof_b} illustre la ciné
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.85\textwidth]{jaco_3dof_b.jpg}
+	\includegraphics[width=0.85\textwidth]{jaco_3dof_b.jpg}
 	\caption{Jacobien d'un robot à trois joints - partie b)}
 	\label{fig:jaco_3dof_b}
 \end{figure}
@@ -748,57 +748,57 @@ Les Figures \pageref{fig:jaco_3dof_a} et \ref{fig:jaco_3dof_b} illustre la ciné
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Cinématique différentielle inverse}
 
-Lorsque le problème de cinématique différentielle est inversé, c'est-à-dire lorsqu'on cherche un vecteur de vitesse aux joints $\col{\dot{q}}$ qui va produire une vitesse de l'effecteur spécifiée $\col{\dot{r}}$, il faut inverser la relation mathématique. Lorsque la matrice Jacobienne est carré et non-singulière, il suffit de multiplier la relation $\col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}$ par l'inverse du Jacobien des deux côtés de l'équation pour obtenir la relation:
+Lorsque le problème de cinématique différentielle est inversé, c'est-à-dire lorsqu'on cherche un vecteur de vitesse aux joints $\col{\dot{q}}$ qui va produire une vitesse de l'effecteur spécifiée $\col{\dot{r}}$, il faut inverser la relation mathématique. Lorsque la matrice Jacobienne est carrée et non-singulière, il suffit de multiplier la relation $\col{\dot{r}} = J\left( \, \col{q} \, \right) \, \col{\dot{q}}$ par l'inverse du Jacobien des deux côtés de l'équation pour obtenir la relation:
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\dot{q}} = J^{-1}\left( \, \col{q} \, \right) \, \col{\dot{r}}
-\end{align} 
+	\col{\dot{q}} = J^{-1}\left( \, \col{q} \, \right) \, \col{\dot{r}}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Toutefois, cette opération est impossible si le robot a une configuration singulière (voir section \ref{sec:singu}). De plus, si les dimensions de $\col{q}$ et $\col{r}$ sont différentes, la matrice Jacobienne est rectangulaire et d'autres techniques doivent être utilisée (voir sections \ref{sec:invdiffkinredondant} et \ref{sec:overconstraintrobot})
+Toutefois, cette opération est impossible si le robot a une configuration singulière (voir section \ref{sec:singu}). De plus, si les dimensions de $\col{q}$ et $\col{r}$ sont différentes, la matrice Jacobienne est rectangulaire et d'autres techniques doivent être utilisées (voir sections \ref{sec:invdiffkinredondant} et \ref{sec:overconstraintrobot})
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Les singularités}
 \label{sec:singu}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Certaine configuration $\col{q}$ d'un robot manipulateur peuvent être singulière, c'est-à-dire des configuration pour lesquelles il est impossible d'inverser la matrice Jacobienne. Les configurations singulière sont l'ensemble des configurations pour lesquelles le déterminant de la matrice Jacobienne est nul:
+Certaines configurations $\col{q}$ d'un robot manipulateur peuvent être singulières, c'est-à-dire qu'il y a des configurations pour lesquelles il est impossible d'inverser la matrice Jacobienne. Les configurations singulières sont l'ensemble des configurations pour lesquelles le déterminant de la matrice Jacobienne est nul:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{Singularités :} \quad \{  \col{q} \; | \; det(J(\col{q})) = 0 \}
-\end{align} 
+	\text{Singularités :} \quad \{  \col{q} \; | \; det(J(\col{q})) = 0 \}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Ces situations correspondent aussi à lorsque les colonnes de $J$ sont co-linéaires, et qu'aucune combinaison linéaire ne permet de déplacer l'effecteur dans au moins une direction (la matrice Jacobienne a un left-nullspace, voir section \ref{sec:leftnullspace} pour les notions d'algèbre linéaire associées). 
+Ces situations correspondent aussi à lorsque les colonnes de $J$ sont colinéaires, et qu'aucune combinaison linéaire ne permet de déplacer l'effecteur dans au moins une direction (la matrice Jacobienne a un left-nullspace, voir section \ref{sec:leftnullspace} pour les notions d'algèbre linéaire associées).
 
 
 \subsubsection{Singularités pour un robot manipulateur 2 DDL}
 
-Pour un robot manipulateur à deux DDl comme décrit à l'exemple \ref{sec:kindiff_2dof}, le Jacobien est donné par:
+Pour un robot manipulateur à deux DDL comme décrit à l'exemple \ref{sec:kindiff_2dof}, le Jacobien est donné par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-J = \left[ \begin{array}{c c} 
--(l_1 s_1 + l_2 s_{12}) & - l_2 s_{12} \\
- (l_1 c_1 + l_2 c_{12}) &   l_2 c_{12}
-\end{array} \right]
-\end{align} 
+	J = \left[ \begin{array}{c c}
+				   -(l_1 s_1 + l_2 s_{12}) & - l_2 s_{12} \\
+				   (l_1 c_1 + l_2 c_{12}) &   l_2 c_{12}
+	\end{array} \right]
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Le déterminant de la matrice est donnée par:
+Le déterminant de la matrice est donné par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-det(J) &= l_2 s_{12} (l_1 c_1 + l_2 c_{12}) - l_2 c_{12} (l_1 s_1 + l_2 s_{12}) \\
-       &= l_1 l_2 s_{12} c_1 + l_2^2 s_{12} c_{12} - l_1 l_2 s_1 c_{12} - l_2^2 s_{12} c_{12} \\
-			 &= l_1 l_2 ( s_1 c_{12} - c_1 s_{12} ) \\
-			 &= l_1 l_2 s_2
-\end{align} 
+	det(J) &= l_2 s_{12} (l_1 c_1 + l_2 c_{12}) - l_2 c_{12} (l_1 s_1 + l_2 s_{12}) \\
+	&= l_1 l_2 s_{12} c_1 + l_2^2 s_{12} c_{12} - l_1 l_2 s_1 c_{12} - l_2^2 s_{12} c_{12} \\
+	&= l_1 l_2 ( s_1 c_{12} - c_1 s_{12} ) \\
+	&= l_1 l_2 s_2
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Donc les singularités sont les configurations avec un angle $q_2$ égale à 0 ou 180 degrés. Comme illustré à la Figure \ref{fig:sigularite_2dof}, ces configurations correspondent à lorsque les deux liens rigides du robot sont alignés. Dans ces configurations, il est seulement possible de faire bouger l'effecteur dans une direction perpendiculaire aux liens rigides. Comme illustré à la Figure \ref{fig:sigularite_2dof_b}, la direction pour laquelle le mouvement est possible correspond à l'espace colonne de la matrice Jacobienne, et la direction orthogonale pour laquelle il est impossible de déplacer l'effecteur correspond au left-nullspace de la matrice Jacobienne, voir section \ref{sec:4espfond} pour les notions d'algèbre linéaire associées.
+Donc les singularités sont les configurations avec un angle $q_2$ égal à 0 ou 180 degrés. Comme illustré à la Figure \ref{fig:sigularite_2dof}, ces configurations correspondent à lorsque les deux liens rigides du robot sont alignés. Dans ces configurations, il est seulement possible de faire bouger l'effecteur dans une direction perpendiculaire aux liens rigides. Comme illustré à la Figure \ref{fig:sigularite_2dof_b}, la direction pour laquelle le mouvement est possible correspond à l'espace colonne de la matrice Jacobienne, et la direction orthogonale pour laquelle il est impossible de déplacer l'effecteur correspond au left-nullspace de la matrice Jacobienne, voir section \ref{sec:4espfond} pour les notions d'algèbre linéaire associées.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.75\textwidth]{sigularite_2dof.png}
+	\includegraphics[width=0.75\textwidth]{sigularite_2dof.png}
 	\caption{Singularités pour un robot manipulateur à deux DDL}
 	\label{fig:sigularite_2dof}
 \end{figure}
@@ -807,8 +807,8 @@ Donc les singularités sont les configurations avec un angle $q_2$ égale à 0 o
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.95\textwidth]{sigularite_2dof_b.png}
-	\caption{Co-linéarité des colonnes du Jacobien pour une singularité}
+	\includegraphics[width=0.95\textwidth]{sigularite_2dof_b.png}
+	\caption{Colinéarité des colonnes du Jacobien pour une singularité}
 	\label{fig:sigularite_2dof_b}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -819,83 +819,83 @@ Donc les singularités sont les configurations avec un angle $q_2$ égale à 0 o
 \label{sec:invdiffkinredondant}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Si le nombre d'entrées $n$ est plus grand que le nombre de sorties $m$ : 
+Si le nombre d'entrées $n$ est plus grand que le nombre de sorties $m$ :
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-n > m
-\end{align} 
+	n > m
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-avec 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-n &= dim(\col{q}) = \quad\text{Nombre de DDL du robot} \\
-m &= dim(\col{r}) = \quad\text{Coordonnées de l'espace de la tâche} 
-\end{align} 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-le robot est dit redondant, et le problème de cinématique différentiel inverse est sous-contraint: il y a plusieurs solutions possible de déplacement des joints qui produisent un même déplacement de l'effecteur. Le Jacobien d'une telle situation est rectangulaire, il a plus de colonnes que de rangées:
+avec
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}  \\ \dot{\col{r}} \\ \\
-\end{array} \right]_{m \times 1}
-&= 
-\left[ \begin{array}{c c c c c} 
-&&&&\\
-&& J(\col{q}) &&\\
-&&&&
-\end{array} \right]_{m \times n}
-\left[ \begin{array}{c} 
-\\ \\ \dot{\col{q}} \\ \\ \\
-\end{array} \right]_{n \times 1}
-\label{eq:underconstraintdiffkin}
-\end{align} 
+	n &= dim(\col{q}) = \quad\text{Nombre de DDL du robot} \\
+	m &= dim(\col{r}) = \quad\text{Coordonnées de l'espace de la tâche}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Cette situation nous même à un problème d'algèbre linéaire sous-contraint qui peu être résolu avec une méthode qui utilise une matrice pseudo inverse, voir section \ref{sec:pseudoinverse} pour les notions d'algèbre linéaire. Cette situation est aussi caractérisée par la présence d'un nullspace: une combinaison de déplacement des joints peut avoir un effet net nul sur l'effecteur, voir section \ref{sec:nullspace} pour les notions d'algèbre linéaire et l'exemple \ref{fig:4spaces_ex1}. 
+le robot est dit redondant, et le problème de cinématique différentielle inverse est sous-contraint: il y a plusieurs solutions possibles de déplacement des joints qui produisent un même déplacement de l'effecteur. Le Jacobien d'une telle situation est rectangulaire, il a plus de colonnes que de rangées:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{align}
+	\left[ \begin{array}{c}  \\ \dot{\col{r}} \\ \\
+	\end{array} \right]_{m \times 1}
+	&=
+	\left[ \begin{array}{c c c c c}
+			   &&&&\\
+			   && J(\col{q}) &&\\
+			   &&&&
+	\end{array} \right]_{m \times n}
+	\left[ \begin{array}{c}
+			   \\ \\ \dot{\col{q}} \\ \\ \\
+	\end{array} \right]_{n \times 1}
+	\label{eq:underconstraintdiffkin}
+\end{align}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Cette situation nous même à un problème d'algèbre linéaire sous-contraint qui peut être résolu avec une méthode qui utilise une matrice pseudo inverse, voir section \ref{sec:pseudoinverse} pour les notions d'algèbre linéaire. Cette situation est aussi caractérisée par la présence d'un nullspace: une combinaison de déplacement des joints peut avoir un effet net nul sur l'effecteur, voir section \ref{sec:nullspace} pour les notions d'algèbre linéaire et l'exemple \ref{fig:4spaces_ex1}.
 
 Une méthode pour travailler avec ce genre de situation consiste à utiliser l'équation de cinématique inverse suivante:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}  \\ \\ \dot{\col{q}} \\ \\ \\
-\end{array} \right]_{n \times 1}
-&= 
-\underbrace{
-\left[ \begin{array}{c c c} 
-&&\\ &&\\ & J^{\#} & \\&& \\ &&
-\end{array} \right]_{n \times m}
-}_{\text{Pseudo-inverse}}
-\left[ \begin{array}{c} 
-\\ \dot{\col{r}} \\ \\
-\end{array} \right]_{m \times 1} + 
-\underbrace{
-\left[ \begin{array}{c c c c c} 
-&&&&\\ &&&&\\ && I - J^{\#}J && \\&&&& \\ &&&&
-\end{array} \right]_{n \times n}
-}_{\text{Projection sur le Nullspace}}
-\left[ \begin{array}{c} 
-\\ \\ \col{\psi} \\ \\ \\
-\end{array} \right]_{n \times 1}
-\label{eq:pseudoinversediffkin}
-\end{align} 
+	\left[ \begin{array}{c}  \\ \\ \dot{\col{q}} \\ \\ \\
+	\end{array} \right]_{n \times 1}
+	&=
+	\underbrace{
+		\left[ \begin{array}{c c c}
+				   &&\\ &&\\ & J^{\#} & \\&& \\ &&
+		\end{array} \right]_{n \times m}
+	}_{\text{Pseudo-inverse}}
+	\left[ \begin{array}{c}
+			   \\ \dot{\col{r}} \\ \\
+	\end{array} \right]_{m \times 1} +
+	\underbrace{
+		\left[ \begin{array}{c c c c c}
+				   &&&&\\ &&&&\\ && I - J^{\#}J && \\&&&& \\ &&&&
+		\end{array} \right]_{n \times n}
+	}_{\text{Projection sur le Nullspace}}
+	\left[ \begin{array}{c}
+			   \\ \\ \col{\psi} \\ \\ \\
+	\end{array} \right]_{n \times 1}
+	\label{eq:pseudoinversediffkin}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 avec $J^{\#}$ qui est la matrice pseudo-inverse droite de Moore–Penrose, définie par:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-J^{\#} = J^T\, (JJ^T)^{-1}
-\end{align} 
+	J^{\#} = J^T\, (JJ^T)^{-1}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Le premier terme $J^{\#} \col{\dot{r}}$ produit un vecteur $\col{\dot{q}}$ qui produit une solution exacte pour le système d'équations \eqref{eq:underconstraintdiffkin}
-et minimise la norme du vecteur-colonne $\col{\dot{q}}$. Le second terme produit une variation pour le vecteur $\col{\dot{q}}$ qui réside dans le nullspace de la matrice $J$, donc cette variation n'a aucun influence sur la sortie et n’affectera pas l'objectif principal d'obtenir un vecteur $\col{\dot{q}}$ qui produit un mouvement de l'effecteur donné par $\col{\dot{r}}$. Le vecteur $\col{\psi}$ dans le second terme est arbitraire et peut être utilisé pour prioriser certaine solutions sans influencer la justesse de la solution. 
+et minimise la norme du vecteur-colonne $\col{\dot{q}}$. Le second terme produit une variation pour le vecteur $\col{\dot{q}}$ qui réside dans le nullspace de la matrice $J$, donc cette variation n'a aucune influence sur la sortie et n’affectera pas l'objectif principal d'obtenir un vecteur $\col{\dot{q}}$ qui produit un mouvement de l'effecteur donné par $\col{\dot{r}}$. Le vecteur $\col{\psi}$ dans le second terme est arbitraire et peut être utilisé pour prioriser certaines solutions sans influencer la justesse de la solution.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Exemple de cinématique différentielle inverse pour une situation sous-contrainte}
 
 
-Le robot de l'exemple \ref{sec:diffkinrobot3dofex} est ici analysé en termes de cinématique différentielle, la Figure \ref{fig:robot_redo_a} illustre la présence de plusieurs solutions possibles et la Figure \ref{fig:robot_redo_c} illustre l'utilisation de la matrice pseudo-inverse pour obtenir la solution optimale ainsi que le nullspace. 
+Le robot de l'exemple \ref{sec:diffkinrobot3dofex} est ici analysé en termes de cinématique différentielle, la Figure \ref{fig:robot_redo_a} illustre la présence de plusieurs solutions possibles et la Figure \ref{fig:robot_redo_c} illustre l'utilisation de la matrice pseudo-inverse pour obtenir la solution optimale ainsi que le nullspace.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.65\textwidth]{robot_redo_a.png}
+	\includegraphics[width=0.65\textwidth]{robot_redo_a.png}
 	\caption{Cinématique différentielle inverse d'un robot redondant ($n=3>m=2$)}
 	\label{fig:robot_redo_a}
 \end{figure}
@@ -903,18 +903,18 @@ Le robot de l'exemple \ref{sec:diffkinrobot3dofex} est ici analysé en termes de
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{figure}[H]
-	%\centering
-		%\includegraphics[width=0.55\textwidth]{robot_redo_b.png}
-	%%\caption{Co-linéarité des colonnes du Jacobien pour une singularité}
-	%\label{fig:robot_redo_b}
+%\centering
+%\includegraphics[width=0.55\textwidth]{robot_redo_b.png}
+%%\caption{Co-linéarité des colonnes du Jacobien pour une singularité}
+%\label{fig:robot_redo_b}
 %\end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.55\textwidth]{robot_redo_b.png}
-		\includegraphics[width=0.95\textwidth]{robot_redo_c.png}
+	\includegraphics[width=0.55\textwidth]{robot_redo_b.png}
+	\includegraphics[width=0.95\textwidth]{robot_redo_c.png}
 	\caption{Cinématique différentielle inverse d'un robot redondant: solution optimale et nullspace}
 	\label{fig:robot_redo_c}
 \end{figure}
@@ -929,45 +929,45 @@ Le robot de l'exemple \ref{sec:diffkinrobot3dofex} est ici analysé en termes de
 \label{sec:overconstraintrobot}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Si le nombre d'entrées $n$ est plus petit que le nombre de sorties $m$ : 
+Si le nombre d'entrées $n$ est plus petit que le nombre de sorties $m$ :
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-n < m
-\end{align} 
+	n < m
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-avec 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\begin{align}
-n &= dim(\col{q}) = \quad\text{Nombre de DDL du robot} \\
-m &= dim(\col{r}) = \quad\text{Coordonnées de l'espace de la tâche} 
-\end{align} 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-le problème de cinématique différentiel inverse est sur-contraint: il n'y a pas de solutions exactes possibles sauf pour un sous-ensemble de déplacements de l'effecteur. Le Jacobien d'une telle situation est rectangulaire, il a plus de rangées que de colonnes:
+avec
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}  \\ \\ \dot{\col{r}} \\ \\ \\ 
-\end{array} \right]_{m \times 1}
-&= 
-\left[ \begin{array}{c c c} 
-&&\\
-&&\\
-& J(\col{q}) &\\
-&&\\
-&&
-\end{array} \right]_{m \times n}
-\left[ \begin{array}{c} 
-\\ \dot{\col{q}} \\ \\
-\end{array} \right]_{n \times 1}
-\label{eq:uoverconstraintdiffkin}
-\end{align} 
+	n &= dim(\col{q}) = \quad\text{Nombre de DDL du robot} \\
+	m &= dim(\col{r}) = \quad\text{Coordonnées de l'espace de la tâche}
+\end{align}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+le problème de cinématique différentielle inverse est sur-contraint: il n'y a pas de solutions exactes possibles sauf pour un sous-ensemble de déplacements de l'effecteur. Le Jacobien d'une telle situation est rectangulaire, il a plus de rangées que de colonnes:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{align}
+	\left[ \begin{array}{c}  \\ \\ \dot{\col{r}} \\ \\ \\
+	\end{array} \right]_{m \times 1}
+	&=
+	\left[ \begin{array}{c c c}
+			   &&\\
+			   &&\\
+			   & J(\col{q}) &\\
+			   &&\\
+			   &&
+	\end{array} \right]_{m \times n}
+	\left[ \begin{array}{c}
+			   \\ \dot{\col{q}} \\ \\
+	\end{array} \right]_{n \times 1}
+	\label{eq:uoverconstraintdiffkin}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Un méthode pratique pour la cinématique inverse dans ce contexte est la méthode des moindres-carré, voir la section \ref{sec:moindrecarre} pour les notions d'algèbre linéaire. L'utilisation de cette méthode permet de calculer explicitement un vecteur solution approximé $\col{\hat{\dot{q}}}$ qui minimise la norme de l'erreur entre une vitesse à l'effecteur désiré et celle obtenue avec la solution approximée. La solution au sens des moindres-carrée est calculée ainsi:
+Une méthode pratique pour la cinématique inverse dans ce contexte est la méthode des moindres carrés, voir la section \ref{sec:moindrecarre} pour les notions d'algèbre linéaire. L'utilisation de cette méthode permet de calculer explicitement un vecteur solution approximé $\col{\hat{\dot{q}}}$ qui minimise la norme de l'erreur entre une vitesse à l'effecteur désiré et celle obtenue avec la solution approximée. La solution au sens des moindres-carrée est calculée ainsi:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\hat{\dot{q}}} = \operatornamewithlimits{argmin}\limits_{\col{\dot{q}}} \left\| J \col{\dot{q}} - \col{\dot{r}} \right\|^2 = \left( J^T J\right)^{-1} J^T \, \dot{\col{r}}
-\label{eq:overconstraintdiffkinleastsquare}
-\end{align} 
+	\col{\hat{\dot{q}}} = \operatornamewithlimits{argmin}\limits_{\col{\dot{q}}} \left\| J \col{\dot{q}} - \col{\dot{r}} \right\|^2 = \left( J^T J\right)^{-1} J^T \, \dot{\col{r}}
+	\label{eq:overconstraintdiffkinleastsquare}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -977,7 +977,7 @@ Un méthode pratique pour la cinématique inverse dans ce contexte est la métho
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.55\textwidth]{robot_under.png}
+	\includegraphics[width=0.55\textwidth]{robot_under.png}
 	\caption{Cinématique différentielle inverse pour une situation sur-contrainte ($n=1<m=2$)}
 	\label{fig:robot_under}
 \end{figure}
@@ -1002,61 +1002,61 @@ Un méthode pratique pour la cinématique inverse dans ce contexte est la métho
 Pour faire le lien en l'accélération dans l'espace des joints et l'accélération dans l'espace de la tâche, il suffit de dériver par rapport au temps l'expression de la cinématique différentielle, autrement dit on dérive deux fois par rapport au temps l'équation de la cinématique directe:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\text{Cinématique directe:}  \quad \col{r} &= f\left( \, \col{q} \, \right) \\
-\text{Cinématique différentielle:} \quad \col{\dot{r}} &= J\left( \, \col{q} \, \right) \, \col{\dot{q}} \\
-\text{Cinématique différentielle ordre-2:} \quad \col{\ddot{r}} &= J\left( \, \col{q} \, \right) \, \col{\ddot{q}}  + \dot{J} \left( \, \col{q}  , \col{\dot{q}} \, \right) \, \col{\dot{q}} 
-\label{eq:ddj}
+	\text{Cinématique directe:}  \quad \col{r} &= f\left( \, \col{q} \, \right) \\
+	\text{Cinématique différentielle:} \quad \col{\dot{r}} &= J\left( \, \col{q} \, \right) \, \col{\dot{q}} \\
+	\text{Cinématique différentielle ordre-2:} \quad \col{\ddot{r}} &= J\left( \, \col{q} \, \right) \, \col{\ddot{q}}  + \dot{J} \left( \, \col{q}  , \col{\dot{q}} \, \right) \, \col{\dot{q}}
+	\label{eq:ddj}
 \end{align}
 %%%%%%%%%%%%%%%
-Comme on dérive un produit avec deux termes qui varient dans le temps, l'accélération $\col{\ddot{r}}$ est le résultat de deux effets représentés par deux termes. Le premier terme est simplement l'accélération des joints fois le Jacobien, i.e. les bras de leviers. Le deuxième terme est une contribution à l'accélération de l'effecteur qui vient de la variation temporelle du Jacobien. Comme le Jacobien a seulement une dépendance directe aux positions $\col{q}$, on peut exprimer son taux de variation temporelle comme sa dérivée par rapport à $\col{q}$ fois le vecteur-colonne de vitesse $\col{\dot{q}}$, selon le principe de dérivée en chaînes:
+Comme on dérive un produit avec deux termes qui varient dans le temps, l'accélération $\col{\ddot{r}}$ est le résultat de deux effets représentés par deux termes. Le premier terme est simplement l'accélération des joints fois le Jacobien, c.-à-d. les bras de levier. Le deuxième terme est une contribution à l'accélération de l'effecteur qui vient de la variation temporelle du Jacobien. Comme le Jacobien a seulement une dépendance directe aux positions $\col{q}$, on peut exprimer son taux de variation temporelle comme sa dérivée par rapport à $\col{q}$ fois le vecteur-colonne de vitesse $\col{\dot{q}}$, selon le principe de dérivée en chaînes:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\dot{J} = \frac{ \partial J}{\partial \col{q}} \, \col{\dot{q}} 
+	\dot{J} = \frac{ \partial J}{\partial \col{q}} \, \col{\dot{q}}
 \end{align}
 %%%%%%%%%%%%%%%
-Toutefois ici, on dérive une matrice $m \times n$ par un vecteur-colonne $n \times 1$, le résultat est donc un tenseur (ses composantes si on veux être rigoureux) d'ordre 3, i.e. une matrice 3D $m \times n \times n$ :
+Toutefois ici, on dérive une matrice $m \times n$ par un vecteur-colonne $n \times 1$, le résultat est donc un tenseur (ses composantes si l'on veut être rigoureux) d'ordre 3, c.-à-d. une matrice 3D $m \times n \times n$ :
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
 %%%%%%%%%%%%%%%%%%%%
-\left[ \begin{array}{c}  \\ \dot{J} \\ \\
-\end{array} \right]_{m \times n}
-&= 
-\underbrace{
-\left[ \begin{array}{c c c} 
-&&\\
-& \frac{ \partial J}{\partial \col{q}} &\\
-&&
-\end{array} \right]_{m \times n \times n}}_{\text{Tenseur d'ordre 3
+	\left[ \begin{array}{c}  \\ \dot{J} \\ \\
+	\end{array} \right]_{m \times n}
+	&=
+	\underbrace{
+		\left[ \begin{array}{c c c}
+				   &&\\
+				   & \frac{ \partial J}{\partial \col{q}} &\\
+				   &&
+		\end{array} \right]_{m \times n \times n}}_{\text{Tenseur d'ordre 3
 %\footnote{Techniquement c'est les composantes du tenseur qui sont contenue dans une "matrice" à 3 dimensions.}
-}}
-\left[ \begin{array}{c} 
-\\ \col{\dot{q}} \\ \\
-\end{array} \right]_{n \times 1}
+	}}
+	\left[ \begin{array}{c}
+			   \\ \col{\dot{q}} \\ \\
+	\end{array} \right]_{n \times 1}
 %%%%%%%%%%%%%%%%%%%%
-\label{eq:jdot}
+	\label{eq:jdot}
 \end{align}
 %%%%%%%%%%%%%%%
-Lorsqu'on travail avec des tenseurs d'ordre 3 et plus, il est normalement plus facile de travailler avec des équations qui relient les composantes avec une notation indicielle. La composante $ijk$ du tenseur qui résultent de la dérivation du Jacobien $J$ par $\col{q}$ est égale à la dérivée de l'élément $ij$ du Jacobien par rapport à l'élément $k$ du vecteur-colonne $\col{q}$:
+Lorsqu'on travaille avec des tenseurs d'ordre 3 et plus, il est normalement plus facile de travailler avec des équations qui relient les composantes avec une notation indicielle. La composante $ijk$ du tenseur qui résultent de la dérivation du Jacobien $J$ par $\col{q}$ est égale à la dérivée de l'élément $ij$ du Jacobien par rapport à l'élément $k$ du vecteur-colonne $\col{q}$:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\left[\frac{ \partial J}{\partial \col{q}} \right]_{ijk} = \frac{ \partial J_{ij} }{\partial q_k } 
+	\left[\frac{ \partial J}{\partial \col{q}} \right]_{ijk} = \frac{ \partial J_{ij} }{\partial q_k }
 \end{align}
 %%%%%%%%%%%%%%%
- Donc le produit intérieur exprimé à l'équation \eqref{eq:jdot} peut être exprimé directement comme une sommation à effectuer pour calculer l'élément $ij$ de la matrice $\dot{J}$:
+Donc le produit intérieur exprimé à l'équation \eqref{eq:jdot} peut être exprimé directement comme une sommation à effectuer pour calculer l'élément $ij$ de la matrice $\dot{J}$:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\dot{J}_{ij} = \sum_k \left( \frac{ \partial J_{ij} }{\partial q_k } \dot{q}_k \right)
+	\dot{J}_{ij} = \sum_k \left( \frac{ \partial J_{ij} }{\partial q_k } \dot{q}_k \right)
 \end{align}
 %%%%%%%%%%%%%%%
 Finalement, il est possible d'exprimer directement l'équation \eqref{eq:ddj} en termes de composantes, d'indices et de sommations:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\ddot{r}_{i} =  
-\sum_j J_{ij} \ddot{q}_j
-+
-\sum_j 
-\sum_k  \frac{ \partial J_{ij} }{\partial q_k } \dot{q}_k 
-\dot{q}_j
+	\ddot{r}_{i} =
+	\sum_j J_{ij} \ddot{q}_j
+	+
+	\sum_j
+	\sum_k  \frac{ \partial J_{ij} }{\partial q_k } \dot{q}_k
+	\dot{q}_j
 \end{align}
 %%%%%%%%%%%%%%%
 Plus de détails sur les équivalences entre les opérations en termes de matrices/vecteur-colonnes/tenseurs et les opérations en termes de composantes et d'indices sont disponibles à la section \ref{sec:vectoropindex}.
@@ -1071,59 +1071,59 @@ Plus de détails sur les équivalences entre les opérations en termes de matric
 Vecteur vitesse et dérivée d'un vecteur position (base $b$ non-inertielle)
 %%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{
-\vec{v}_{B} = {}^{b}\frac{d}{dt} \vec{r}_{B/A} +  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
-}_{\text{Relation vectorielle}}
-\quad \Leftrightarrow \quad 
-\underbrace{
-\col{v}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{r}}^b_{B/A} +  (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  \right] 
-}_{\text{Relation matricielle des composantes}}
+	\underbrace{
+		\vec{v}_{B} = {}^{b}\frac{d}{dt} \vec{r}_{B/A} +  \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
+	}_{\text{Relation vectorielle}}
+	\quad \Leftrightarrow \quad
+	\underbrace{
+		\col{v}_{B}^{a} = {}^{a}R^b \left[ \col{\dot{r}}^b_{B/A} +  (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  \right]
+	}_{\text{Relation matricielle des composantes}}
 \end{align}
 %%%%%%%%%%%%%%%
 
 Vecteur accélération et dérivée seconde d'un vecteur position
 %%%%%%%%%%%%%%%%
 \begin{align}
-\vec{a}_{B} = 
-{}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A} 
-+  
-{}^{b}\frac{d}{dt} \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
-+
-\underbrace{
-2 \vec{w}_{b/a} \, \times \, {}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
-}_{\text{Coriolis}}
-+
-\underbrace{
-\vec{w}_{b/a} \, \times \vec{w}_{b/a} \, \times \,
-\vec{r}_{B/A}
-}_{\text{Centrifuge}}
+	\vec{a}_{B} =
+	{}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
+	+
+	{}^{b}\frac{d}{dt} \vec{w}_{b/a} \, \times \, \vec{r}_{B/A}
+	+
+	\underbrace{
+		2 \vec{w}_{b/a} \, \times \, {}^{b}\frac{d^2}{dt^2} \vec{r}_{B/A}
+	}_{\text{Coriolis}}
+	+
+	\underbrace{
+		\vec{w}_{b/a} \, \times \vec{w}_{b/a} \, \times \,
+		\vec{r}_{B/A}
+	}_{\text{Centrifuge}}
 \end{align}
 %%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{a}_{B}^{a} 
-= 
-{}^{a}R^b \left[ 
-\col{\ddot{r}}^b_{B/A}
-+ 
-(\col{\dot{w}}_{b/a}^b)^{\times} \col{r}^b_{B/A}  
-+
-\underbrace{
-2 (\col{w}_{b/a}^b)^{\times} \col{\dot{r}}^b_{B/A}  
-}_{\text{Coriolis}}
-+
-\underbrace{
-(\col{w}_{b/a}^b)^{\times} (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}  
-}_{\text{Centrifuge}}
-\right] 
+	\col{a}_{B}^{a}
+	=
+	{}^{a}R^b \left[
+		\col{\ddot{r}}^b_{B/A}
+		+
+		(\col{\dot{w}}_{b/a}^b)^{\times} \col{r}^b_{B/A}
+		+
+		\underbrace{
+			2 (\col{w}_{b/a}^b)^{\times} \col{\dot{r}}^b_{B/A}
+		}_{\text{Coriolis}}
+		+
+		\underbrace{
+			(\col{w}_{b/a}^b)^{\times} (\col{w}_{b/a}^b)^{\times} \col{r}^b_{B/A}
+		}_{\text{Centrifuge}}
+		\right]
 \end{align}
 %%%%%%%%%%%%%%%
 
 Dérivée temporelle d'une matrice de rotation:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-\dot{R} = \frac{d}{dt} R = (\col{w})^x \, R
+	\dot{R} = \frac{d}{dt} R = (\col{w})^x \, R
 \end{equation}
 %%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%
@@ -1135,20 +1135,21 @@ Dérivée temporelle d'une matrice de rotation:
 Relations différentielles entre l'espace des joints et de la tâche:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{r} &= f\left( \, \col{q} \, \right) \\
-\col{\dot{r}} &= J\left( \, \col{q} \, \right) \, \col{\dot{q}} \\
-\col{\ddot{r}} &= J\left( \, \col{q} \, \right) \, \col{\ddot{q}}  + \dot{J} \left( \, \col{q}  , \col{\dot{q}} \, \right) \, \col{\dot{q}} 
+	\col{r} &= f\left( \, \col{q} \, \right) \\
+	\col{\dot{r}} &= J\left( \, \col{q} \, \right) \, \col{\dot{q}} \\
+	\col{\ddot{r}} &= J\left( \, \col{q} \, \right) \, \col{\ddot{q}}  + \dot{J} \left( \, \col{q}  , \col{\dot{q}} \, \right) \, \col{\dot{q}}
 \end{align}
 %%%%%%%%%%%%%%%
 
 La matrice Jacobienne:
 %%%%%%%%%%%%%%%%
 \begin{equation}
-J\left( \col{q} \right) = \frac{\partial \col{r}}{\partial \col{q}} = 
-\left[ \begin{array}{c c c} 
-\frac{\partial r_1 }{\partial q_1}   &  \hdots & \frac{\partial r_1 }{\partial q_n} \\ 
-\vdots                               &  \ddots & \vdots                             \\
-\frac{\partial r_m }{\partial q_1}   &  \hdots & \frac{\partial r_m }{\partial q_n}
-\end{array} \right]_{m \times n}
+	J\left( \col{q} \right) = \frac{\partial \col{r}}{\partial \col{q}} =
+	\left[ \begin{array}{c c c}
+			   \frac{\partial r_1 }{\partial q_1}   &  \hdots & \frac{\partial r_1 }{\partial q_n} \\
+			   \vdots                               &  \ddots & \vdots                             \\
+			   \frac{\partial r_m }{\partial q_1}   &  \hdots & \frac{\partial r_m }{\partial q_n}
+	\end{array} \right]_{m \times n}
 \end{equation}
 %%%%%%%%%%%%%%%%
+

--- a/src/manip/static.tex
+++ b/src/manip/static.tex
@@ -9,92 +9,92 @@ Chapitre en construction!
 La relation entre les forces/couples dans l'espace des joints $\col{\tau}$ et un vecteur de forces externes $\vec{f}_e$ à l'effecteur d'un robot peut être décrite par la relation suivante:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e 
-\label{eq:staticmanipulator}
+	\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e
+	\label{eq:staticmanipulator}
 \end{align}
 %%%%%%%%%%%%%%%
-où la matrice Jacobienne $J$ est la même matrice de la relation de cinématique différentielle de l'équation \ref{eq:diffkinrel}. Comme illustré à la Figure \ref{fig:controlvolume}, les variables de forces/couples doivent correspondent aux même dégrées de liberté que les variables vitesses associées à la relation de cinématique différentielle. 
+où la matrice Jacobienne $J$ est la même matrice de la relation de cinématique différentielle de l'équation \ref{eq:diffkinrel}. Comme illustré à la Figure \ref{fig:controlvolume}, les variables de forces/couples doivent correspondre aux mêmes degrés de liberté que les variables vitesses associées à la relation de cinématique différentielle.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.75\textwidth]{fig/controlvolume.jpg}
+	\includegraphics[width=0.75\textwidth]{fig/controlvolume.jpg}
 	\caption{Bilan de puissance mécanique pour un robot manipulateur}
 	\label{fig:controlvolume}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La relation statique qui implique le Jacobien (eq. \eqref{eq:staticmanipulator} peut être déterminée à partir d'un bilan de puissance. Si on applique la 1ère loi de la thermodynamique au volume de contrôle indiqué à la Figure \ref{fig:controlvolume} pour calculer le bilan d'énergie:
+La relation statique qui implique le Jacobien (éq. \eqref{eq:staticmanipulator}) peut être déterminée à partir d'un bilan de puissance. Si on applique la 1re loi de la thermodynamique au volume de contrôle indiqué à la Figure \ref{fig:controlvolume} pour calculer le bilan d'énergie:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\frac{dE}{dt} = P_{in} - P_{out}
+	\frac{dE}{dt} = P_{in} - P_{out}
 \end{align}
 %%%%%%%%%%%%%%%
-Les forces internes inertielles et dissipatrices sont ici négligés pour trouver une relation valide dans des conditions quasi-statique. De plus considérons d'abord un cas sans force conservatrice (voir section \ref{sec:manipstaticconservative} pour ce cas) Dans ces conditions, il n'y a aucune accumulation d'énergie interne: les seules entrée/sorties de puissance dans le système sont le travail mécanique fait par les moteurs sur le robot, et le travail mécanique fait par le robot sur l'environnement. L'égalité du travail mécanique en entrée et sortie peut être convertie en relation matricielle:
+Ici, les forces internes inertielles et dissipatrices sont ici négligées pour trouver une relation valide dans des conditions quasi-statique. De plus, considérons d'abord un cas sans force conservatrice (voir section \ref{sec:manipstaticconservative} pour ce cas). Dans ces conditions, il n'y a aucune accumulation d'énergie interne: les seules entrées/sorties de puissance dans le système sont le travail mécanique fait par les moteurs sur le robot, et le travail mécanique fait par le robot sur l'environnement. L'égalité du travail mécanique en entrée et sortie peut être convertie en relation matricielle:
 %%%%%%%%%%%%%%%%
 \begin{align}
-P_{in} &= P_{out} \\
-\dot{q}_1 \tau_1  + \dot{q}_2 \tau_2 + \hdots  &= \Vec{v} \bullet \Vec{f}_e \\
-\left[ \begin{array}{c c c} 
-\dot{q}_1 & \dot{q}_2 & \hdots 
-\end{array} \right] \,
-\left[ \begin{array}{c} 
-\tau_1 \\ \tau_2 \\ \vdots 
-\end{array} \right] &= \col{\dot{r}}^T \col{f}_e \\
-\col{\dot{q}}^T \col{\tau} &= \col{\dot{r}}^T \col{f}_e \\
+	P_{in} &= P_{out} \\
+	\dot{q}_1 \tau_1  + \dot{q}_2 \tau_2 + \hdots  &= \Vec{v} \bullet \Vec{f}_e \\
+	\left[ \begin{array}{c c c}
+			   \dot{q}_1 & \dot{q}_2 & \hdots
+	\end{array} \right] \,
+	\left[ \begin{array}{c}
+			   \tau_1 \\ \tau_2 \\ \vdots
+	\end{array} \right] &= \col{\dot{r}}^T \col{f}_e \\
+	\col{\dot{q}}^T \col{\tau} &= \col{\dot{r}}^T \col{f}_e \\
 \end{align}
 %%%%%%%%%%%%%%%
-Ensuite, si on substitut les composantes du vecteur vitesse de l'effecteur $\col{\dot{r}}$ par l'équation de cinématique différentielle directe (eq. \eqref{eq:diffkinrel}, on obtient:
+Ensuite, si l'on substitue les composantes du vecteur vitesse de l'effecteur $\col{\dot{r}}$ par l'équation de cinématique différentielle directe (éq. \eqref{eq:diffkinrel},) on obtient:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\dot{q}}^T \col{\tau} &= \left( J( \col{q}) \,  \col{\dot{q}}  \right)^T \col{f}_e \\
-\col{\dot{q}}^T \col{\tau} &= \col{\dot{q}}^T  J( \col{q})^T \col{f}_e    \\
-\col{\dot{q}}^T \Big( \col{\tau} \Big) &= \col{\dot{q}}^T  \Big( J( \col{q})^T \col{f}_e \Big)   
-\quad \Rightarrow \quad \col{\tau} = J\left( \, \col{q} \, \right)^T \, \col{f}_e 
+	\col{\dot{q}}^T \col{\tau} &= \left( J( \col{q}) \,  \col{\dot{q}}  \right)^T \col{f}_e \\
+	\col{\dot{q}}^T \col{\tau} &= \col{\dot{q}}^T  J( \col{q})^T \col{f}_e    \\
+	\col{\dot{q}}^T \Big( \col{\tau} \Big) &= \col{\dot{q}}^T  \Big( J( \col{q})^T \col{f}_e \Big)
+	\quad \Rightarrow \quad \col{\tau} = J\left( \, \col{q} \, \right)^T \, \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%
-Donc les deux termes qui multiplient (produit intérieur) le vecteur colonne $\col{\dot{q}}$ doivent nécessairement être égaux, se qui nous donne l'équation qui relie les forces dans l'espace des joints aux forces équivalentes dans l'espace de la tâche. 
+Donc les deux termes qui multiplient (produit intérieur) le vecteur colonne $\col{\dot{q}}$ doivent nécessairement être égaux, ce qui nous donne l'équation qui relie les forces dans l'espace des joints aux forces équivalentes dans l'espace de la tâche.
 
 
 \subsection{Flux de puissance}
 
-Du point de vue du flux de puissance dans le système robotique, de l'énergie électrique vers le travail mécanique fait par le robot, la matrice Jacobien peut-être vue comme une matrice de ratios de transformation. Par exemple, les Figures \ref{fig:robotpowerflow1} et \ref{fig:robotpowerflow2} illustrent quelques unes des transformations de puissance dans un système robotique et les paramètres associées. Dans chacun des domaines la puissance est caractérisée par deux variables, une de flux (courant, vitesse, débit, etc.) et une de d'effort (tension, couple, force, pression, etc.). La puissance est le produit de ces deux variables, ou le produit intérieur des vecteurs-colonnes de ces variables dans le cas de systèmes multi-variables. Le flux de puissance peut être transformé par des dispositifs qu'on appelle des transformateurs. Un transformateur amplifie la variable de flux et réduit la variable d'effort, ou vice-versa. Par exemple, les transformateurs électriques qui réduise la tension dans un réseau électrique, les transmissions mécaniques avec ratios de réduction, etc. Lorsqu'un dispositif transfert la puissance sous une forme d'énergie différente, on les appelle des transducteurs, par exemple un moteur électrique. La puissance en entrée et en sortie des transformateurs est conservée, si l'effort est amplifié d'un facteur $T$ le flux est réduit d'un facteur $T$. 
+Du point de vue du flux de puissance dans le système robotique, de l'énergie électrique vers le travail mécanique fait par le robot, la matrice Jacobien peut-être vue comme une matrice de ratios de transformation. Par exemple, les Figures \ref{fig:robotpowerflow1} et \ref{fig:robotpowerflow2} illustrent quelques-unes des transformations de puissance dans un système robotique et les paramètres associés. Dans chacun des domaines la puissance est caractérisée par deux variables, une de flux (courant, vitesse, débit, etc.) et une d'effort (tension, couple, force, pression, etc.). La puissance est le produit de ces deux variables, ou le produit intérieur des vecteurs-colonnes de ces variables dans le cas de systèmes multi-variables. Le flux de puissance peut être transformé par des dispositifs qu'on appelle des transformateurs. Un transformateur amplifie la variable de flux et réduit la variable d'effort, ou vice-versa. Par exemple, les transformateurs électriques qui réduisent la tension dans un réseau électrique, les transmissions mécaniques avec ratios de réduction, etc. Lorsqu'un dispositif transfère la puissance sous une forme d'énergie différente, on les appelle des transducteurs, par exemple un moteur électrique. La puissance en entrée et en sortie des transformateurs est conservée, si l'effort est amplifié d'un facteur $T$ le flux est réduit d'un facteur $T$.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
 	\centering
-		\includegraphics[width=0.70\textwidth]{fig/robotpowerflow1.jpg}
+	\includegraphics[width=0.70\textwidth]{fig/robotpowerflow1.jpg}
 	\caption{Flux de puissance: les variables de flux et d'effort dans les différents domaines et espaces du robot.}
 	\label{fig:robotpowerflow1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les Figures \ref{fig:robotpowerflow1} et \ref{fig:robotpowerflow2} illustrent les trois transformations de puissances principales dans un bras robotique typique. La puissance électrique est transformée en puissance mécanique des l'arbre des moteurs par les moteurs électriques, ensuite celle-ci est transformée en puissance mécanique dans les joints du robot par les transmissions, et finalement la puissance mécanique dans les joints est transformé en puissance mécanique à l'effecteur du robot. La première transformation est caractérisée par les constantes moteurs:
+Les Figures \ref{fig:robotpowerflow1} et \ref{fig:robotpowerflow2} illustrent les trois transformations de puissances principales dans un bras robotique typique. La puissance électrique est transformée en puissance mécanique des l'arbre des moteurs par les moteurs électriques, ensuite celle-ci est transformée en puissance mécanique dans les joints du robot par les transmissions, et finalement la puissance mécanique dans les joints est transformée en puissance mécanique à l'effecteur du robot. La première transformation est caractérisée par les constantes moteurs:
 %%%%%%%%%%%%%%%%
 \begin{align}
 %\text{\underline{Scalaire}} \quad \quad \text{Multi-DDL } \\
-\tau = k_m I \quad \quad  \col{\tau} &= K \col{I} \\
-v = k_m w \quad \quad  \col{v} &= K \col{w}
+	\tau = k_m I \quad \quad  \col{\tau} &= K \col{I} \\
+	v = k_m w \quad \quad  \col{v} &= K \col{w}
 \end{align}
 %%%%%%%%%%%%%%%
 la deuxième transformation est caractérisée par les ratios de réductions des transmissions:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\tau = R \tau_m \quad \quad  \col{\tau} &= R \col{\tau_m } \\
-w = R q \quad \quad  \col{w} &= R \col{q}
+	\tau = R \tau_m \quad \quad  \col{\tau} &= R \col{\tau_m } \\
+	w = R q \quad \quad  \col{w} &= R \col{q}
 \end{align}
 %%%%%%%%%%%%%%%
 et la dernière transformation est caractérisée par la matrice Jacobienne du robot:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J^T \col{f}_e \\
-\col{\dot{r}} &= J \col{q}
+	\col{\tau} &= J^T \col{f}_e \\
+	\col{\dot{r}} &= J \col{q}
 \end{align}
 %%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/robotpowerflow2.jpg}
+	\includegraphics[width=0.80\textwidth]{fig/robotpowerflow2.jpg}
 	\caption{Flux de puissance: de l'alimentation électrique vers le travail sur la charge}
 	\label{fig:robotpowerflow2}
 \end{figure}
@@ -106,12 +106,12 @@ et la dernière transformation est caractérisée par la matrice Jacobienne du r
 
 \subsection{Illustration pour un robot simple à un DDL}
 
-La Figure \ref{fig:static1dofexemple} illustre un la matrice Jacobienne d'un robot simple à 1 DDL, pour lequel l'espace de la tâche est simplement la position horizontale $x$ de l'effecteur. Pour ce système à une entrée et une sortie, la matrice Jacobienne est de dimension $1\times1$, donc un scalaire qui ici correspond à la hauteur de l'effecteur du robot. La vitesse $\dot{x}$ pour une vitesse angulaire $\dot{\theta}$ donnée est fonction de cette hauteur. Finalement, le lien entre une force horizontale à l'effecteur et le couple équivalent au joint est aussi fonction de cette même hautuer. 
+La Figure \ref{fig:static1dofexemple} illustre un la matrice Jacobienne d'un robot simple à 1 DDL, pour lequel l'espace de la tâche est simplement la position horizontale $x$ de l'effecteur. Pour ce système à une entrée et une sortie, la matrice Jacobienne est de dimension $1\times1$, donc un scalaire qui ici correspond à la hauteur de l'effecteur du robot. La vitesse $\dot{x}$ pour une vitesse angulaire $\dot{\theta}$ donnée est fonction de cette hauteur. Finalement, le lien entre une force horizontale à l'effecteur et le couple équivalent au joint est aussi fonction de cette même hauteur.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.70\textwidth]{fig/static1dofexemple.jpg}
+	\includegraphics[width=0.70\textwidth]{fig/static1dofexemple.jpg}
 	\caption{Exemple de la relation statique pour un manipulateur à 1 DDL}
 	\label{fig:static1dofexemple}
 \end{figure}
@@ -119,11 +119,11 @@ La Figure \ref{fig:static1dofexemple} illustre un la matrice Jacobienne d'un rob
 
 \subsection{Relation statique sur une singularité}
 
-Lorsqu'un robot manipulateur est sur une singularité, la transposée de la matrice Jacobienne est caractérisée par une amplification d'un facteur zéro pour certaines direction spécifique de vecteur force externe. Cela signifie que aucun couple dans l'espace des joints est nécessaire pour résister à une force externe dans cette direction. De façon générale si le un robot est proche d'une singularité, très peu de couple aux joint est nécessaire pour résister à certaines directions de forces externes. La marche humaine est particulièrement efficace car nos jambes sont maintenues dans des configurations proches de singularité qui permette de résister à la charge gravitationnelle avec peu d'effort musculaire. 
+Lorsqu'un robot manipulateur est sur une singularité, la transposée de la matrice Jacobienne est caractérisée par une amplification d'un facteur zéro pour certaines directions spécifiques de vecteur force externe. Cela signifie qu’aucun couple dans l'espace des joints n’est nécessaire pour résister à une force externe dans cette direction. De façon générale, si un robot est proche d'une singularité, très peu de couples aux joints sont nécessaires pour résister à certaines directions de forces externes. La marche humaine est particulièrement efficace, car nos jambes sont maintenues dans des configurations proches de singularité qui permettent de résister à la charge gravitationnelle avec peu d'effort musculaire.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.40\textwidth]{fig/externalforcesingularity.jpg}
+	\includegraphics[width=0.40\textwidth]{fig/externalforcesingularity.jpg}
 	\caption{Relation statique sur une singularité}
 	\label{fig:externalforcesingularity}
 \end{figure}
@@ -133,34 +133,34 @@ Lorsqu'un robot manipulateur est sur une singularité, la transposée de la matr
 \section{Relation statique incluant les forces conservatrices}
 \label{sec:manipstaticconservative}
 
-Si la bilan d'énergie effectué à la section \ref{sec:manipstatic} est fait en incluant l'énergie potentielle, un terme de forces conservatrices $\col{g}$ doit être ajouté à l'équation de la balance des forces dans le systèmes. On nomme ce vecteur $\col{g}$ car pour les robots c'est souvent un vecteur de forces gravitationnelles. 
+Si le bilan d'énergie effectué à la section \ref{sec:manipstatic} est fait en incluant l'énergie potentielle, un terme de forces conservatrices $\col{g}$ doit être ajouté à l'équation de la balance des forces dans le système. On nomme ce vecteur $\col{g}$, car pour les robots c'est souvent un vecteur de forces gravitationnelles.
 
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e +  g( \col{q} )
-\quad \quad \text{avec:  }
-\underbrace{ \col{g} ( \col{q} ) = 
-\frac{ \partial V(\col{q} ) }{\partial \col{q}^T } 
-}_{\text{Gradient de l'énergie potentielle}}
-\label{eq:staticgravity}
+	\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e +  g( \col{q} )
+	\quad \quad \text{avec:  }
+	\underbrace{ \col{g} ( \col{q} ) =
+		\frac{ \partial V(\col{q} ) }{\partial \col{q}^T }
+	}_{\text{Gradient de l'énergie potentielle}}
+	\label{eq:staticgravity}
 \end{align}
 %%%%%%%%%%%%%%%
 
-Note: Le vecteur colonne par lequel on prend les dérivés partielles de $V$ est ici noté avec une transposition pour respecter la convention (voir section \ref{sec:vectoropindex}) pour obtenir un vecteur-colonne $\col{g}$ $n \times 1$ plutôt que un vecteur-rangé $1 \times n$. Le nouveau terme provient du fait que la variation de l'énergie interne du système n'est pas nulle, car l'énergie potentielle du système varie selon le travail effectué par les forces conservatrices:
+Note: Le vecteur colonne par lequel on prend les dérivées partielles de $V$ est ici noté avec une transposition pour respecter la convention (voir section \ref{sec:vectoropindex}) pour obtenir un vecteur-colonne $\col{g}$ $n \times 1$ plutôt qu’un vecteur-rangée $1 \times n$. Le nouveau terme provient du fait que la variation de l'énergie interne du système n'est pas nulle, car l'énergie potentielle du système varie selon le travail effectué par les forces conservatrices:
 %%%%%%%%%%%%%%%%
 \begin{align}
-E = V( \col{q} ) \quad \Rightarrow \quad \frac{dE}{dt} = \frac{dV}{dt} = \frac{\partial V}{ \partial \col{q}} \, \frac{d \col{q}}{dt} = \frac{\partial V}{ \partial \col{q}} \, \col{\dot{q}}
+	E = V( \col{q} ) \quad \Rightarrow \quad \frac{dE}{dt} = \frac{dV}{dt} = \frac{\partial V}{ \partial \col{q}} \, \frac{d \col{q}}{dt} = \frac{\partial V}{ \partial \col{q}} \, \col{\dot{q}}
 \end{align}
 %%%%%%%%%%%%%%%
-On obient alors:
+On obtient alors:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\frac{dE}{dt} &= P_{in} - P_{out} \\
-\frac{\partial V}{ \partial \col{q}} \, \col{\dot{q}} &=  \col{\dot{q}}^T \col{\tau} - \col{\dot{q}}^T  J( \col{q})^T \col{f}_e  \\
-\col{\dot{q}}^T  \, \Big(  \frac{\partial V}{ \partial \col{q}^T} \Big) &=  \col{\dot{q}}^T  \Big(\col{\tau} -  J( \col{q})^T \col{f}_e  \Big)
+	\frac{dE}{dt} &= P_{in} - P_{out} \\
+	\frac{\partial V}{ \partial \col{q}} \, \col{\dot{q}} &=  \col{\dot{q}}^T \col{\tau} - \col{\dot{q}}^T  J( \col{q})^T \col{f}_e  \\
+	\col{\dot{q}}^T  \, \Big(  \frac{\partial V}{ \partial \col{q}^T} \Big) &=  \col{\dot{q}}^T  \Big(\col{\tau} -  J( \col{q})^T \col{f}_e  \Big)
 \end{align}
 %%%%%%%%%%%%%%%
-Donc pour que la relation de puissance soit respecté, les termes qui multiplie le vecteur-colonne de vitesses doivent être égaux, ce qui donne la relation entre les forces de l'équation \eqref{eq:staticgravity}.
+Donc pour que la relation de puissance soit respectée, les termes qui multiplient le vecteur-colonne de vitesses doivent être égaux, ce qui donne la relation entre les forces de l'équation \eqref{eq:staticgravity}.
 
 
 
@@ -169,53 +169,53 @@ Donc pour que la relation de puissance soit respecté, les termes qui multiplie 
 \section{Relation de la compliance aux joints et à l'effecteur}
 \label{sec:manipcompliance}
 
-Lorsque les robots sont contrôlé en position par des servo-moteurs à chaque joint, chacun de ces moteurs et sa boucle d'asservissement en position peut être représenté comme une rigidité dans l'espace des joints, i.e. une variation du couple produit par le joint pour un déplacement de ce joint par rapport à la configuration que le contrôleur tente de maintenir:
+Lorsque les robots sont contrôlés en position par des servomoteurs à chaque joint, chacun de ces moteurs et sa boucle d'asservissement en position peut être représenté comme une rigidité dans l'espace des joints, c.-à-d. une variation du couple produit par le joint pour un déplacement de ce joint par rapport à la configuration que le contrôleur tente de maintenir:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\delta \tau_i = k_i \delta q_i \quad \Rightarrow \quad \delta \col{\tau} = K_q \, \delta \col{q}
+	\delta \tau_i = k_i \delta q_i \quad \Rightarrow \quad \delta \col{\tau} = K_q \, \delta \col{q}
 \end{align}
 %%%%%%%%%%%%%%%
-où $K_q$ est une matrice de rigidité dans l'espace des joints. Il est ensuite intéressant de déterminer la rigidité d'un robot, comme illustré à la Figure \ref{fig:robotcompliance}, lorsqu'il subit une force externe en fonction de la rigidité angulaire de ces servo-moteurs.
+où $K_q$ est une matrice de rigidité dans l'espace des joints. Il est ensuite intéressant de déterminer la rigidité d'un robot, comme illustré à la Figure \ref{fig:robotcompliance}, lorsqu'il subit une force externe en fonction de la rigidité angulaire de ces servomoteurs.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/robotcompliance.jpg}
+	\includegraphics[width=0.80\textwidth]{fig/robotcompliance.jpg}
 	\caption{Compliance d'un robot à une force externe}
 	\label{fig:robotcompliance}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La variation de position de l'effecteur peut être reliée aux déplacement angulaire dans l'espace des joints, et la force externe peut-être ramener à des coules équivalent à chaque joint. En manipulant les équations on obtient:
+La variation de position de l'effecteur peut être reliée aux déplacements angulaires dans l'espace des joints, et la force externe peut être ramenée à des couples équivalent à chaque joint. En manipulant les équations, on obtient:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\delta \col{r} = J \delta \col{q} = J K_q^{-1} \col{\tau} = 
-\underbrace{
-\left[ J K_q^{-1} J^T \right]
-}_{C_r} \,  \col{f}_e
+	\delta \col{r} = J \delta \col{q} = J K_q^{-1} \col{\tau} =
+	\underbrace{
+		\left[ J K_q^{-1} J^T \right]
+	}_{C_r} \,  \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%
-où $C_r$ est une matrice de compliance à l'effecteur. La rigidité apparente à l'effecteur, due à un rigidité dans l'espace des joints, est donc donnée par une relation qui relie la variation de la position de l'effecteur à un force externe appliquée sur l'effecteur:
+où $C_r$ est une matrice de compliance à l'effecteur. La rigidité apparente à l'effecteur, due à une rigidité dans l'espace des joints, est donc donnée par une relation qui relie la variation de la position de l'effecteur à une force externe appliquée sur l'effecteur:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{f}_e = K_r \delta \col{r} \quad \text{avec } K_r = C_r^{-1} = \left[ J K_q^{-1} J^T \right]^{-1}
+	\col{f}_e = K_r \delta \col{r} \quad \text{avec } K_r = C_r^{-1} = \left[ J K_q^{-1} J^T \right]^{-1}
 \end{align}
 %%%%%%%%%%%%%%%
-Comme illustré à la Figure \ref{fig:robotcompliance_effector}, la matrice de rigidité dans l'espace des joints est généralement diagonale (les moteurs sont indépendents). Il est à noter que la matrice de rigidité à l'effecteur est dépendante de la configuration nominale du robot (i.e. $J$ est une fonction de $\col{q}$ en général).
+Comme illustré à la Figure \ref{fig:robotcompliance_effector}, la matrice de rigidité dans l'espace des joints est généralement diagonale (les moteurs sont indépendants). Il est à noter que la matrice de rigidité à l'effecteur est dépendante de la configuration nominale du robot (c.-à-d. $J$ est une fonction de $\col{q}$ en général).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/robotcompliance_effector.jpg}
+	\includegraphics[width=0.80\textwidth]{fig/robotcompliance_effector.jpg}
 	\caption{Matrice de rigidité équivalente d'un robot dans l'espace de l'effecteur}
 	\label{fig:robotcompliance_effector}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-Finalement, il est à noter que la matrice $C$ de compliance est singulière lorsque le Jacobien est singulier, donc sur une singularité, un robot manipulateur a une ou des directions avec aucune compliance, i.e. infiniment rigide, comme illustré à la Figure \ref{fig:robotcompliance_singular}.
+Finalement, il est à noter que la matrice $C$ de compliance est singulière lorsque le Jacobien est singulier, donc sur une singularité, un robot manipulateur a une ou des directions avec aucune compliance, c.-à-d. infiniment rigide, comme illustré à la Figure \ref{fig:robotcompliance_singular}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.80\textwidth]{fig/robotcompliance_singular.jpg}
-	\caption{Effet des configuration singulière sur la rigidité d'un robot manipulateur}
+	\includegraphics[width=0.80\textwidth]{fig/robotcompliance_singular.jpg}
+	\caption{Effet des configurations singulières sur la rigidité d'un robot manipulateur}
 	\label{fig:robotcompliance_singular}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -227,23 +227,24 @@ Finalement, il est à noter que la matrice $C$ de compliance est singulière lor
 Relation force joints-effecteur:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e 
+	\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e
 \end{align}
 %%%%%%%%%%%%%%%
 
 Équilibre statique:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e +  g( \col{q} )
-\quad \quad \text{avec:  }
-g( \col{q} ) = 
-\frac{ \partial V(\col{q} ) }{\partial \col{q} } 
+	\col{\tau} &= J\left( \, \col{q} \, \right)^T \, \col{f}_e +  g( \col{q} )
+	\quad \quad \text{avec:  }
+	g( \col{q} ) =
+	\frac{ \partial V(\col{q} ) }{\partial \col{q} }
 \end{align}
 %%%%%%%%%%%%%%%
 
 Rigidité apparente à l'effecteur:
 %%%%%%%%%%%%%%%%
 \begin{align}
-K_r = C_r^{-1} = \left[ J K_q^{-1} J^T \right]^{-1}
+	K_r = C_r^{-1} = \left[ J K_q^{-1} J^T \right]^{-1}
 \end{align}
 %%%%%%%%%%%%%%%
+

--- a/src/math/geo.tex
+++ b/src/math/geo.tex
@@ -7,20 +7,20 @@ Chapitre en construction!
 \section{Les Vecteurs}
 \label{sec:vec}
 
-Un vecteur-géométrique est une quantité physique représentée par \textbf{une amplitude et une direction}. Lorsqu'une base vectorielle est spécifiée, un vecteur peut alors être représenté par des composantes scalaires selon chaque vecteur unitaire de la base. Il est important de distinguer la notion de vecteur-géométrique $\vec{v}$ et de ses composantes regroupées dans un vecteur colonne $\col{v}$, surtout lorsque plusieurs bases sont utilisés. 
+Un vecteur géométrique est une quantité physique représentée par \textbf{une amplitude et une direction}. Lorsqu'une base vectorielle est spécifiée, un vecteur peut alors être représenté par des composantes scalaires selon chaque vecteur unitaire de la base. Il est important de distinguer la notion de vecteur géométrique $\vec{v}$ et de ses composantes regroupées dans un vecteur colonne $\col{v}$, surtout lorsque plusieurs bases sont utilisées.
 
-La notation suivant est utilisée dans ces notes:
+La notation suivante est utilisée dans ces notes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\text{\textbf{Vecteur-géométrique:}}&\quad
-\vec{v} = v_1 \, \hat{a}_{1} + v_2 \, \hat{a}_{2} + v_3 \, \hat{a}_{3}
-\\
-\text{\textbf{Vecteur-colonne des composantes:}}&\quad
-\col{v}^{a} = \left[ \begin{array}{c} v_1 \\ v_2 \\ v_3  \end{array} \right] 
-\label{eq:veccoldef2}
-\end{align} 
+ \text{\textbf{Vecteur-géométrique:}}&\quad
+ \vec{v} = v_1 \, \hat{a}_{1} + v_2 \, \hat{a}_{2} + v_3 \, \hat{a}_{3}
+ \\
+ \text{\textbf{Vecteur-colonne des composantes:}}&\quad
+ \col{v}^{a} = \left[ \begin{array}{c} v_1 \\ v_2 \\ v_3  \end{array} \right]
+ \label{eq:veccoldef2}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée aux composantes scalaires. Selon les domaines, le terme vecteur réfère soit à la quantité avec une amplitude et une direction (physique, géométrie, etc) soit à une colonne de scalaire (algèbre linéaire, programmation, etc). Comme tous ces domaines sont utilisés en robotique on fera toujours la distinction 
+où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée aux composantes scalaires. Selon les domaines, le terme vecteur réfère soit à la quantité avec une amplitude et une direction (physique, géométrie, etc.) soit à une colonne de scalaire (algèbre linéaire, programmation, etc.). Comme tous ces domaines sont utilisés en robotique, on fera toujours la distinction.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -36,55 +36,55 @@ où l'exposant $a$ est utilisé pour spécifier la base vectorielle associée au
 Une base vectorielle correspond à trois vecteurs unitaires (en 3D) orthogonaux qui déterminent l'orientation de trois axes dans l'espace et forment une base qui permet de décrire n'importe quel vecteur $\vec{v}$ sous la forme:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{v} = v_1^a \, \hat{a}_{1} + v_2^a \, \hat{a}_{2} + v_3^a \, \hat{a}_{3}
-\label{eq:vecbasis}
-\end{equation} 
+ \vec{v} = v_1^a \, \hat{a}_{1} + v_2^a \, \hat{a}_{2} + v_3^a \, \hat{a}_{3}
+ \label{eq:vecbasis}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 On appellera \textit{base vectorielle} $a$, une base formée par l'ensemble des vecteurs unitaires $\{\hat{a}_{1},\hat{a}_{2},\hat{a}_{3}\}$.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htpb]
-				%\vspace{-10pt}
-        \centering
-				\subfloat[Base $a$]{
-				\includegraphics[width=0.20\textwidth]{base}
-				\label{fig:base}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-        \subfloat[Exemple]{
-				\includegraphics[width=0.25\textwidth]{baseex}
-				\label{fig:baseex}}
-				%%%%
-				\hspace{10pt}
-				%%%%
-				\subfloat[Convention de la main droite]{
-				\includegraphics[width=0.25\textwidth]{righthand}
-				\label{fig:righthand}}
-        \caption{Les bases vectorielles}
-				\label{fig:vecbasis}
+ %\vspace{-10pt}
+ \centering
+ \subfloat[Base $a$]{
+  \includegraphics[width=0.20\textwidth]{base}
+  \label{fig:base}}
+ %%%%
+ \hspace{10pt}
+ %%%%
+ \subfloat[Exemple]{
+  \includegraphics[width=0.25\textwidth]{baseex}
+  \label{fig:baseex}}
+ %%%%
+ \hspace{10pt}
+ %%%%
+ \subfloat[Convention de la main droite]{
+  \includegraphics[width=0.25\textwidth]{righthand}
+  \label{fig:righthand}}
+ \caption{Les bases vectorielles}
+ \label{fig:vecbasis}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Mathématiquement, les critères de dimensions unitaires et d'orthogonalités sont donnés par les équations:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{a}_{1} \bullet \hat{a}_{1} = 1 \quad\quad \hat{a}_{2} \bullet \hat{a}_{2} = 1 \quad\quad \hat{a}_{3} \bullet \hat{a}_{3} = 1 
-\label{eq:unit} \\
-\hat{a}_{1} \bullet \hat{a}_{2} = 0 \quad\quad \hat{a}_{2} \bullet \hat{a}_{3} = 0 \quad\quad \hat{a}_{3} \bullet \hat{a}_{1} = 0
-\label{eq:ortho}
-\end{align} 
+ \hat{a}_{1} \bullet \hat{a}_{1} = 1 \quad\quad \hat{a}_{2} \bullet \hat{a}_{2} = 1 \quad\quad \hat{a}_{3} \bullet \hat{a}_{3} = 1
+ \label{eq:unit} \\
+ \hat{a}_{1} \bullet \hat{a}_{2} = 0 \quad\quad \hat{a}_{2} \bullet \hat{a}_{3} = 0 \quad\quad \hat{a}_{3} \bullet \hat{a}_{1} = 0
+ \label{eq:ortho}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Normalement, par convention, les bases vectorielles suivent la règle de main droite (voir figure \ref{fig:righthand}) pour spécifier la direction du troisième vecteur unitaire. La convention de la main droite permet aussi de spécifier des relations en termes de produits vectoriels entre les vecteurs unitaires:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\hat{a}_{1} = \hat{a}_{2} \times \hat{a}_{3} \quad\quad \hat{a}_{2} = \hat{a}_{3} \times \hat{a}_{1} \quad\quad \hat{a}_{3} = \hat{a}_{1} \times \hat{a}_{2} 
-\label{eq:righthand}
-\end{align} 
+ \hat{a}_{1} = \hat{a}_{2} \times \hat{a}_{3} \quad\quad \hat{a}_{2} = \hat{a}_{3} \times \hat{a}_{1} \quad\quad \hat{a}_{3} = \hat{a}_{1} \times \hat{a}_{2}
+ \label{eq:righthand}
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les bases vectorielles permettent de faire des opérations et combiner des vecteurs en les exprimant avec une base commune de vecteurs unitaires. Dans la littérature, la notation $(\hat{i},\hat{j},\hat{k})$ ou $(\hat{x},\hat{y},\hat{z})$ est parfois utilisée. Dans ces notes, on utilisera des lettres ($a$,$b$,$c$,...) pour identifier des bases, ainsi que des indices (1,2,3) pour spécifier les trois axes (voir figure \ref{fig:base}). 
- 
+Les bases vectorielles permettent de faire des opérations et combiner des vecteurs en les exprimant avec une base commune de vecteurs unitaires. Dans la littérature, la notation $(\hat{i},\hat{j},\hat{k})$ ou $(\hat{x},\hat{y},\hat{z})$ est parfois utilisée. Dans ces notes, on utilisera des lettres ($a$,$b$,$c$,...) pour identifier des bases, ainsi que des indices (1,2,3) pour spécifier les trois axes (voir figure \ref{fig:base}).
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Relation entre un vecteur et ses composantes dans une base}
@@ -92,68 +92,68 @@ Les bases vectorielles permettent de faire des opérations et combiner des vecte
 Comme illustré à la figure \ref{fig:vecpospro2}, il est possible de calculer les composantes d'un vecteur exprimé dans une base par un produit scalaire du vecteur géométrique avec chacun des vecteurs unitaires de la base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-v_i^a = \vec{v} \bullet \hat{a}_i  \quad \Rightarrow \quad 
-\col{v}^{a} = \left[ \begin{array}{c} \vec{v} \bullet \hat{a}_1 \\ \vec{v} \bullet \hat{a}_2 \\ \vec{v} \bullet \hat{a}_3  \end{array} \right] 
-\end{equation} 
+ v_i^a = \vec{v} \bullet \hat{a}_i  \quad \Rightarrow \quad
+ \col{v}^{a} = \left[ \begin{array}{c} \vec{v} \bullet \hat{a}_1 \\ \vec{v} \bullet \hat{a}_2 \\ \vec{v} \bullet \hat{a}_3  \end{array} \right]
+\end{equation}
 Inversement, comme illustré à la figure \ref{fig:vecpospro3}, le vecteur position géométrique peut être reconstruit en effectuant la somme des composantes multipliées avec leurs vecteurs unitaires respectifs:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{v} = \sum_{i} v_i^a \hat{a}_i = v_1^a \hat{a}_1 + v_2^a \hat{a}_2 + v_3^a \hat{a}_3%= \left[ \begin{array}{c c c} p_1^a & p_2^a & p_3^a  \end{array} \right]  \left[ \begin{array}{c} \hat{a}_1 \\ \hat{a}_2 \\ \hat{a}_3  \end{array} \right] 
-\end{equation} 
+ \vec{v} = \sum_{i} v_i^a \hat{a}_i = v_1^a \hat{a}_1 + v_2^a \hat{a}_2 + v_3^a \hat{a}_3%= \left[ \begin{array}{c c c} p_1^a & p_2^a & p_3^a  \end{array} \right]  \left[ \begin{array}{c} \hat{a}_1 \\ \hat{a}_2 \\ \hat{a}_3  \end{array} \right]
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
-				%\vspace{-10pt}
-        \centering
-        \subfloat[Projection sur une base vectorielle]{
-				\includegraphics[width=0.50\textwidth]{vecpospro2.png}
-				\label{fig:vecpospro2}}
-				\hspace{+20pt}
-				\subfloat[Décomposition selon les directions de la base]{
-				\includegraphics[width=0.40\textwidth]{vecpospro3.png}
-				\label{fig:vecpospro3}}
-				%\vspace{+30pt}
-        \caption{Relations entre le vecteur géométrique de position et les composantes du vecteur-colonne}
-				\label{fig:vecpospro23}
+ %\vspace{-10pt}
+ \centering
+ \subfloat[Projection sur une base vectorielle]{
+  \includegraphics[width=0.50\textwidth]{vecpospro2.png}
+  \label{fig:vecpospro2}}
+ \hspace{+20pt}
+ \subfloat[Décomposition selon les directions de la base]{
+  \includegraphics[width=0.40\textwidth]{vecpospro3.png}
+  \label{fig:vecpospro3}}
+ %\vspace{+30pt}
+ \caption{Relations entre le vecteur géométrique de position et les composantes du vecteur-colonne}
+ \label{fig:vecpospro23}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Transfert d'une équation vectorielle vers une équation matricielle} 
+\subsection{Transfert d'une équation vectorielle vers une équation matricielle}
 %
-Lorsque les composantes de plusieurs vecteurs sont exprimées avec la même base, il est possible de faire des opérations directement avec les vecteur-colonnes de composantes. Cela permet de traiter simultanément les calculs de plusieurs axes, et aussi de faire des calculs numériques efficaces en utilisant les outils de l'algèbre linéaire. Par exemple, les additions et soustractions de vecteurs géométriques peuvent être calculées directement en termes des vecteur-colonnes dans une base:
+Lorsque les composantes de plusieurs vecteurs sont exprimées avec la même base, il est possible de faire des opérations directement avec les vecteurs-colonne de composantes. Cela permet de traiter simultanément les calculs de plusieurs axes, et aussi de faire des calculs numériques efficaces en utilisant les outils de l'algèbre linéaire. Par exemple, les additions et soustractions de vecteurs géométriques peuvent être calculées directement en termes des vecteurs-colonne dans une base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u}   = \vec{v} + \vec{w}   \quad \Rightarrow \quad
-\col{u}^a = \col{v}^a + \col{w}^a
-\end{equation} 
+ \vec{u}   = \vec{v} + \vec{w}   \quad \Rightarrow \quad
+ \col{u}^a = \col{v}^a + \col{w}^a
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Ce transfert d'une seule équation vectorielle à une équation matricielle (équivalent à un système de trois équations scalaires) correspond à une projection de l'équation vectorielle sur chacun des axes de la base:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u}   = \vec{v} + \vec{w}   
-\quad \Rightarrow \quad
-\left[ \begin{array}{c} (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_1 \\ (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_2 \\ (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_3  \end{array} \right] 
-\quad \Rightarrow \quad
-\left[ \begin{array}{c}  u_1^a   = v_1^a + w_1^a   \\  u_2^a   = v_2^a + w_2^a   \\ u_3^a   = v_3^a + w_3^a   \end{array} \right] 
-\quad \Rightarrow \quad
-\col{u}^a = \col{v}^a + \col{w}^a
-\end{equation} 
+ \vec{u}   = \vec{v} + \vec{w}
+ \quad \Rightarrow \quad
+ \left[ \begin{array}{c} (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_1 \\ (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_2 \\ (\vec{u}   = \vec{v} + \vec{w}  ) \bullet \hat{a}_3  \end{array} \right]
+ \quad \Rightarrow \quad
+ \left[ \begin{array}{c}  u_1^a   = v_1^a + w_1^a   \\  u_2^a   = v_2^a + w_2^a   \\ u_3^a   = v_3^a + w_3^a   \end{array} \right]
+ \quad \Rightarrow \quad
+ \col{u}^a = \col{v}^a + \col{w}^a
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les équations vectorielles avec des vecteurs de position peuvent donc être substituées par des équations matricielles équivalentes avec les vecteur-colonnes,\textbf{ à condition que tous les vecteur-colonnes soient exprimés dans une base commune}. 
+Les équations vectorielles avec des vecteurs de position peuvent donc être substituées par des équations matricielles équivalentes avec les vecteurs-colonne,\textbf{ à condition que tous les vecteurs-colonne soient exprimés dans une base commune}.
 
 %Voici quelques exemples de substitution d'équation de vecteurs de position vers des équations matricielles:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
-%\vec{v}_{B/C}   = \vec{v}_{B/A} - \vec{v}_{C/A}   
-%\quad &\Rightarrow \quad  \col{r}_{B/C}^a   = \col{r}_{B/A}^a - \col{r}_{C/A}^a 
+%\vec{v}_{B/C}   = \vec{v}_{B/A} - \vec{v}_{C/A}
+%\quad &\Rightarrow \quad  \col{r}_{B/C}^a   = \col{r}_{B/A}^a - \col{r}_{C/A}^a
 %\\
-%\vec{v}_{B/C}   = \vec{v}_{B/A} - \vec{v}_{C/A} \quad &\Rightarrow \quad \col{r}_{B/C}^b   = \col{r}_{B/A}^b - \col{r}_{C/A}^b 
+%\vec{v}_{B/C}   = \vec{v}_{B/A} - \vec{v}_{C/A} \quad &\Rightarrow \quad \col{r}_{B/C}^b   = \col{r}_{B/A}^b - \col{r}_{C/A}^b
 %\\
 %2  \vec{v}_{D/A} = 3 \vec{v}_{B/A} + \vec{v}_{C/A} \quad &\Rightarrow \quad  2  \col{r}_{D/A}^a = 3 \col{r}_{B/A}^a + \col{r}_{C/A}^a
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -161,7 +161,7 @@ Les équations vectorielles avec des vecteurs de position peuvent donc être sub
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Opérations vectorielles avec les vecteur-colonnes} 
+\section{Opérations vectorielles avec les vecteurs-colonne}
 \label{sec:opeveccol}
 %
 Les opérations vectorielles ont des équivalents en termes d'opérations matricielle avec les vecteur-colonnes qui sont très utiles pour les calculs numériques. Cette section introduit les opérations principales utiles pour la cinématique.
@@ -170,28 +170,28 @@ Les opérations vectorielles ont des équivalents en termes d'opérations matric
 Un produit scalaire peut être calculé directement par une opération matricielle avec les vecteur-colonnes appelée produit intérieur (\textit{inner product}):
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u} \bullet \vec{v} = \col{u}^T \col{v} = \left[ \begin{array}{c c c} u_1 & u_2 & u_3  \end{array} \right]  \left[ \begin{array}{c} v_1 \\ v_2 \\ v_3  \end{array} \right]
-= u_1 v_1 + u_2 v_2 + u_3 v_3
-\end{equation} 
+ \vec{u} \bullet \vec{v} = \col{u}^T \col{v} = \left[ \begin{array}{c c c} u_1 & u_2 & u_3  \end{array} \right]  \left[ \begin{array}{c} v_1 \\ v_2 \\ v_3  \end{array} \right]
+ = u_1 v_1 + u_2 v_2 + u_3 v_3
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 si $\col{u}$ et $\col{v}$ sont les composantes exprimées dans une base vectorielle commune, par exemple:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{u} \bullet \vec{v} &= (\col{u}^a)^T \col{v}^a = (\col{u}^b)^T \col{v}^b
-\end{align} 
+ \vec{u} \bullet \vec{v} &= (\col{u}^a)^T \col{v}^a = (\col{u}^b)^T \col{v}^b
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-mais attention car: 
+mais attention car:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\vec{u} \bullet \vec{v} &\ne (\col{u}^a)^T \col{v}^b \\
-\vec{u} \bullet \vec{v} &\ne (\col{u}^b)^T \col{v}^a 
-\end{align} 
+ \vec{u} \bullet \vec{v} &\ne (\col{u}^a)^T \col{v}^b \\
+ \vec{u} \bullet \vec{v} &\ne (\col{u}^b)^T \col{v}^a
+\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Il est à noter que l'ordre de multiplication ne change pas le résultat pour le produit scalaire:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u} \bullet \vec{v} = \vec{v} \bullet \vec{u} = \col{u}^T \col{v} = \col{v}^T \col{u} 
-\end{equation} 
+ \vec{u} \bullet \vec{v} = \vec{v} \bullet \vec{u} = \col{u}^T \col{v} = \col{v}^T \col{u}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -200,27 +200,27 @@ Il est à noter que l'ordre de multiplication ne change pas le résultat pour le
 Un produit vectoriel (\textit{cross product}) peut être calculé directement par une opération matricielle définie avec les vecteur-colonnes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u} = \vec{v} \times \vec{w} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} \quad \Rightarrow \quad 
- \left[ \begin{array}{c} u_1 \\ u_2 \\ u_3  \end{array} \right] = 
-\left[ \begin{array}{c c c}
-	0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
-\end{array}  \right]
+ \vec{u} = \vec{v} \times \vec{w} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} \quad \Rightarrow \quad
+ \left[ \begin{array}{c} u_1 \\ u_2 \\ u_3  \end{array} \right] =
+ \left[ \begin{array}{c c c}
+         0 & -v_3 & v_2  \\ v_3 & 0 & -v_1 \\ -v_2 & v_1 & 0
+ \end{array}  \right]
  \left[ \begin{array}{c} w_1 \\ w_2 \\ w_3  \end{array} \right]
-\end{equation} 
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 L'ordre de multiplication est important pour le produit vectoriel, il change la direction du vecteur résultant:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\vec{u} = \vec{v} \times \vec{w} =  -\vec{w} \times \vec{v} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} = - \col{w}^{\times}\col{v}
-\end{equation} 
+ \vec{u} = \vec{v} \times \vec{w} =  -\vec{w} \times \vec{v} \quad \Rightarrow \quad  \col{u} = \col{v}^{\times}\col{w} = - \col{w}^{\times}\col{v}
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{Vecteurs unitaires d'une base vectorielle:}
-Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux: 
+Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\hat{b}_3 = \hat{b}_1 \times \hat{b}_2  \quad \Rightarrow \quad   \col{b}_3 = \col{b}_1^{\times}\col{b}_2
-\end{equation} 
+ \hat{b}_3 = \hat{b}_1 \times \hat{b}_2  \quad \Rightarrow \quad   \col{b}_3 = \col{b}_1^{\times}\col{b}_2
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{Note:}
@@ -233,21 +233,21 @@ Pour alléger la présentation, les exposants qui spécifient les bases vectorie
 Un produit tensoriel (\textit{outer-product}) peut être calculé directement par une opération matricielle définie avec les vecteur-colonnes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\tensor{T} = \vec{v} \vec{w} \quad \Rightarrow \quad  T = \col{v} \, \col{w}^T = 
-\left[ \begin{array}{c}     v_1 \\ v_2 \\ v_3  \end{array} \right]
-\left[ \begin{array}{c c c} w_1 &  w_2 &  w_3  \end{array} \right] = 
-\left[ \begin{array}{c c c}
-v_1 w_1 & v_1 w_2 & v_1 w_3  \\ 
-v_2 w_1 & v_2 w_2 & v_2 w_3         \\ 
-v_3 w_1 & v_3 w_2 & v_3 w_3 
-\end{array}  \right]
-\end{equation} 
+ \tensor{T} = \vec{v} \vec{w} \quad \Rightarrow \quad  T = \col{v} \, \col{w}^T =
+ \left[ \begin{array}{c}     v_1 \\ v_2 \\ v_3  \end{array} \right]
+ \left[ \begin{array}{c c c} w_1 &  w_2 &  w_3  \end{array} \right] =
+ \left[ \begin{array}{c c c}
+         v_1 w_1 & v_1 w_2 & v_1 w_3  \\
+         v_2 w_1 & v_2 w_2 & v_2 w_3         \\
+         v_3 w_1 & v_3 w_2 & v_3 w_3
+ \end{array}  \right]
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 où le matrice $T$ correspond aux composantes du tenseur $\tensor{T}$, avec comme correspondance si toutes les composantes sont relatives à une base $a$ :
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\tensor{T} = T_{11} \hat{a}_1 \hat{a}_1  + T_{12} \hat{a}_1 \hat{a}_2 + \hdots + T_{23} \hat{a}_2 \hat{a}_3  + T_{33} \hat{a}_3 \hat{a}_3 
-\end{equation} 
+ \tensor{T} = T_{11} \hat{a}_1 \hat{a}_1  + T_{12} \hat{a}_1 \hat{a}_2 + \hdots + T_{23} \hat{a}_2 \hat{a}_3  + T_{33} \hat{a}_3 \hat{a}_3
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -256,181 +256,181 @@ où le matrice $T$ correspond aux composantes du tenseur $\tensor{T}$, avec comm
 Les composantes d'un vecteur géométrique $\vec{v}$ dans une base $a$ peuvent être directement reliées aux composantes du même vecteur géométrique $\vec{v}$ dans une autre base $b$, par une équation matricielle qui implique les vecteur-colonnes et une matrice 3$\times$3 appelée une \textit{matrice de rotation}. On va noter une matrice $^bR^a$ lorsqu'une multiplication par la gauche de cette matrice avec un vecteur colonne $\col{v}^a$ donne le vecteur-colonne $\col{v}^b$:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}^b &= {}^bR^a \col{v}^a  \quad \Rightarrow \quad
+ \col{v}^b &= {}^bR^a \col{v}^a  \quad \Rightarrow \quad
  \left[ \begin{array}{c} v_1^b \\ v_2^b \\ v_3^b  \end{array} \right]
-=
-\left[ \begin{array}{c c c}
-	{}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\ 
-	{}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
-	{}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
-\end{array}  \right]
+ =
+ \left[ \begin{array}{c c c}
+ {}^bR^a_{11} & {}^bR^a_{12} & {}^bR^a_{13} \\
+ {}^bR^a_{21} & {}^bR^a_{22} & {}^bR^a_{23} \\
+ {}^bR^a_{31} & {}^bR^a_{32} & {}^bR^a_{33}
+ \end{array}  \right]
  \left[ \begin{array}{c} v_1^a \\ v_2^a \\ v_3^a  \end{array} \right]
-\label{eq:basechange1}
-\end{align} 
+ \label{eq:basechange1}
+\end{align}
 %%%%%%%%%%%%%%%%%
 Les propriétés et le calcul des matrices de rotation seront traités en détails à la section \ref{sec:changematrice}.
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\subsection{Calculs appliqués dans un contexte de cinématique} 
+%\subsection{Calculs appliqués dans un contexte de cinématique}
 %%
 %\paragraph{Normes, projections et calcul d'angles:}
 %Lorsque qu'on connait les composantes de vecteurs dans une base commune, le produit intérieur peut être utilisé pour calculer la longueur d'un vecteur position:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %\|\vec{r}\|^2 &= \vec{r} \bullet \vec{r} = \col{r}^T \col{r} = r_1^2 + r_2^2 + r_3^2
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %pour calculer une distance projeté selon un axe décrit par un vecteur unitaire $\hat{n}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %d_n &= \vec{r} \bullet \hat{n} = \col{r}^T \col{n} = r_1 n_1 + r_2 n_2 + r_3 n_3
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %et pour calculer un angle entre deux vecteurs unitaires $\hat{x}$ et $\hat{y}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %\cos \angle (\hat{x},\hat{y}) = \hat{x} \bullet \hat{y} = \col{x}^T \col{y} = x_1 y_1 + x_2 y_2 + x_3 y_3
-%\end{align} 
+%\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 %\paragraph{Vecteurs unitaires:}
-%Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux: 
+%Il est possible de calculer les composantes d'un vecteur unitaire qui complète une base vectorielle avec une opération de produit vectorielle, connaissant les composantes de deux vecteurs unitaires orthogonaux:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{equation}
 %\hat{b}_3 = \hat{b}_1 \times \hat{b}_2  \quad \Rightarrow \quad   \col{b}_3 = \col{b}_1^{\times}\col{b}_2
-%\end{equation} 
+%\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Invariants} 
+\subsection{Invariants}
 %
-Le vecteur géométrique $\vec{v}$ est une quantité constante peu importe la base vectorielle utilisée: 
+Le vecteur géométrique $\vec{v}$ est une quantité constante peu importe la base vectorielle utilisée:
 %%%%%%%%%%%%%%%
 \begin{equation}
-\vec{v} = \sum_{i} v_i^a \hat{a}_i = \sum_{i} v_i^b \hat{b}_i = \sum_{i} v_i^c \hat{c}_i
+ \vec{v} = \sum_{i} v_i^a \hat{a}_i = \sum_{i} v_i^b \hat{b}_i = \sum_{i} v_i^c \hat{c}_i
 \end{equation}
 %%%%%%%%%%%%%%%
 mais le vecteur-colonne dépend de la base vectorielle. Les vecteur-colonnes sont en générale différents sauf dans le cas particulier de bases vectorielles coïncidentes:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{equation}
-\col{v}^{a} \ne \col{v}^{b} \quad\quad \text{sauf dans le cas particulier:} \quad \hat{a}_1 = \hat{b}_1 \;,\; \hat{a}_2 = \hat{b}_2  \;\text{et}\; \hat{a}_3 = \hat{b}_3 
-\end{equation} 
+ \col{v}^{a} \ne \col{v}^{b} \quad\quad \text{sauf dans le cas particulier:} \quad \hat{a}_1 = \hat{b}_1 \;,\; \hat{a}_2 = \hat{b}_2  \;\text{et}\; \hat{a}_3 = \hat{b}_3
+\end{equation}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-La longueur du vecteur-géométrique étant une constante peut importe la base vectorielle utilisée, il est possible d'établir la relation suivante entre les vecteur-colonnes utilisant différentes bases:
+La longueur du vecteur géométrique étant une constante peut importe la base vectorielle utilisée, il est possible d'établir la relation suivante entre les vecteur-colonnes utilisant différentes bases:
 %%%%%%%%%%%%%%%
 \begin{equation}
-\|\vec{v}\|^2 = \vec{v} \bullet \vec{v} = (\col{v}^{a})^T \col{v}^{a} = (\col{v}^{b})^T \col{v}^{b} = (\col{v}^{c})^T \col{v}^{c}
+ \|\vec{v}\|^2 = \vec{v} \bullet \vec{v} = (\col{v}^{a})^T \col{v}^{a} = (\col{v}^{b})^T \col{v}^{b} = (\col{v}^{c})^T \col{v}^{c}
 \end{equation}
 %%%%%%%%%%%%%%%
-La norme des vecteur-colonnes est donc invariante par rapport au choix de la base. 
+La norme des vecteur-colonnes est donc invariante par rapport au choix de la base.
 
 
 
 
 
 
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newpage
 \section{Summary of vector operations in terms of components}
 \label{sec:vectoropindex}
 
 \begin{table}[H]
 %\caption{ Basic Vectorial Operations }
-\label{basic}
+ \label{basic}
  \begin{tabular}{ | c | c | c |}
- \hline
- Vector and Tensors & Matrix, Row and Columns & Components and index \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- \hline
- \multicolumn{3}{| c |}{Definitions} \\
- \hline
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- Vector $\vec{v}$ and Tensor $\vec{\vec{T}}$ 
- &
- Column $\underline{c}$, Row $\underline{r}$ and Matrix $M$ 
- &
- Scalar components $x_i$ and  $x_{ij}$ 
- \\ & & \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- %  1-D
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- $\vec{v} = x_1 \vec{i} + x_2 \vec{j} + x_3 \vec{k}$ 
- &
- $\underline{c} = \left[ \begin{array}{c} x_1 \\ x_2 \\x_3 \end{array} \right] $
- $\underline{r} = \left[ \begin{array}{c c c } x_1 & x_2 & x_3 \end{array} \right] $
- &
- $x_i \quad i \in \{ 1,2,3\}$
- \\ && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- %  2-D
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- $\vec{\vec{T}} = x_{11} \vec{i}\vec{i} +  x_{12} \vec{i}\vec{j} + ... + x_{33}  \vec{k}\vec{k}$
- &
- $ M = \left[ \begin{array}{c c c } 
- x_{11} & x_{12} & x_{13} \\  
- x_{21} & x_{22} & x_{23} \\  
- x_{31} & x_{32} & x_{33} \\  
- \end{array} \right] $
- &
- $x_{ij} \quad i \in \{ 1,2,3\} \; j \in \{ 1,2,3\}$
- \\ && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- \hline 
- \multicolumn{3}{| c |}{Dot or inner product} \\
- \hline && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- $z = \vec{x} \bullet \vec{y}$ 
- &
- $z = \underline{x}^T \underline{y} = \left[ \begin{array}{c c c } x_1 & x_2 & x_3 \end{array} \right] \left[ \begin{array}{c} y_1 \\ y_2 \\ y_3 \end{array} \right] $
- &
- $z = \sum_{ij}{ x_i y_j \delta_{ij}} = \sum_{i}{x_i y_i} $
- \\ && \\
- $\vec{z} = \vec{\vec{A}} \bullet \vec{x}$ 
- &
- $\underline{z}  = A \underline{x} = \left[ \begin{array}{c c c } 
- a_{11} & a_{12} & a_{13} \\
- a_{21} & a_{22} & a_{23} \\
- a_{31} & a_{32} & a_{33} 
- \end{array} \right] \left[ \begin{array}{c} x_1 \\ x_2 \\ x_3 \end{array} \right] $
- &
- $z_i = \sum_{jk}{ a_{ij} x_k \delta_{jk}} = \sum_{j}{a_{ij} x_j} $
- \\ && \\
- $\vec{z} = \vec{x} \bullet \vec{\vec{A}}$ 
- &
- $\underline{z}  = \underline{x}^T A $
- &
- $z_j = \sum_{ik}{ x_k a_{ij} \delta_{ki}} = \sum_{i}{x_i a_{ij}} $
- \\ && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- \hline
- \multicolumn{3}{| c |}{Dyadic or outer product} \\
- \hline && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- $\vec{\vec{Z}} = \vec{x}  \vec{y}$ 
- &
- $Z = \underline{x} \, \underline{y}^T = \left[ \begin{array}{c } x_1 \\ x_2 \\ x_3 \end{array} \right] \left[ \begin{array}{c c c} y_1 & y_2 & y_3 \end{array} \right] $
- &
- $z_{ij} = x_i \, y_j $
- \\ && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- \hline
- \multicolumn{3}{| c |}{Cross product} \\
- \hline && \\
- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- $\vec{z} = \vec{x} \times \vec{y}$ 
- &
- $\underline{z} = \underline{x}^{\times} \underline{y} = \left[ \begin{array}{c c c } 
-  0   & -x_3 & x_2 \\
-  x_3 & 0    & -x_1 \\
- -x_2 & x_1  & 0 
- \end{array} \right] \left[ \begin{array}{c} y_1 \\ y_2 \\ y_3 \end{array} \right] $
- &
- $z_i = \sum_{jk}{ \epsilon_{ijk} x_j y_k } $
- \\ && \\
-\hline
+  \hline
+  Vector and Tensors & Matrix, Row and Columns & Components and index \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \hline
+  \multicolumn{3}{| c |}{Definitions} \\
+  \hline
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  Vector $\vec{v}$ and Tensor $\vec{\vec{T}}$
+  &
+  Column $\underline{c}$, Row $\underline{r}$ and Matrix $M$
+  &
+  Scalar components $x_i$ and  $x_{ij}$
+  \\ & & \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %  1-D
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  $\vec{v} = x_1 \vec{i} + x_2 \vec{j} + x_3 \vec{k}$
+  &
+  $\underline{c} = \left[ \begin{array}{c} x_1 \\ x_2 \\x_3 \end{array} \right] $
+  $\underline{r} = \left[ \begin{array}{c c c } x_1 & x_2 & x_3 \end{array} \right] $
+  &
+  $x_i \quad i \in \{ 1,2,3\}$
+  \\ && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %  2-D
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  $\vec{\vec{T}} = x_{11} \vec{i}\vec{i} +  x_{12} \vec{i}\vec{j} + ... + x_{33}  \vec{k}\vec{k}$
+  &
+  $ M = \left[ \begin{array}{c c c }
+                x_{11} & x_{12} & x_{13} \\
+                x_{21} & x_{22} & x_{23} \\
+                x_{31} & x_{32} & x_{33} \\
+  \end{array} \right] $
+  &
+  $x_{ij} \quad i \in \{ 1,2,3\} \; j \in \{ 1,2,3\}$
+  \\ && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \hline
+  \multicolumn{3}{| c |}{Dot or inner product} \\
+  \hline && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  $z = \vec{x} \bullet \vec{y}$
+  &
+  $z = \underline{x}^T \underline{y} = \left[ \begin{array}{c c c } x_1 & x_2 & x_3 \end{array} \right] \left[ \begin{array}{c} y_1 \\ y_2 \\ y_3 \end{array} \right] $
+  &
+  $z = \sum_{ij}{ x_i y_j \delta_{ij}} = \sum_{i}{x_i y_i} $
+  \\ && \\
+  $\vec{z} = \vec{\vec{A}} \bullet \vec{x}$
+  &
+  $\underline{z}  = A \underline{x} = \left[ \begin{array}{c c c }
+                                              a_{11} & a_{12} & a_{13} \\
+                                              a_{21} & a_{22} & a_{23} \\
+                                              a_{31} & a_{32} & a_{33}
+  \end{array} \right] \left[ \begin{array}{c} x_1 \\ x_2 \\ x_3 \end{array} \right] $
+  &
+  $z_i = \sum_{jk}{ a_{ij} x_k \delta_{jk}} = \sum_{j}{a_{ij} x_j} $
+  \\ && \\
+  $\vec{z} = \vec{x} \bullet \vec{\vec{A}}$
+  &
+  $\underline{z}  = \underline{x}^T A $
+  &
+  $z_j = \sum_{ik}{ x_k a_{ij} \delta_{ki}} = \sum_{i}{x_i a_{ij}} $
+  \\ && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \hline
+  \multicolumn{3}{| c |}{Dyadic or outer product} \\
+  \hline && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  $\vec{\vec{Z}} = \vec{x}  \vec{y}$
+  &
+  $Z = \underline{x} \, \underline{y}^T = \left[ \begin{array}{c } x_1 \\ x_2 \\ x_3 \end{array} \right] \left[ \begin{array}{c c c} y_1 & y_2 & y_3 \end{array} \right] $
+  &
+  $z_{ij} = x_i \, y_j $
+  \\ && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \hline
+  \multicolumn{3}{| c |}{Cross product} \\
+  \hline && \\
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  $\vec{z} = \vec{x} \times \vec{y}$
+  &
+  $\underline{z} = \underline{x}^{\times} \underline{y} = \left[ \begin{array}{c c c }
+                                                                  0   & -x_3 & x_2 \\
+                                                                  x_3 & 0    & -x_1 \\
+                                                                  -x_2 & x_1  & 0
+  \end{array} \right] \left[ \begin{array}{c} y_1 \\ y_2 \\ y_3 \end{array} \right] $
+  &
+  $z_i = \sum_{jk}{ \epsilon_{ijk} x_j y_k } $
+  \\ && \\
+  \hline
  \end{tabular}
 \end{table}
 
@@ -438,22 +438,22 @@ La norme des vecteur-colonnes est donc invariante par rapport au choix de la bas
 
 \subsubsection{ Kronecker delta }
 \begin{align}
-\delta_{ij} = \left\lbrace \begin{array}{c}
-1 \quad\text{if}\quad i=j\\
-0 \quad\text{if}\quad i\neq j
-\end{array}
-\right.
+ \delta_{ij} = \left\lbrace \begin{array}{c}
+                             1 \quad\text{if}\quad i=j\\
+                             0 \quad\text{if}\quad i\neq j
+ \end{array}
+ \right.
 \end{align}
 
 
 \subsubsection{ Levi-Civita permutation symbol }
 \begin{align}
-\epsilon_{ijk} = \left\lbrace \begin{array}{l}
-+1  \quad\text{if}\quad ijk=(123),(231) \;\text{or}\; (312)\\
--1   \quad\text{if}\quad ijk=(321),(213) \;\text{or}\; (132)\\
-\,0  \quad\text{if an index is repeated}
-\end{array}
-\right.
+ \epsilon_{ijk} = \left\lbrace \begin{array}{l}
+                                +1  \quad\text{if}\quad ijk=(123),(231) \;\text{or}\; (312)\\
+                                -1   \quad\text{if}\quad ijk=(321),(213) \;\text{or}\; (132)\\
+                                \,0  \quad\text{if an index is repeated}
+ \end{array}
+ \right.
 \end{align}
 
 
@@ -465,11 +465,11 @@ Note that the shape of vector/matrix resulting from a multi-axis differentiation
 
 \subsubsection{Scalar by Scalar}
 
-For a scalar function $y = f(x)$: 
+For a scalar function $y = f(x)$:
 %%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-%y = f(x) \quad \quad 
-z = \frac{\partial y}{\partial x}
+%y = f(x) \quad \quad
+ z = \frac{\partial y}{\partial x}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%
 
@@ -479,9 +479,9 @@ z = \frac{\partial y}{\partial x}
 For the derivation of a vector function $\underline{y} = f(x)$ where $\underline{y} \in \mathbb{R}^n$ with respect to a scalar $x$, by convention if the numerator $\underline{y}$ is a $n \times 1$ column vector, the result is a $n \times 1$ column vector too:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underline{z} = \frac{\partial \underline{y}}{\partial x} =  
- \left[ \begin{array}{c } 
-  \frac{\partial y_1}{\partial x}   \\ \vdots \\ \frac{\partial y_n}{\partial x}
+ \underline{z} = \frac{\partial \underline{y}}{\partial x} =
+ \left[ \begin{array}{c }
+         \frac{\partial y_1}{\partial x}   \\ \vdots \\ \frac{\partial y_n}{\partial x}
  \end{array} \right]
  \quad\Leftrightarrow\quad
  z_{i} = \frac{\partial y_i}{\partial x}
@@ -494,17 +494,17 @@ For the derivation of a vector function $\underline{y} = f(x)$ where $\underline
 For the gradient of a multi-inputs scalar function $y = f(\underline{x})$ where $\underline{x} \in \mathbb{R}^n$, by convention if the denominator $\underline{x}$ is a $n \times 1$ column vector, the result is a $1 \times n$ row vector:
 %%%%%%%%%%%%%%%%
 \begin{align}
-\underline{z} = \frac{\partial y}{\partial \underline{x}} &= 
- \left[ \begin{array}{c c c } 
-  \frac{\partial y}{\partial x_1}   & ... & \frac{\partial y}{\partial x_n}
+ \underline{z} = \frac{\partial y}{\partial \underline{x}} &=
+ \left[ \begin{array}{c c c }
+         \frac{\partial y}{\partial x_1}   & ... & \frac{\partial y}{\partial x_n}
  \end{array} \right]
  \quad \Leftrightarrow\quad
  z_i = \frac{\partial y}{\partial x_i}
 \end{align}
 %%%%%%%%%%%%%%%%%%%
 %\begin{align}
-%\frac{\partial y}{\partial \underline{x}^T} &= \underline{z}^T = 
-%\left[ \begin{array}{c } 
+%\frac{\partial y}{\partial \underline{x}^T} &= \underline{z}^T =
+%\left[ \begin{array}{c }
 %  \frac{\partial y}{\partial x_1}   \\ \vdots \\ \frac{\partial y}{\partial x_n}
 % \end{array} \right]
 % & \quad \Leftrightarrow\quad
@@ -512,29 +512,29 @@ For the gradient of a multi-inputs scalar function $y = f(\underline{x})$ where 
 %\end{align}
 
 \begin{table}[H]
-\centering
-\caption{ Scalar by a vector: Identities}
-\label{scavec}
+ \centering
+ \caption{ Scalar by a vector: Identities}
+ \label{scavec}
  \begin{tabular}{ | c | c | c |}
- \hline \hline & & \\
- Scalar $y = f(\underline{x})$ expression & Gradient Vector $\frac{\partial y}{\partial \underline{x}}$  & Notes \\ & & \\
- \hline \hline & & \\
- $ \underline{a}^T \underline{x} = \underline{x}^T \underline{a} $ & 
- $\underline{a}^T$ &   If $\underline{a}$ is not a function of $\underline{x}$
- \\ & & \\
+  \hline \hline & & \\
+  Scalar $y = f(\underline{x})$ expression & Gradient Vector $\frac{\partial y}{\partial \underline{x}}$  & Notes \\ & & \\
+  \hline \hline & & \\
+  $ \underline{a}^T \underline{x} = \underline{x}^T \underline{a} $ &
+  $\underline{a}^T$ &   If $\underline{a}$ is not a function of $\underline{x}$
+  \\ & & \\
   \hline & & \\
- $ \underline{x}^T \underline{x} $ & 
- $ 2 \, \underline{x}^T $ &   
- \\ & & \\
- \hline & & \\
- $ \underline{x}^T A \underline{x} $ & 
- $\underline{x}^T ( A + A^T )$ &   If $A$ is not a function of $\underline{x}$
- \\ & & \\
- \hline & & \\
- $ \underline{x}^T A \underline{x} $ & 
- $ 2\, \underline{x}^T A$ &   If $A$ is symmetric and not a function of $\underline{x}$
- \\ & & \\
- \hline
+  $ \underline{x}^T \underline{x} $ &
+  $ 2 \, \underline{x}^T $ &
+  \\ & & \\
+  \hline & & \\
+  $ \underline{x}^T A \underline{x} $ &
+  $\underline{x}^T ( A + A^T )$ &   If $A$ is not a function of $\underline{x}$
+  \\ & & \\
+  \hline & & \\
+  $ \underline{x}^T A \underline{x} $ &
+  $ 2\, \underline{x}^T A$ &   If $A$ is symmetric and not a function of $\underline{x}$
+  \\ & & \\
+  \hline
  \end{tabular}
 \end{table}
 
@@ -543,37 +543,37 @@ For the gradient of a multi-inputs vector function $\underline{y} = f(\underline
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-Z = \frac{\partial \underline{y}}{\partial \underline{x}} =  
-\left[ \begin{array}{c c c } 
-  \frac{\partial y_1}{\partial x_{1}}   & ... & \frac{\partial y_1}{\partial x_{n}} \\
-  \vdots                             & ... & \vdots                          \\
-  \frac{\partial y_m}{\partial x_{1}}   & ... & \frac{\partial y_m}{\partial x_{n}} \\
+ Z = \frac{\partial \underline{y}}{\partial \underline{x}} =
+ \left[ \begin{array}{c c c }
+         \frac{\partial y_1}{\partial x_{1}}   & ... & \frac{\partial y_1}{\partial x_{n}} \\
+         \vdots                             & ... & \vdots                          \\
+         \frac{\partial y_m}{\partial x_{1}}   & ... & \frac{\partial y_m}{\partial x_{n}} \\
  \end{array} \right]
  \quad\Leftrightarrow\quad
-  z_{ij} = \frac{\partial y_i}{\partial x_j}
+ z_{ij} = \frac{\partial y_i}{\partial x_j}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{table}[H]
-\centering
-\caption{ Vector by a vector: Identities}
-\label{scavec}
+ \centering
+ \caption{ Vector by a vector: Identities}
+ \label{scavec}
  \begin{tabular}{ | c | c | c |}
- \hline \hline & & \\
- Vector $\underline{y} = f(\underline{x})$ expression &Jacobian Matrix $\frac{\partial \underline{y}}{\partial \underline{x}}$  & Notes \\ & & \\
- \hline \hline & & \\
- $ \underline{x} $ & 
- $I$ &   Identity Matrix
- \\ & & \\
- \hline & & \\
- $ A \underline{x} $ & 
- $A$ &   If $A$ is not a function of $\underline{x}$
- \\ & & \\
- \hline & & \\
- $ \underline{x}^T A $ & 
- $A^T$ &   If $A$ is not a function of $\underline{x}$
- \\ & & \\
- \hline
+  \hline \hline & & \\
+  Vector $\underline{y} = f(\underline{x})$ expression &Jacobian Matrix $\frac{\partial \underline{y}}{\partial \underline{x}}$  & Notes \\ & & \\
+  \hline \hline & & \\
+  $ \underline{x} $ &
+  $I$ &   Identity Matrix
+  \\ & & \\
+  \hline & & \\
+  $ A \underline{x} $ &
+  $A$ &   If $A$ is not a function of $\underline{x}$
+  \\ & & \\
+  \hline & & \\
+  $ \underline{x}^T A $ &
+  $A^T$ &   If $A$ is not a function of $\underline{x}$
+  \\ & & \\
+  \hline
  \end{tabular}
 \end{table}
 
@@ -585,29 +585,29 @@ Z = \frac{\partial \underline{y}}{\partial \underline{x}} =
 For the gradient of a matrix function $\underline{A} = f(x)$ where $x$ is a scalar and $A$ is a $n \times m$ matrix, the result is also a $n \times m$ matrix:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-Z = \frac{\partial A}{\partial x} =  
-\left[ \begin{array}{c c c } 
-  \frac{\partial a_{11}}{\partial x}   & ... & \frac{\partial a_{1m}}{\partial x} \\
-  \vdots                             & ... & \vdots                          \\
-  \frac{\partial a_{n1}}{\partial x}   & ... & \frac{\partial a_{nm}}{\partial x} \\
+ Z = \frac{\partial A}{\partial x} =
+ \left[ \begin{array}{c c c }
+         \frac{\partial a_{11}}{\partial x}   & ... & \frac{\partial a_{1m}}{\partial x} \\
+         \vdots                             & ... & \vdots                          \\
+         \frac{\partial a_{n1}}{\partial x}   & ... & \frac{\partial a_{nm}}{\partial x} \\
  \end{array} \right]
  \quad\Leftrightarrow\quad
-  z_{ij} = \frac{\partial a_{ij}}{\partial x}
+ z_{ij} = \frac{\partial a_{ij}}{\partial x}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{table}[H]
-\centering
-\caption{ Matrix by scalar: Identities}
-\label{scavec}
+ \centering
+ \caption{ Matrix by scalar: Identities}
+ \label{scavec}
  \begin{tabular}{ | c | c | c |}
- \hline \hline & & \\
- Matrix $A$ expression & Differential Matrix $\frac{\partial A}{\partial x}$  & Notes \\ & & \\
- \hline \hline & & \\
- $ M^{-1} $ & 
- $ -M^{-1} \frac{\partial M}{\partial x} M^{-1} $ &   
- \\ & & \\
- \hline
+  \hline \hline & & \\
+  Matrix $A$ expression & Differential Matrix $\frac{\partial A}{\partial x}$  & Notes \\ & & \\
+  \hline \hline & & \\
+  $ M^{-1} $ &
+  $ -M^{-1} \frac{\partial M}{\partial x} M^{-1} $ &
+  \\ & & \\
+  \hline
  \end{tabular}
 \end{table}
 
@@ -618,11 +618,11 @@ Z = \frac{\partial A}{\partial x} =
 For the gradient of a multi-inputs scalar function $y = f( A )$ where $A$ is an $n \times m$ matrix, by convention the result is a $m \times n$ matrix:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-Z = \frac{\partial y}{\partial A} =  
-\left[ \begin{array}{c c c } 
-  \frac{\partial y}{\partial a_{11}}   & ... & \frac{\partial y}{\partial a_{1n}} \\
-  \vdots                             & ... & \vdots                          \\
-  \frac{\partial y}{\partial a_{m1}}   & ... & \frac{\partial y}{\partial a_{mn}} \\
+ Z = \frac{\partial y}{\partial A} =
+ \left[ \begin{array}{c c c }
+         \frac{\partial y}{\partial a_{11}}   & ... & \frac{\partial y}{\partial a_{1n}} \\
+         \vdots                             & ... & \vdots                          \\
+         \frac{\partial y}{\partial a_{m1}}   & ... & \frac{\partial y}{\partial a_{mn}} \\
  \end{array} \right]
  \quad\Leftrightarrow\quad
  z_{ji} = \frac{\partial y}{\partial a_{ij}}
@@ -630,20 +630,20 @@ Z = \frac{\partial y}{\partial A} =
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{table}[H]
-\centering
-\caption{ Scalar by Matrix: Identities}
-\label{scavec}
+ \centering
+ \caption{ Scalar by Matrix: Identities}
+ \label{scavec}
  \begin{tabular}{ | c | c | c |}
- \hline \hline & & \\
- Scalar $y$ expression & Differential Matrix $\frac{\partial y}{\partial A}$  & Notes \\ & & \\
- \hline \hline & & \\
- $ \underline{a}^T A \, \underline{b} $ & 
- $ \underline{b} \, \underline{a}^T   $ &    $\underline{a}$ and  $\underline{b}$ are not function of $A$
- \\ & & \\
- $ \underline{a}^T A^T A \, \underline{b} $ & 
- $ \underline{a} \, \underline{b}^T A^T + \underline{b} \, \underline{a}^T  A^T  $ &    $\underline{a}$ and  $\underline{b}$ are not function of $A$
- \\ & & \\
- \hline
+  \hline \hline & & \\
+  Scalar $y$ expression & Differential Matrix $\frac{\partial y}{\partial A}$  & Notes \\ & & \\
+  \hline \hline & & \\
+  $ \underline{a}^T A \, \underline{b} $ &
+  $ \underline{b} \, \underline{a}^T   $ &    $\underline{a}$ and  $\underline{b}$ are not function of $A$
+  \\ & & \\
+  $ \underline{a}^T A^T A \, \underline{b} $ &
+  $ \underline{a} \, \underline{b}^T A^T + \underline{b} \, \underline{a}^T  A^T  $ &    $\underline{a}$ and  $\underline{b}$ are not function of $A$
+  \\ & & \\
+  \hline
  \end{tabular}
 \end{table}
 
@@ -655,14 +655,14 @@ Z = \frac{\partial y}{\partial A} =
 For the gradient of a matrix function $\underline{A} = f(\col{x})$ where $\col{x}$ is a $p \times 1$ column-vector and $A$ is a $n \times m$ matrix, the result is a $n \times m \times p$ tensor:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-T = \frac{\partial A}{\partial \col{x}} =  
-\left[ \begin{array}{c c c } 
-  \frac{\partial a_{11}}{\partial \col{x}}   & ... & \frac{\partial a_{1m}}{\partial \col{x}} \\
-  \vdots                             & ... & \vdots                          \\
-  \frac{\partial a_{n1}}{\partial \col{x}}   & ... & \frac{\partial a_{nm}}{\partial \col{x}} \\
+ T = \frac{\partial A}{\partial \col{x}} =
+ \left[ \begin{array}{c c c }
+         \frac{\partial a_{11}}{\partial \col{x}}   & ... & \frac{\partial a_{1m}}{\partial \col{x}} \\
+         \vdots                             & ... & \vdots                          \\
+         \frac{\partial a_{n1}}{\partial \col{x}}   & ... & \frac{\partial a_{nm}}{\partial \col{x}} \\
  \end{array} \right]
  \quad\Leftrightarrow\quad
-  z_{ijk} = \frac{\partial a_{ij}}{\partial x_k}
+ z_{ijk} = \frac{\partial a_{ij}}{\partial x_k}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -683,29 +683,29 @@ T = \frac{\partial A}{\partial \col{x}} =
 
 Finding the gradient $\frac{\partial f}{\partial \underline{x}}$ of the quadratic function $f=\underline{x}^T A \underline{x}$. First converting to index notations:
 \begin{align}
-f = \sum_{ij}{x_i A_{ij} x_j}
+ f = \sum_{ij}{x_i A_{ij} x_j}
 \end{align}
 Then differentiating per $x_k$ components:
 \begin{align}
-\frac{\partial f}{\partial x_k} &= \sum_{ij}{  \frac{\partial}{\partial x_k} \left(x_i A_{ij} x_j \right)} \\
-\frac{\partial f}{\partial x_k} &= \sum_{ij}{\left( \underbrace{ \frac{\partial x_i}{\partial x_k}}_{\delta_{ik}}  A_{ij} x_j + x_i \underbrace{\frac{\partial A_{ij} }{\partial x_k}}_{0} x_j + x_i A_{ij} \underbrace{\frac{\partial x_j}{\partial x_k}}_{\delta_{jk}} \right)} \\
-\frac{\partial f}{\partial x_k} &= \sum_{ij}{  \delta_{ik}  A_{ij} x_j } + \sum_{ij}{  \delta_{jk} x_i A_{ij} }\\
-\frac{\partial f}{\partial x_k} &= \sum_{j}{  A_{kj} x_j } + \sum_{i}{ x_i A_{ik} }\\
-\frac{\partial f}{\partial x_k} &= \sum_{i}{\left(  A_{ki} x_i  + x_i A_{ik} \right)}\\
+ \frac{\partial f}{\partial x_k} &= \sum_{ij}{  \frac{\partial}{\partial x_k} \left(x_i A_{ij} x_j \right)} \\
+ \frac{\partial f}{\partial x_k} &= \sum_{ij}{\left( \underbrace{ \frac{\partial x_i}{\partial x_k}}_{\delta_{ik}}  A_{ij} x_j + x_i \underbrace{\frac{\partial A_{ij} }{\partial x_k}}_{0} x_j + x_i A_{ij} \underbrace{\frac{\partial x_j}{\partial x_k}}_{\delta_{jk}} \right)} \\
+ \frac{\partial f}{\partial x_k} &= \sum_{ij}{  \delta_{ik}  A_{ij} x_j } + \sum_{ij}{  \delta_{jk} x_i A_{ij} }\\
+ \frac{\partial f}{\partial x_k} &= \sum_{j}{  A_{kj} x_j } + \sum_{i}{ x_i A_{ik} }\\
+ \frac{\partial f}{\partial x_k} &= \sum_{i}{\left(  A_{ki} x_i  + x_i A_{ik} \right)}\\
 %\frac{\partial f}{\partial x_k} &= \sum_{i}{ x_i \left(  A_{ik} + A_{ki} \right)  }\\
 \end{align}
 Which correspond in matrix form, with the numerator layout convention, to:
 \begin{align}
-\frac{\partial f}{\partial \underline{x}} = \underline{x}^T ( A + A^T )
+ \frac{\partial f}{\partial \underline{x}} = \underline{x}^T ( A + A^T )
 \end{align}
 
 \subsubsection{Least square solution derivation in vector form}
 
 Minimizing the error norm $\|\underline{e}\|^2$ of the estimation problem $\underline{e} = A \underline{\hat{x}} - \underline{b}$ by selecting the parameters $\underline{\hat{x}}$. If the gradient of the error norm with respect to the parameter vector is set to zero:
 \begin{align}
-\underline{0} &= \frac{\partial \|\underline{e}\|^2 }{\partial \underline{\hat{x}}} = \frac{\partial (\underline{e}^T \underline{e} )}{\partial \underline{\hat{x}}} = 2 \, \underline{e}^T \frac{\partial \underline{e} }{\partial \underline{\hat{x}}} = 2\, (A \underline{\hat{x}} - \underline{b})^T A 
+ \underline{0} &= \frac{\partial \|\underline{e}\|^2 }{\partial \underline{\hat{x}}} = \frac{\partial (\underline{e}^T \underline{e} )}{\partial \underline{\hat{x}}} = 2 \, \underline{e}^T \frac{\partial \underline{e} }{\partial \underline{\hat{x}}} = 2\, (A \underline{\hat{x}} - \underline{b})^T A
 \end{align}
 For which the solution is
 \begin{align}
-\underline{\hat{x}} = \left[ A^T A \right]^{-1} A^T \underline{b}
+ \underline{\hat{x}} = \left[ A^T A \right]^{-1} A^T \underline{b}
 \end{align}

--- a/src/math/lin.tex
+++ b/src/math/lin.tex
@@ -1,10 +1,10 @@
 \chapter{Notions d'algèbre linéaire}
 
-L'algèbre linéaire, c'est à la base une collection d'outils mathématique pour traiter plusieurs fonctions/opérations en parallèle. 
+L'algèbre linéaire, c'est à la base une collection d'outils mathématique pour traiter plusieurs fonctions/opérations en parallèle.
 
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.70\textwidth]{calculmatriciel.png}
+	\includegraphics[width=0.70\textwidth]{calculmatriciel.png}
 	\caption{Calcul matriciel }
 	\label{fig:calculmatriciel}
 \end{figure}
@@ -19,40 +19,40 @@ L'algèbre linéaire, c'est à la base une collection d'outils mathématique pou
 Les opérations matricielles permettent de traiter plusieurs fonctions (linéaires) en parallèle. Par exemple, deux fonctions linéaires, $f_1$ et $f_2$, de deux variables (entrées), $x_1$ et $x_2$, peuvent s’écrire :
 %
 \begin{align}
-y_1 = f_1(x_1,x_2) = a_{11} \, x_1 + a_{12} \, x_2   \\
-y_2 = f_2(x_1,x_2) = a_{21} \, x_1 + a_{22} \, x_2
+	y_1 = f_1(x_1,x_2) = a_{11} \, x_1 + a_{12} \, x_2   \\
+	y_2 = f_2(x_1,x_2) = a_{21} \, x_1 + a_{22} \, x_2
 \end{align}
 %
-ou $y_1$ et $y_2$ sont les variables résultats (sorties) des fonctions, et $a_{ii}$ les paramètres internes des fonctions. Ces équations, avec la notation matricielle prennent la forme:
+où $y_1$ et $y_2$ sont les variables résultats (sorties) des fonctions, et $a_{ii}$ les paramètres internes des fonctions. Ces équations, avec la notation matricielle, prennent la forme:
 %
 \begin{align}
-\left[ \begin{array}{c} 
-	y_1 \\ y_2
-\end{array} \right] &= 
-\left[ \begin{array}{c c} 
-a_{11} & a_{12} \\ a_{21} & a_{22}
-\end{array} \right]
-\left[ \begin{array}{c} 
-	x_1 \\ x_2
-\end{array} \right] \quad \leftrightarrow \quad  \col{y}  =   A  \col{x} 
-\label{eq:sys2}
+	\left[ \begin{array}{c}
+			   y_1 \\ y_2
+	\end{array} \right] &=
+	\left[ \begin{array}{c c}
+			   a_{11} & a_{12} \\ a_{21} & a_{22}
+	\end{array} \right]
+	\left[ \begin{array}{c}
+			   x_1 \\ x_2
+	\end{array} \right] \quad \leftrightarrow \quad  \col{y}  =   A  \col{x}
+	\label{eq:sys2}
 \end{align}
 %
-ou $\col{y}$ et $\col{x}$ sont des vecteur-colonnes de dimension 2 et $A$ est une matrice 2x2. De façon générale, une matrice d'un tel système d’équation a une largeur $n$, correspondant au nombre de variable dans les équations, et une hauteur $m$, correspondant au nombre d’équations.
+où $\col{y}$ et $\col{x}$ sont des vecteurs-colonnes de dimension 2 et $A$ est une matrice 2x2. De façon générale, une matrice d'un tel système d’équations a une largeur $n$, correspondant au nombre de variables dans les équations, et une hauteur $m$, correspondant au nombre d’équations.
 %
 \begin{align}
-\left[ \begin{array}{c} 
-	y_1 \\ \vdots \\ y_m
-\end{array} \right] &= 
-\left[ \begin{array}{c c c} 
-a_{11} & ... & a_{1n} \\ \vdots & \ddots  &  \vdots \\ 
-a_{m1} & ... & a_{mn}
-\end{array} \right]
-\left[ \begin{array}{c} 
-	x_1 \\ \vdots \\ x_n
-\end{array} \right] \\
-m: \quad \text{nombre de ranges} \quad&=\quad \text{nombre d’équations / sorties} \\
-n: \quad \text{nombre de colonnes} \quad&=\quad \text{nombre de variables / entrées}
+	\left[ \begin{array}{c}
+			   y_1 \\ \vdots \\ y_m
+	\end{array} \right] &=
+	\left[ \begin{array}{c c c}
+			   a_{11} & ... & a_{1n} \\ \vdots & \ddots  &  \vdots \\
+			   a_{m1} & ... & a_{mn}
+	\end{array} \right]
+	\left[ \begin{array}{c}
+			   x_1 \\ \vdots \\ x_n
+	\end{array} \right] \\
+	m: \quad \text{nombre de ranges} \quad&=\quad \text{nombre d’équations / sorties} \\
+	n: \quad \text{nombre de colonnes} \quad&=\quad \text{nombre de variables / entrées}
 \end{align}
 %
 
@@ -62,35 +62,35 @@ n: \quad \text{nombre de colonnes} \quad&=\quad \text{nombre de variables / entr
 \label{sec:combveccol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La multiplication d'une matrice par un vecteur-colonne peut être vue comme une combinaison linéaire des vecteur-colonnes de la matrice. Cette interprétation est très importante pour comprendre toutes les propriétés importantes et utiles des matrices, qui seront détaillées dans les prochaines sections. L’équation \eqref{eq:sys2}, correspondant a la multiplication d'un vecteur-colonne de dimension 2 par une matrice $2\times2$ peut être réécrite comme l'addition pondérée des deux colonnes de la matrice:
+La multiplication d'une matrice par un vecteur-colonne peut être vue comme une combinaison linéaire des vecteurs-colonne de la matrice. Cette interprétation est très importante pour comprendre toutes les propriétés importantes et utiles des matrices, qui seront détaillées dans les prochaines sections. L’équation \eqref{eq:sys2}, correspondant a la multiplication d'un vecteur-colonne de dimension 2 par une matrice $2\times2$ peut être réécrite comme l'addition pondérée des deux colonnes de la matrice:
 %
 \begin{align}
-\left[ \begin{array}{c} 
-	y_1 \\ y_2
-\end{array} \right] &= 
-\left[ \begin{array}{c c} 
-a_{11} & a_{12} \\ a_{21} & a_{22}
-\end{array} \right]
-\left[ \begin{array}{c} 
-	x_1 \\ x_2
-\end{array} \right] \quad \leftrightarrow \quad  \col{y}  =   
+	\left[ \begin{array}{c}
+			   y_1 \\ y_2
+	\end{array} \right] &=
+	\left[ \begin{array}{c c}
+			   a_{11} & a_{12} \\ a_{21} & a_{22}
+	\end{array} \right]
+	\left[ \begin{array}{c}
+			   x_1 \\ x_2
+	\end{array} \right] \quad \leftrightarrow \quad  \col{y}  =
 %
-\underbrace{\left[ \begin{array}{c} 
-	a_{11} \\ a_{21}
-\end{array} \right]}_{\col{c}_1} \, x_1 +
-\underbrace{\left[ \begin{array}{c} 
-	a_{12} \\ a_{22}
-\end{array} \right]}_{\col{c}_2} \, x_2
-\label{eq:sys2-col}
+	\underbrace{\left[ \begin{array}{c}
+						   a_{11} \\ a_{21}
+	\end{array} \right]}_{\col{c}_1} \, x_1 +
+	\underbrace{\left[ \begin{array}{c}
+						   a_{12} \\ a_{22}
+	\end{array} \right]}_{\col{c}_2} \, x_2
+	\label{eq:sys2-col}
 \end{align}
 %
-Graphiquement, tel illustré à la figure \ref{fig:lincomb}, la multiplication d'une matrice peux être représenté par une addition pondérée (combinaison linéaire) des vecteurs correspondants aux colonnes de la matrice, dans l'espace sortie $\col{y} \in \re^m$.
+Graphiquement, tel qu'illustré à la figure \ref{fig:lincomb}, la multiplication d'une matrice peut être représentée par une addition pondérée (combinaison linéaire) des vecteurs correspondants aux colonnes de la matrice, dans l'espace sortie $\col{y} \in \re^m$.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.60\textwidth]{lincomb.png}
-	\caption{La multiplication matricielle comme une combinaison lineaire de vecteurs}
+	\includegraphics[width=0.60\textwidth]{lincomb.png}
+	\caption{La multiplication matricielle comme une combinaison linéaire de vecteurs}
 	\label{fig:lincomb}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -99,85 +99,85 @@ De façon générale, le vecteur-colonne $\col{y}$ résultant d'une multiplicati
 %
 \begin{align}
 %
-\left[ \begin{array}{c} 
-	y_1 \\ \vdots \\ y_m
-\end{array} \right] 
+	\left[ \begin{array}{c}
+			   y_1 \\ \vdots \\ y_m
+	\end{array} \right]
 %
-&= 
+	&=
 %
-\left[ \begin{array}{c c c c c} 
-\underbrace{\left[ \begin{array}{c} 
-	a_{11} \\ \vdots \\ a_{1m}
-\end{array} \right]}_{\col{c}_1}
-& ... &
-\underbrace{\left[ \begin{array}{c} 
-	a_{i1} \\ \vdots \\ a_{im}
-\end{array} \right]}_{\col{c}_i}
-& ... &
-\underbrace{\left[ \begin{array}{c} 
-	a_{n1} \\ \vdots \\ a_{nm}
-\end{array} \right]}_{\col{c}_n}
-\end{array} \right] 
+	\left[ \begin{array}{c c c c c}
+			   \underbrace{\left[ \begin{array}{c}
+									  a_{11} \\ \vdots \\ a_{1m}
+			   \end{array} \right]}_{\col{c}_1}
+			   & ... &
+			   \underbrace{\left[ \begin{array}{c}
+									  a_{i1} \\ \vdots \\ a_{im}
+			   \end{array} \right]}_{\col{c}_i}
+			   & ... &
+			   \underbrace{\left[ \begin{array}{c}
+									  a_{n1} \\ \vdots \\ a_{nm}
+			   \end{array} \right]}_{\col{c}_n}
+	\end{array} \right]
 %
-\left[ \begin{array}{c} 
-	x_1 \\ \vdots \\ x_n
-\end{array} \right]  \\
+	\left[ \begin{array}{c}
+			   x_1 \\ \vdots \\ x_n
+	\end{array} \right]  \\
 %
 %
-\col{y}
-&= \sum_{i=1}^{n}{ \col{c}_i x_i}
+	\col{y}
+	&= \sum_{i=1}^{n}{ \col{c}_i x_i}
 \end{align}
 %
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Produits scalaires avec les rangés de la matrice} 
+\section{Produits scalaires avec les rangées de la matrice}
 \label{sec:combveccol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Une autre interprétation de l'opération matricielle $\col{y} = A \col{x}$ est que chaque élément $y_j$ du résultat correspond au produit scalaire du vecteur-rangé $j$ avec le vecteur colonne $\col{x}$. L'équation \eqref{eq:sys2} peut prendre la forme:
+Une autre interprétation de l'opération matricielle $\col{y} = A \col{x}$ est que chaque élément $y_j$ du résultat correspond au produit scalaire du vecteur-rangée $j$ avec le vecteur-colonne $\col{x}$. L'équation \eqref{eq:sys2} peut prendre la forme:
 %
 \begin{align}
-\left[ \begin{array}{c} 
-	y_1 \\ y_2
-\end{array} \right] &= 
-\left[ \begin{array}{c c} 
-a_{11} & a_{12} \\ a_{21} & a_{22}
-\end{array} \right]
-\left[ \begin{array}{c} 
-	x_1 \\ x_2
-\end{array} \right] = 
-\left[ \begin{array}{c} 
-\underbrace{
-\left[ \begin{array}{c c} 
-a_{11} & a_{12} 
-\end{array} \right]
-}_{\col{r}_1}
-\left[ \begin{array}{c} 
-	x_1 \\ x_2
-\end{array} \right] 
-	\\ \\
-\underbrace{
-\left[ \begin{array}{c c} 
-a_{21} & a_{22} 
-\end{array} \right]
-}_{\col{r}_2}
-\left[ \begin{array}{c} 
-	x_1 \\ x_2
-\end{array} \right] 
-\end{array} \right] 
-= 
-\left[ \begin{array}{c} 
-\vec{r}_1 \bullet \vec{x}
-\\
-\vec{r}_2 \bullet \vec{x}
-\end{array} \right]
+	\left[ \begin{array}{c}
+			   y_1 \\ y_2
+	\end{array} \right] &=
+	\left[ \begin{array}{c c}
+			   a_{11} & a_{12} \\ a_{21} & a_{22}
+	\end{array} \right]
+	\left[ \begin{array}{c}
+			   x_1 \\ x_2
+	\end{array} \right] =
+	\left[ \begin{array}{c}
+			   \underbrace{
+				   \left[ \begin{array}{c c}
+							  a_{11} & a_{12}
+				   \end{array} \right]
+			   }_{\col{r}_1}
+			   \left[ \begin{array}{c}
+						  x_1 \\ x_2
+			   \end{array} \right]
+			   \\ \\
+			   \underbrace{
+				   \left[ \begin{array}{c c}
+							  a_{21} & a_{22}
+				   \end{array} \right]
+			   }_{\col{r}_2}
+			   \left[ \begin{array}{c}
+						  x_1 \\ x_2
+			   \end{array} \right]
+	\end{array} \right]
+	=
+	\left[ \begin{array}{c}
+			   \vec{r}_1 \bullet \vec{x}
+			   \\
+			   \vec{r}_2 \bullet \vec{x}
+	\end{array} \right]
 \end{align}
 %
-De façon générale, chaque élément du $y_j$ vecteur-colonne $\col{y}$ résultant d'une multiplication d'une matrice $A$ avec un vecteur-colonne $\col{x}$, peut-être exprimé comme le résultat du produit scalaire entre le vecteur-rangé $\col{r}_j$ et le vecteur-colonne $\col{x}$:
+De façon générale, chaque élément du $y_j$ vecteur-colonne $\col{y}$ résultant d'une multiplication d'une matrice $A$ avec un vecteur-colonne $\col{x}$, peut-être exprimé comme le résultat du produit scalaire entre le vecteur-rangée $\col{r}_j$ et le vecteur-colonne $\col{x}$:
 %
 \begin{align}
-y_j
-&= \col{r}_j \, \col{x}
+	y_j
+	&= \col{r}_j \, \col{x}
 \end{align}
 %
 
@@ -192,11 +192,11 @@ Une matrice multipliée par un vecteur-colonne:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
 %%%%%%%%%%%%%%%%%%%%
-\col{y}  = A \col{x} 
+	\col{y}  = A \col{x}
 %%%%%%%%%%%%%%%%%%%%
-\quad \Leftrightarrow \quad
+	\quad \Leftrightarrow \quad
 %%%%%%%%%%%%%%%%%%%%
-y_j = \sum_i{A_{ji} x_i }
+	y_j = \sum_i{A_{ji} x_i }
 %%%%%%%%%%%%%%%%%%%%
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
@@ -206,11 +206,11 @@ Une matrice multipliée par une autre matrice:
 %%%%%%%%%%%%%%%%%%%%
 \begin{align}
 %%%%%%%%%%%%%%%%%%%%
-A  = B C
+	A  = B C
 %%%%%%%%%%%%%%%%%%%%
-\quad \Leftrightarrow \quad
+	\quad \Leftrightarrow \quad
 %%%%%%%%%%%%%%%%%%%%
-A_{ik} = \sum_j{B_{ij} C_{jk} }
+	A_{ik} = \sum_j{B_{ij} C_{jk} }
 %%%%%%%%%%%%%%%%%%%%
 \end{align}
 %%%%%%%%%%%%%%%%%%%%
@@ -221,14 +221,14 @@ A_{ik} = \sum_j{B_{ij} C_{jk} }
 \label{sec:espcol}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-L'espace colonne d'une matrice $A$ représente l'ensemble de toutes les valeurs possible de la sortie $\col{y}$ qui résulte de l'opération $\col{y} = A \col{x}$. Avec l'interprétation présentée à la section \ref{sec:combveccol}, il est possible de voir que cette sortie a comme domaine toutes les combinaisons linéaires possibles des vecteur-colonnes de la matrice. 
+L'espace colonne d'une matrice $A$ représente l'ensemble de toutes les valeurs possible de la sortie $\col{y}$ qui résulte de l'opération $\col{y} = A \col{x}$. Avec l'interprétation présentée à la section \ref{sec:combveccol}, il est possible de voir que cette sortie a comme domaine toutes les combinaisons linéaires possibles des vecteurs-colonne de la matrice.
 
-Par exemple, pour une matrice 3$\times$3 avec une sortie qui représente une position spatiale (x,y,z), dans le cas le plus générale la sortie peut potentiellement être une valeur arbitraire en 3D. Toutefois, si les vecteurs-colonnes de la matrice sont co-linéaire (donc  ils forment un plan), alors l'espace colonne est restreint à ce plan. La sortie $\col{y}$ peut seulement prendre des valeurs qui correspondent à ce plan. 
+Par exemple, pour une matrice 3$\times$3 avec une sortie qui représente une position spatiale (x,y,z), dans le cas le plus général la sortie peut potentiellement être une valeur arbitraire en 3D. Toutefois, si les vecteurs-colonne de la matrice sont colinéaires (donc ils forment un plan), alors l'espace colonne est restreint à ce plan. La sortie $\col{y}$ peut seulement prendre des valeurs qui correspondent à ce plan.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.60\textwidth]{2dspace.png}
+	\includegraphics[width=0.60\textwidth]{2dspace.png}
 	\caption{Visualisation graphique d'un espace colonne de dimension 2}
 	\label{fig:2dspace}
 \end{figure}
@@ -238,88 +238,88 @@ Par exemple, pour une matrice 3$\times$3 avec une sortie qui représente une pos
 L'espace colonne d'une matrice $A$ sera noté $col(A)$ et a la définition suivante:
 %%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-col(A) = 
-\{ A \col{x} \; | \; \col{x} \in \re^n \}
-\label{eq:cola}
+	col(A) =
+	\{ A \col{x} \; | \; \col{x} \in \re^n \}
+	\label{eq:cola}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%
 
-\textbf{Note sur la notation mathématique pour les ensembles:} Les crochets $\{ \}$ représentent un ensemble, à l'intérieur on note la liste des éléments de l'ensemble ou bien la définition. La barre verticale $|$ signifie \textit{tel que} et le symbole $\in$ signifie \textit{appartient à}. L'équation \eqref{eq:cola} peut donc se lire \textit{l'espace colonne de la matrice $A$ est égale à l'ensemble des résultats possible de l'opération $A \col{x} $ tel que $\col{x}$ appartient à l'espace vectoriel de dimension $n$}.
+\textbf{Note sur la notation mathématique pour les ensembles:} Les crochets $\{ \}$ représentent un ensemble, à l'intérieur on note la liste des éléments de l'ensemble ou bien la définition. La barre verticale $|$ signifie \textit{tel que} et le symbole $\in$ signifie \textit{appartient à}. L'équation \eqref{eq:cola} peut donc se lire \textit{l'espace colonne de la matrice $A$ est égale à l'ensemble des résultats possibles de l'opération $A \col{x} $ tel que $\col{x}$ appartient à l'espace vectoriel de dimension $n$}.
 
-Lorsque la matrice $A$ est inversible, i.e. de rang plein, l'espace colonne correspond à $\re^m$, ou $m$ est le nombre de variables de sortie.
+Lorsque la matrice $A$ est inversible, c.-à-d. de rang plein, l'espace colonne correspond à $\re^m$, ou $m$ est le nombre de variables de sortie.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Espace rangée}
 \label{sec:esprow}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-L'espace rangé d'une matrice correspond à l'ensemble des vecteur-colonne entré $\col{x}$ qui donne un vecteur-colonne sortie $\col{y}$ non-nul lorsque multiplié par la matrice $A$. Cet ensemble correspond aussi à toutes les combinaisons possibles des rangées de la matrice $A$.
+L'espace rangé d'une matrice correspond à l'ensemble des vecteurs-colonne entré $\col{x}$ qui donne un vecteur-colonne sortie $\col{y}$ non-nul lorsque multiplié par la matrice $A$. Cet ensemble correspond aussi à toutes les combinaisons possibles des rangées de la matrice $A$.
 
 
 L'espace rangée d'une matrice $A$ sera noté $row(A)$ et a la définition suivante:
 %%%%%%%%%%%%%%%%%%%
 \begin{align}
-row(A) =  col(A^T) = 
-\{ A^T \col{y} \; | \; \col{y} \in \re^m \}
+	row(A) =  col(A^T) =
+	\{ A^T \col{y} \; | \; \col{y} \in \re^m \}
 \end{align}
 %%%%%%%%%%%%%%%%%%%
-Lorsque la matrice $A$ est inversible, i.e. de rang plein, l'espace rangé correspond à $\re^n$, ou $n$ est le nombre de variables de sortie.
+Lorsque la matrice $A$ est inversible, c.-à-d. de rang plein, l'espace rangé correspond à $\re^n$, ou $n$ est le nombre de variables de sortie.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Factorisation LU}
 \label{sec:lu}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Une matrice $A$ peut-etre factorise en deux matrices (triangulaires lorsque $A$ est une matrice inversible):
+Une matrice $A$ peut être factorisée en deux matrices (triangulaires lorsque $A$ est une matrice inversible):
 %
 \begin{align}
-A = LU 
+	A = LU
 \end{align}
 %
-ou la matrice $U$ est une matrice ou tout les coefficients sous la diagonale sont nuls et la matrice $L$ correspond aux opérations sur les ranges conduites dans le cadre d'une élimination Gauss-Jordan. Par exemple pour une matrice 3x3 inversible:
+où la matrice $U$ est une matrice où tous les coefficients sous la diagonale sont nuls et la matrice $L$ correspond aux opérations sur les ranges conduites dans le cadre d'une élimination Gauss-Jordan. Par exemple pour une matrice 3x3 inversible:
 %
 \begin{align}
-L= 
-\left[ \begin{array}{c c c } 
-1      &   0       & 0   \\ 
-l_{21} &   1       & 0   \\  
-l_{31} & l_{32}    & 1
-\end{array} \right]
-\quad\quad
-U = 
-\left[ \begin{array}{c c c c c } 
-p_{1} & u_{12} &  u_{13} \\ 
-0     & p_{2}  &  u_{23}  \\ 
-0     & 0      &  p_{3}
-\end{array} \right]
+	L=
+	\left[ \begin{array}{c c c }
+			   1      &   0       & 0   \\
+			   l_{21} &   1       & 0   \\
+			   l_{31} & l_{32}    & 1
+	\end{array} \right]
+	\quad\quad
+	U =
+	\left[ \begin{array}{c c c c c }
+			   p_{1} & u_{12} &  u_{13} \\
+			   0     & p_{2}  &  u_{23}  \\
+			   0     & 0      &  p_{3}
+	\end{array} \right]
 \end{align}
 %
-Les coefficients non-nuls $p_i$ sur la diagonale de la matrice $U$ sont appeles les pivots.
+Les coefficients non-nuls $p_i$ sur la diagonale de la matrice $U$ sont appelés les pivots.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Indépendance linéaire}
 \label{sec:lindep}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Un vecteur est dit linéairement dépendant d'un autre vecteur (ou un ensemble de vecteurs), lorsque celui-ci peut être exprimé comme un combinaison pondéré des autres. 
+Un vecteur est dit linéairement dépendant d'un autre vecteur (ou un ensemble de vecteurs), lorsque celui-ci peut être exprimé comme une combinaison pondérée des autres.
 
 TODO figure
 
 Un ensemble de vecteurs $\left\{ \col{v}_1, \col{v}_2, \hdots, \col{v}_n \right\}$ est \textbf{linéairement dépendant} s'il existe des coefficients non nuls $x_i$ tels que la somme pondérée des vecteurs est nulle:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{0} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
+	\col{0} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%
 
 Inversement, un ensemble de vecteurs $\left\{ \col{v}_1, \col{v}_2, \hdots, \col{v}_n \right\}$ est \textbf{linéairement indépendant} si:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{0} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
-\quad
-\text{implique que:}
-\quad
-0 = x_1 = x_2 = ... = x_n 
+	\col{0} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
+	\quad
+	\text{implique que:}
+	\quad
+	0 = x_1 = x_2 = ... = x_n
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%
 
@@ -331,25 +331,25 @@ Inversement, un ensemble de vecteurs $\left\{ \col{v}_1, \col{v}_2, \hdots, \col
 Un ensemble $\{ \col{v}_1 \; \col{v}_2 \; \hdots \; \col{v}_n \}$ de vecteurs de dimensions $m$ dans un espace vectoriel appartenant à $\re^m$, forme une base de cet espace si: \textbf{1)} les vecteurs $\col{v}_1 \; \col{v}_2 \; \hdots \; \col{v}_n$ sont linéairement indépendants et \textbf{2)} tout vecteur $\col{w}$ de cet espace peut être exprimé comme une combinaison linéaire de ces vecteurs:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{w} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
+	\col{w} = x_1 \col{v}_1 + x_2 \col{v}_2 + ... + x_n \col{v}_n
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%
 
-Par exemple, dans un espace tri-dimensionnel qui correspond à des coordonnées $
+Par exemple, dans un espace tridimensionnel qui correspond à des coordonnées $
 \left[
 \begin{array}{c}
-x \\ y \\ z
+	x \\ y \\ z
 \end{array}
 \right]
-$, les vecteur-colonnes $\left\{ 
+$, les vecteurs-colonne $\left\{
 \left[
 \begin{array}{c}
-1 \\ 0 \\ 0
+	1 \\ 0 \\ 0
 \end{array}
 \right],
 \left[
 \begin{array}{c}
-0 \\ 1 \\ 0
+	0 \\ 1 \\ 0
 \end{array}
 \right]
 \right\}$
@@ -363,20 +363,20 @@ forment une base pour le sous-espace qui correspond au plan $z=0$.
 Le rang $r$ d'une matrice correspond à la dimension de l'espace colonne d'une matrice, qui est toujours aussi égale à la dimension de l'espace rangé. Ce nombre correspond aussi au nombre de pivots, il sera noté par la variable $r$:
 %%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-r = rank( A ) = dim( col(A) ) = dim( col(A^T) ) =\#\, pivots
+	r = rank( A ) = dim( col(A) ) = dim( col(A^T) ) =\#\, pivots
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%
 
 
-Le rang d'une matrice est toujours inférieur ou égale aux dimensions $m$ et $n$.
+Le rang d'une matrice est toujours inférieur ou égal aux dimensions $m$ et $n$.
 %%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-r \leq n &= \#\, ranges \\
-r \leq m &= \#\, colonnes
+	r \leq n &= \#\, ranges \\
+	r \leq m &= \#\, colonnes
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%
 
-Dans le cas d'une matrice carré ($m=n$), il est possible de déterminer si la matrice à une rang dit plein, i.e. si $r=m=n$, en calculant le déterminant de la matrice $A$. Si le déterminant est non-nul alors la matrice à un rang plein.  
+Dans le cas d'une matrice carrée ($m=n$), il est possible de déterminer si la matrice a un rang dit plein, c.-à-d. si $r=m=n$, en calculant le déterminant de la matrice $A$. Si le déterminant est non-nul, alors la matrice a un rang plein.
 
 
 \newpage
@@ -385,24 +385,24 @@ Dans le cas d'une matrice carré ($m=n$), il est possible de déterminer si la m
 \label{sec:rangpleinvstrop}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Un système d'équations peut être parfaitement contraint (une seule solution existe), sur-contraint (aucune solution exacte n'existe) ou bien sous-contraint (plusieurs solutions sont possible. Dans le cas d'une relation matricielle de type $A \col{x} = \col{y} $, qui représente un système d’équations linéaires, le rang de la matrice $A$ permet de déterminer la situation, voir figure \ref{fig:rmn}.
+Un système d'équations peut être parfaitement contraint (une seule solution existe), sur-contraint (aucune solution exacte n'existe) ou bien sous-contraint (plusieurs solutions sont possibles. Dans le cas d'une relation matricielle de type $A \col{x} = \col{y} $, qui représente un système d’équations linéaires, le rang de la matrice $A$ permet de déterminer la situation, voir figure \ref{fig:rmn}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.95\textwidth]{linalgebra_4types.png}
+	\includegraphics[width=0.95\textwidth]{linalgebra_4types.png}
 	\caption{Quatre situations possibles pour un système d'équations}
 	\label{fig:rmn}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Les grandes catégories de situations possibles illustrés à la figure \ref{fig:rmn} sont exemplifiés avec les exemples illustrés aux figures \ref{fig:rmn_ex1}, \ref{fig:rmn_ex2}, \ref{fig:rmn_ex3} et \ref{fig:rmn_ex4}.
+Les grandes catégories de situations possibles illustrés à la figure \ref{fig:rmn} sont exemplifiées avec les exemples illustrés aux figures \ref{fig:rmn_ex1}, \ref{fig:rmn_ex2}, \ref{fig:rmn_ex3} et \ref{fig:rmn_ex4}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex1.png}
-	\caption{Exemple d'un système d'équation parfaitement contraint}
+	\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex1.png}
+	\caption{Exemple d'un système d'équations parfaitement contraint}
 	\label{fig:rmn_ex1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -410,8 +410,8 @@ Les grandes catégories de situations possibles illustrés à la figure \ref{fig
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex2.png}
-	\caption{Exemple d'un système d'équation sous-contraint}
+	\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex2.png}
+	\caption{Exemple d'un système d'équations sous-contraint}
 	\label{fig:rmn_ex2}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -419,8 +419,8 @@ Les grandes catégories de situations possibles illustrés à la figure \ref{fig
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex3.png}
-	\caption{Exemple d'un système d'équation sur-contraint}
+	\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex3.png}
+	\caption{Exemple d'un système d'équations sur-contraint}
 	\label{fig:rmn_ex3}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -428,8 +428,8 @@ Les grandes catégories de situations possibles illustrés à la figure \ref{fig
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex4.png}
-	\caption{Exemple d'un système d'équation non-inversible}
+	\includegraphics[width=0.65\textwidth]{linalgebra_4types_ex4.png}
+	\caption{Exemple d'un système d'équations non-inversible}
 	\label{fig:rmn_ex4}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -441,67 +441,67 @@ Les grandes catégories de situations possibles illustrés à la figure \ref{fig
 \label{sec:nullspace}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Le \textit{Nullspace} d'une matrice $A$, noté $N(A)$ correspond a l'ensemble de tous les vecteur-colonnes $\col{x}$ pour lesquels la multiplication avec la matrice $A$ donne un vecteur-colonne nulle $\col{0}$ :
+Le \textit{Nullspace} d'une matrice $A$, noté $N(A)$ correspond à l'ensemble de tous les vecteurs-colonne $\col{x}$ pour lesquels la multiplication avec la matrice $A$ donne un vecteur-colonne nulle $\col{0}$ :
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-N(A) = \left\{ \col{x} \in \mathbb{R}^n \,|\, A\col{x} = \col{0} \right\}
+	N(A) = \left\{ \col{x} \in \mathbb{R}^n \,|\, A\col{x} = \col{0} \right\}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Tous les vecteur-colonnes entrées $\col{x}$ pour une matrice appartiennent soit à l'espace rangé soit au \textit{Nullspace}:
+Tous les vecteurs-colonne entrée $\col{x}$ pour une matrice appartiennent soit à l'espace rangé soit au \textit{Nullspace}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{x} \in \re^n = col(A^T) \; \cup \; N(A) %\quad \text{et} \quad
-%n     = dim( row(A) ) + dim( N(A) ) 
+	\col{x} \in \re^n = col(A^T) \; \cup \; N(A) %\quad \text{et} \quad
+%n     = dim( row(A) ) + dim( N(A) )
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\textbf{Les vecteur-colonnes appartenant à l'espace rangé influencent la sortie alors que les vecteur-colonnes appartenant au \textit{Nullspace} n'influent pas la sortie.} 
+\textbf{Les vecteurs-colonne appartenant à l'espace rangé influencent la sortie, alors que les vecteur-colonnes appartenant au \textit{Nullspace} n'influent pas la sortie.}
 
-Une matrice $A$ va avoir un \textit{Nullspace} seulement lorsqu'elle a une rang déficient, donc des colonnes linéairement dépendantes. La présence d'un \textit{Nullspace} indique un système sous-contraint ou il y a un surplus de variables, donc plusieurs solutions possibles d'entrées $\col{x}$ pour obtenir une même sortie $\col{y}$. 
+Une matrice $A$ va avoir un \textit{Nullspace} seulement lorsqu'elle a un rang déficient, donc des colonnes linéairement dépendantes. La présence d'un \textit{Nullspace} indique un système sous-contraint ou il y a un surplus de variables, donc plusieurs solutions possibles d'entrées $\col{x}$ pour obtenir une même sortie $\col{y}$.
 %
-%\textbf{Utilisation} Une utilité du \textit{Nullspace} est que si on connaît un solution $\col{x}_s$ tel que: 
+%\textbf{Utilisation} Une utilité du \textit{Nullspace} est que si on connaît un solution $\col{x}_s$ tel que:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
 %A \col{x}_s = \col{y}
 %\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Il est possible de trouver les autres solutions possible directement si on connaît le \textit{Nullspace}, car une addition de la solution connue et d'un vecteur-colonne appartenant au \textit{Nullspace} ($\col{x}_n \in N(A) $)  est aussi une solution: 
+%Il est possible de trouver les autres solutions possible directement si on connaît le \textit{Nullspace}, car une addition de la solution connue et d'un vecteur-colonne appartenant au \textit{Nullspace} ($\col{x}_n \in N(A) $)  est aussi une solution:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\begin{align}
-%A ( \col{x}_s + \col{x}_n) = A \col{x}_s + 
+%A ( \col{x}_s + \col{x}_n) = A \col{x}_s +
 %\underbrace{
-%A \col{x}_n 
+%A \col{x}_n
 %}_{ \col{0} }
 %= A \col{x}_s = \col{y}
 %\end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-La figure \ref{fig:4spaces_ex1} illustre la signification physique du \textit{Nullspace} d'une matrice qui relie la vitesse des joints d'un robot manipulateur à la vitesse de son effecteur. 
+La figure \ref{fig:4spaces_ex1} illustre la signification physique du \textit{Nullspace} d'une matrice qui relie la vitesse des joints d'un robot manipulateur à la vitesse de son effecteur.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Left-Nullspace}
 \label{sec:leftnullspace}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Le \textit{Left-Nullspace} d'une matrice $A$, noté $N(A^T)$ correspond a l'ensemble de tous les vecteur-colonnes $\col{y}$ pour lesquels la multiplication avec la matrice $A^T$ donne un vecteur-colonne nulle $\col{0}$ :
+Le \textit{Left-Nullspace} d'une matrice $A$, noté $N(A^T)$ correspond à l'ensemble de tous les vecteurs-colonne $\col{y}$ pour lesquels la multiplication avec la matrice $A^T$ donne un vecteur-colonne nul $\col{0}$ :
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-N(A^T) = \left\{ \col{y} \in \mathbb{R}^m \,|\, A^T\col{y} = \col{0} \right\}
+	N(A^T) = \left\{ \col{y} \in \mathbb{R}^m \,|\, A^T\col{y} = \col{0} \right\}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Tous les vecteur-colonnes sorties $\col{y}$ appartiennent soit à l'espace colonne soit au \textit{Left-Nullspace}:
+Tous les vecteurs-colonne sorties $\col{y}$ appartiennent soit à l'espace colonne, soit au \textit{Left-Nullspace}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{y} \in \re^m = col(A) \; \cup \; N(A^T) %\quad \text{et} \quad
-%n     = dim( row(A) ) + dim( N(A) ) 
+	\col{y} \in \re^m = col(A) \; \cup \; N(A^T) %\quad \text{et} \quad
+%n     = dim( row(A) ) + dim( N(A) )
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\textbf{Les vecteur-colonnes $\col{y}$ appartenant à l'espace colonne ont une solution $\col{x}$ possible, tandis que ceux appartenant au \textit{Left-Nullspace} n'ont aucune solution exacte $\col{x}$ possible}.
+\textbf{Les vecteurs-colonne $\col{y}$ appartenant à l'espace colonne ont une solution $\col{x}$ possible, tandis que ceux appartenant au \textit{Left-Nullspace} n'ont aucune solution exacte $\col{x}$ possible}.
 %
-Une matrice $A$ va avoir un \textit{Left-Nullspace} seulement lorsqu'elle a une rang déficient. La présence d'un \textit{Left-Nullspace} indique un système sur-contraint, i.e. un surplus d'équations. Il y aura donc plusieurs sorties $\col{y}$ pour lesquelles il n'y a pas de solutions $\col{x}$.
+Une matrice $A$ va avoir un \textit{Left-Nullspace} seulement lorsqu'elle a un rang déficient. La présence d'un \textit{Left-Nullspace} indique un système sur-contraint, c.-à-d. un surplus d'équations. Il y aura donc plusieurs sorties $\col{y}$ pour lesquelles il n'y a pas de solutions $\col{x}$.
 
 
 \newpage
@@ -510,13 +510,13 @@ Une matrice $A$ va avoir un \textit{Left-Nullspace} seulement lorsqu'elle a une 
 \label{sec:4espfond}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matrice, deux sont caractérisent les entrées et deux espaces caractérisent les sorties. La figure \ref{fig:4spaces2} illustre comment les dimensions de ces espaces sont reliés au rang et dimensions d'une matrice.
+La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matrice, deux sont caractérisent les entrées et deux espaces caractérisent les sorties. La figure \ref{fig:4spaces2} illustre comment les dimensions de ces espaces sont reliées au rang et dimensions d'une matrice.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.80\textwidth]{linalgebra_4spaces.png}
-	\caption{Quatres espaces fondamentaux d'une matrice}
+	\includegraphics[width=0.80\textwidth]{linalgebra_4spaces.png}
+	\caption{Quatre espaces fondamentaux d'une matrice}
 	\label{fig:4spaces}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -524,7 +524,7 @@ La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matric
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.60\textwidth]{linalgebra_4spaces2.png}
+	\includegraphics[width=0.60\textwidth]{linalgebra_4spaces2.png}
 	\caption{Dimensions des quatre espaces fondamentaux d'une matrice}
 	\label{fig:4spaces2}
 \end{figure}
@@ -533,7 +533,7 @@ La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matric
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.85\textwidth]{linalgebra_4spaces_ex1.png}
+	\includegraphics[width=0.85\textwidth]{linalgebra_4spaces_ex1.png}
 	\caption{Exemple de Nullspace d'une matrice}
 	\label{fig:4spaces_ex1}
 \end{figure}
@@ -542,7 +542,7 @@ La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matric
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.85\textwidth]{linalgebra_4spaces_ex2.png}
+	\includegraphics[width=0.85\textwidth]{linalgebra_4spaces_ex2.png}
 	\caption{Exemple de Left-Nullspace d'une matrice}
 	\label{fig:4spaces_ex2}
 \end{figure}
@@ -565,15 +565,15 @@ La figure \ref{fig:4spaces} résume les quatre espaces fondamentaux d'une matric
 Lorsqu'un système d'équation linéaire $\col{y} = A \col{x}$ est sur-contraint, c'est-à-dire que le vecteur $\col{y}$ n'est pas dans l'espace colonne de la matrice $A$, il n'y a pas de solution exacte possible. Il est toutefois possible de calculer une solution approximée qui minimise la norme de l'erreur avec une expression explicite:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\hat{x}}^* &= \operatornamewithlimits{argmin}\limits_{\col{\hat{x}}} \left\| A \col{\hat{x}} - \col{y} \right\|^2
-= (A^T A)^{-1} A^T \, \col{y}
+	\col{\hat{x}}^* &= \operatornamewithlimits{argmin}\limits_{\col{\hat{x}}} \left\| A \col{\hat{x}} - \col{y} \right\|^2
+	= (A^T A)^{-1} A^T \, \col{y}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.5\textwidth]{leastsquare.png}
-	\caption{Système sur-contraint: solution des moindres-carrés}
+	\includegraphics[width=0.5\textwidth]{leastsquare.png}
+	\caption{Système sur-contraint: solution des moindres carrés}
 	\label{fig:leastsquare}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -581,70 +581,70 @@ Lorsqu'un système d'équation linéaire $\col{y} = A \col{x}$ est sur-contraint
 La matrice $(A^T A)^{-1} A^T$ est souvent appelée inverse gauche de Moore–Penrose et notée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A^{+} &= (A^T A)^{-1} A^T  \quad \Rightarrow \quad A^{+} A = I
+	A^{+} &= (A^T A)^{-1} A^T  \quad \Rightarrow \quad A^{+} A = I
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Il est à noter que la matrice $A$ doit avoir des colonnes indépendantes pour que la matrice $A^T A$ soit inversible et donc pour que la méthode des moindres-carrés fonctionne.
+Il est à noter que la matrice $A$ doit avoir des colonnes indépendantes pour que la matrice $A^T A$ soit inversible et donc pour que la méthode des moindres carrés fonctionne.
 
 
 \subsection{Application à des problèmes d'identification de paramètres}
 
 
-La méthode des moindres-carrés est très utile pour identifier des paramètres inconnus dans une relation linéaire. Lorsqu'on a un modèle linéaire qui implique des signaux connus et des paramètres inconnus qui peut être exprimé sous la forme:
+La méthode des moindres carrés est très utile pour identifier des paramètres inconnus dans une relation linéaire. Lorsqu'on a un modèle linéaire qui implique des signaux connus et des paramètres inconnus, et qu'ils  peuvent être exprimés sous la forme:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underline{\varphi}^T \underline{\theta}
-= b
-\quad\quad\Rightarrow\quad\quad
-\underbrace{ 
-\left[ \begin{array}{c c c } 
-\varphi_1 & ... & \varphi_m
-\end{array} \right] }_{ m \text{ signaux connus} }
-\underbrace{ \left[ \begin{array}{c} 
-\theta_1 \\ \vdots \\ \theta_m
-\end{array} \right] }_{ m \text{ paramètre inconnus} } = 
-\underbrace{b}_{\text{signal connu} }
+	\underline{\varphi}^T \underline{\theta}
+	= b
+	\quad\quad\Rightarrow\quad\quad
+	\underbrace{
+		\left[ \begin{array}{c c c }
+				   \varphi_1 & ... & \varphi_m
+		\end{array} \right] }_{ m \text{ signaux connus} }
+	\underbrace{ \left[ \begin{array}{c}
+							\theta_1 \\ \vdots \\ \theta_m
+	\end{array} \right] }_{ m \text{ paramètre inconnus} } =
+	\underbrace{b}_{\text{signal connu} }
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est possible de regrouper plusieurs mesures expérimentales dans un système matricielle:
+Il est possible de regrouper plusieurs mesures expérimentales dans un système matriciel:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A \underline{\theta}
-= \underline{b}
-\quad\quad\Rightarrow\quad\quad
-\underbrace{ 
-\left[ \begin{array}{c c c c c } 
-&& \underline{\varphi}^T(1) && \\
-&& \vdots & \\
-&& \underline{\varphi}^T(N) && \\
-\end{array} \right] }_{\text{ $A$ : $N \times m$  known samples} }
-\left[ \begin{array}{c} 
-\theta_1 \\ \vdots \\ \theta_m
-\end{array} \right]
- = \underbrace{ \left[ \begin{array}{c}  
-b(1) \\ \vdots \\ b(N)\\ 
- \end{array} \right] }_{ \text{ $\underline{b}$: $N$ known samples} } 
+	A \underline{\theta}
+	= \underline{b}
+	\quad\quad\Rightarrow\quad\quad
+	\underbrace{
+		\left[ \begin{array}{c c c c c }
+				   && \underline{\varphi}^T(1) && \\
+				   && \vdots & \\
+				   && \underline{\varphi}^T(N) && \\
+		\end{array} \right] }_{\text{ $A$ : $N \times m$  known samples} }
+	\left[ \begin{array}{c}
+			   \theta_1 \\ \vdots \\ \theta_m
+	\end{array} \right]
+	= \underbrace{ \left[ \begin{array}{c}
+							  b(1) \\ \vdots \\ b(N)\\
+	\end{array} \right] }_{ \text{ $\underline{b}$: $N$ known samples} }
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Pour ensuite utiliser la méthode des moindres-carrés pour obtenir un estimé des paramètres inconnus qui minimise l'erreur avec les mesures expérimentales:
+Pour ensuite utiliser la méthode des moindres carrés pour obtenir une estimation des paramètres inconnus qui minimise l'erreur avec les mesures expérimentales:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{\hat{\theta}}^* &= \operatornamewithlimits{argmin}\limits_{\col{\hat{\theta}}} \left\| A \col{\hat{\theta}} - \col{b} \right\|^2
-= (A^T A)^{-1} A^T \, \col{b}
+	\col{\hat{\theta}}^* &= \operatornamewithlimits{argmin}\limits_{\col{\hat{\theta}}} \left\| A \col{\hat{\theta}} - \col{b} \right\|^2
+	= (A^T A)^{-1} A^T \, \col{b}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 
-\subsection{Exemple de régression linéaire avec les moindres-carrés}
+\subsection{Exemple de régression linéaire avec les moindres carrés}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.5\textwidth]{regression_ex1.png}
-		\includegraphics[width=0.5\textwidth]{regression_ex2.png}
-	\caption{Régression linéaire avec les moindres-carrés pour identifier les paramètres d'une ligne}
+	\includegraphics[width=0.5\textwidth]{regression_ex1.png}
+	\includegraphics[width=0.5\textwidth]{regression_ex2.png}
+	\caption{Régression linéaire avec les moindres carrés pour identifier les paramètres d'une ligne}
 	\label{fig:regression-ex1}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -652,29 +652,29 @@ Pour ensuite utiliser la méthode des moindres-carrés pour obtenir un estimé d
 
 \subsection{Preuve}
 
-La solution des moindres-carrés minimise une fonction coût qui est défini comme le carré de la norme du vecteur d'erreur, qui correspond à la somme des carrés des erreurs individuelles pour chaque sortie du système:
+La solution des moindres carrés minimise une fonction coût qui est définie comme le carré de la norme du vecteur d'erreur, qui correspond à la somme des carrés des erreurs individuelles pour chaque sortie du système:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-J = \left\| \col{e} \right\|^2  = \col{e}^T\col{e} = \sum{ e_i^2}
+	J = \left\| \col{e} \right\|^2  = \col{e}^T\col{e} = \sum{ e_i^2}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 L'erreur est définie comme la différence entre les sorties $\col{y}$ et le résultat du calcul $A \col{\hat{x}}$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{e} = A \col{\hat{x}} - \col{y}
+	\col{e} = A \col{\hat{x}} - \col{y}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 Il est ensuite possible de trouver le minimum de la fonction coût $J$ en trouvant le point pour lequel toutes les dérivées par rapport à $\col{\hat{x}}$ sont nulles:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{0} &= \frac{\partial J}{\partial \col{\hat{x}}} \\
-\col{0} &= \frac{\partial \col{e}^T\col{e}}{\partial \col{\hat{x}}} \\
-\col{0} &= 2 \col{e}^T \frac{\partial e }{\partial \col{\hat{x}}} \\
-\col{0} &= 2 ( A \col{\hat{x}} -\col{y} )^T \frac{\partial (A \col{\hat{x}} -\col{y}) }{\partial \col{\hat{x}}} \\
-\col{0} &= 2 ( A \col{\hat{x}} -\col{y}  )^T A  \\
-\col{0} &=  \col{\hat{x}}^T A^T A  - \col{y}^T A   \\
-A^T \col{y} &= A^T A \col{\hat{x}} \\
-(A^T A)^{-1} A^T \col{y} &= \col{\hat{x}} 
+	\col{0} &= \frac{\partial J}{\partial \col{\hat{x}}} \\
+	\col{0} &= \frac{\partial \col{e}^T\col{e}}{\partial \col{\hat{x}}} \\
+	\col{0} &= 2 \col{e}^T \frac{\partial e }{\partial \col{\hat{x}}} \\
+	\col{0} &= 2 ( A \col{\hat{x}} -\col{y} )^T \frac{\partial (A \col{\hat{x}} -\col{y}) }{\partial \col{\hat{x}}} \\
+	\col{0} &= 2 ( A \col{\hat{x}} -\col{y}  )^T A  \\
+	\col{0} &=  \col{\hat{x}}^T A^T A  - \col{y}^T A   \\
+	A^T \col{y} &= A^T A \col{\hat{x}} \\
+	(A^T A)^{-1} A^T \col{y} &= \col{\hat{x}}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -684,70 +684,70 @@ A^T \col{y} &= A^T A \col{\hat{x}} \\
 
 Given an input-output model with linearly involved parameters:
 \begin{align}
-\underline{\varphi}^T \underline{\theta}
-= y
-\quad\quad\Rightarrow\quad\quad
-\underbrace{ 
-\left[ \begin{array}{c c c } 
-\varphi_1 & ... & \varphi_m
-\end{array} \right] }_{ m \text{ known inputs} }
-\underbrace{ \left[ \begin{array}{c} 
-\theta_1 \\ \vdots \\ \theta_m
-\end{array} \right] }_{ m \text{ unknown parameters} } = 
-\underbrace{y}_{\text{known scalar output} }
+	\underline{\varphi}^T \underline{\theta}
+	= y
+	\quad\quad\Rightarrow\quad\quad
+	\underbrace{
+		\left[ \begin{array}{c c c }
+				   \varphi_1 & ... & \varphi_m
+		\end{array} \right] }_{ m \text{ known inputs} }
+	\underbrace{ \left[ \begin{array}{c}
+							\theta_1 \\ \vdots \\ \theta_m
+	\end{array} \right] }_{ m \text{ unknown parameters} } =
+	\underbrace{y}_{\text{known scalar output} }
 \end{align}
 
 Given an $N$ samples of input-output data:
 \begin{align}
-\Phi^T \underline{\theta}
-= \underline{y}
-\quad\quad\Rightarrow\quad\quad
-\underbrace{ 
-\left[ \begin{array}{c c c c c } 
-&& \underline{\varphi}^T(1) && \\
-&& \vdots & \\
-&& \underline{\varphi}^T(N) && \\
-\end{array} \right] }_{\text{ $\Phi^T$ : $N \times m$  inputs data} }
-\left[ \begin{array}{c} 
-\theta_1 \\ \vdots \\ \theta_m
-\end{array} \right]
- = \underbrace{ \left[ \begin{array}{c}  
- y(1) \\ \vdots \\ y(N)\\ 
- \end{array} \right] }_{ \text{ $\underline{y}$: $N$ output samples} } 
+	\Phi^T \underline{\theta}
+	= \underline{y}
+	\quad\quad\Rightarrow\quad\quad
+	\underbrace{
+		\left[ \begin{array}{c c c c c }
+				   && \underline{\varphi}^T(1) && \\
+				   && \vdots & \\
+				   && \underline{\varphi}^T(N) && \\
+		\end{array} \right] }_{\text{ $\Phi^T$ : $N \times m$  inputs data} }
+	\left[ \begin{array}{c}
+			   \theta_1 \\ \vdots \\ \theta_m
+	\end{array} \right]
+	= \underbrace{ \left[ \begin{array}{c}
+							  y(1) \\ \vdots \\ y(N)\\
+	\end{array} \right] }_{ \text{ $\underline{y}$: $N$ output samples} }
 \end{align}
 
 Column of matrix $\Phi^T$ span a $N$ dimension hyperplane:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\Phi^T = 
-\left[ \begin{array}{c@{}c@{}c}  
-\left[  \begin{array}{c}  \\ \underline{c_1} \\ \\ \end{array} \right] &  \ldots & \left[  \begin{array}{c} \\ \underline{c_m} \\ \\ \end{array} \right]
-\end{array} \right]
+	\Phi^T =
+	\left[ \begin{array}{c@{}c@{}c}
+			   \left[  \begin{array}{c}  \\ \underline{c_1} \\ \\ \end{array} \right] &  \ldots & \left[  \begin{array}{c} \\ \underline{c_m} \\ \\ \end{array} \right]
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Exact solution does not exist when $\underline{y} \notin col( \Phi^T )$, instead we look for an approximation:
 \begin{align}
-\text{Projection Approximation : }
-\Phi^T \hat{\underline{\theta}}= \underline{p}
-\quad\quad\quad
-\text{Error : }
-\underline{e} = \underline{y} - \underline{p}
+	\text{Projection Approximation : }
+	\Phi^T \hat{\underline{\theta}}= \underline{p}
+	\quad\quad\quad
+	\text{Error : }
+	\underline{e} = \underline{y} - \underline{p}
 \end{align}
 The distance between the approximation $\underline{p}$ and $\underline{y}$ is minimal when the error $\underline{e}$ is orthogonal to the column space hyperplane:
 \begin{align}
-\underline{c}_i^T \underline{e}= 0 \quad \forall \, i
-\quad\Rightarrow\quad
-\Phi \underline{e}= \underline{0}
-\quad\Rightarrow\quad
-\Phi ( \, \underline{y} - \Phi^T \hat{\underline{\theta}} \, )= \underline{0}
-\quad\Rightarrow\quad
-\hat{\underline{\theta}} = \left[ \Phi \Phi^T \right]^{-1} \Phi \underline{y}
+	\underline{c}_i^T \underline{e}= 0 \quad \forall \, i
+	\quad\Rightarrow\quad
+	\Phi \underline{e}= \underline{0}
+	\quad\Rightarrow\quad
+	\Phi ( \, \underline{y} - \Phi^T \hat{\underline{\theta}} \, )= \underline{0}
+	\quad\Rightarrow\quad
+	\hat{\underline{\theta}} = \left[ \Phi \Phi^T \right]^{-1} \Phi \underline{y}
 \end{align}
 
 \begin{figure}[htp]
 	\centering
-		\includegraphics[width=0.45\textwidth]{projectionLS.png}
+	\includegraphics[width=0.45\textwidth]{projectionLS.png}
 	\caption{Graphical Visualization of Least Square}
 \end{figure}
 
@@ -764,29 +764,29 @@ The distance between the approximation $\underline{p}$ and $\underline{y}$ is mi
 Lorsqu'un système d'équation linéaire $\col{y} = A \col{x}$ est sous-contraint, c'est-à-dire que plusieurs vecteurs $\col{x}$ sont des solutions, il est possible d'utiliser une matrice pseudo-inverse pour obtenir une solution qui optimise une fonction coût quadratique:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{x}^* &= \operatornamewithlimits{argmin}\limits_{\col{x}} \left( \col{x}^T Q \col{x} \right) \quad \text{subject to} \quad \col{y} = A \col{x}  \\
-\col{x}^* &= Q^{-1} A^T (A Q^{-1} A^T)^{-1} \, \col{y}
+	\col{x}^* &= \operatornamewithlimits{argmin}\limits_{\col{x}} \left( \col{x}^T Q \col{x} \right) \quad \text{subject to} \quad \col{y} = A \col{x}  \\
+	\col{x}^* &= Q^{-1} A^T (A Q^{-1} A^T)^{-1} \, \col{y}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Dans un cas simplifié ou la matrice de poids $Q$ est réduite à une matrice identité on a:
+Dans un cas simplifié où la matrice de poids $Q$ est réduite à une matrice identité on a:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{x}^* &= \operatornamewithlimits{argmin}\limits_{\col{x}} \left\| \col{x} \right\|^2 \quad \text{subject to} \quad \col{y} = A \col{x}  \\
-\col{x}^* &= A^T (A A^T)^{-1} \, \col{y}
+	\col{x}^* &= \operatornamewithlimits{argmin}\limits_{\col{x}} \left\| \col{x} \right\|^2 \quad \text{subject to} \quad \col{y} = A \col{x}  \\
+	\col{x}^* &= A^T (A A^T)^{-1} \, \col{y}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 La matrice $A^T (A A^T)^{-1}$ est souvent appelée inverse droit de Moore–Penrose et notée:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A^{\#} &= A^T (A A^T)^{-1}  \quad \Rightarrow \quad A A^{\#} = I
+	A^{\#} &= A^T (A A^T)^{-1}  \quad \Rightarrow \quad A A^{\#} = I
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est à noter que la matrice $A$ doit avoir des rangés indépendantes pour que la matrice $A A^T$ soit inversible et donc pour pouvoir utiliser la pseudo-inverse droite.
+Il est à noter que la matrice $A$ doit avoir des rangées indépendantes pour que la matrice $A A^T$ soit inversible et donc pour pouvoir utiliser la pseudo-inverse droite.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.75\textwidth]{pseudo-inverse.png}
+	\includegraphics[width=0.75\textwidth]{pseudo-inverse.png}
 	\caption{Système sous-contraint - solution avec matrice pseudo-inverse}
 	\label{fig:pseudo-inverse}
 \end{figure}
@@ -796,14 +796,14 @@ Il est à noter que la matrice $A$ doit avoir des rangés indépendantes pour qu
 
 
 \newpage
-\subsection{Exemple d'utilisation d'un matrice pseudo-inverse}
+\subsection{Exemple d'utilisation d'une matrice pseudo-inverse}
 
-Pour cet exemple, un robot doit produire un force de 14 N sur un mur. Pour y parvenir le courant électrique dans les trois moteurs doit être ajusté. La relation entre la force et le courant dans les moteurs est linéaire et illustrée ci-dessous. On cherche ici une solution qui minimise les pertes joules $ri^2$ dans les moteurs. Comme il y a plusieurs solutions possible pour atteindre le niveau de force désiré, et que la fonction coût à minimiser est quadratique, une matrice pseudo-inverse droite peut être utilisée pour calculer la solution optimale directement, voir Figure \ref{fig:pseudo-inverse-ex1}.
+Pour cet exemple, un robot doit produire une force de 14 N sur un mur. Pour y parvenir, le courant électrique dans les trois moteurs doit être ajusté. La relation entre la force et le courant dans les moteurs est linéaire et illustrée ci-dessous. On cherche ici une solution qui minimise les pertes par effet Joule $ri^2$ dans les moteurs. Comme il y a plusieurs solutions possibles pour atteindre le niveau de force désiré, et que la fonction coût à minimiser est quadratique, une matrice pseudo-inverse droite peut être utilisée pour calculer la solution optimale directement, voir Figure \ref{fig:pseudo-inverse-ex1}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[htbp]
 	\centering
-		\includegraphics[width=0.7\textwidth]{pseudo-inverse-ex1.png}
-		\includegraphics[width=0.5\textwidth]{pseudo-inverse-ex2.png}
+	\includegraphics[width=0.7\textwidth]{pseudo-inverse-ex1.png}
+	\includegraphics[width=0.5\textwidth]{pseudo-inverse-ex2.png}
 	\caption{Exemple d'utilisation d'une matrice pseudo-inverse}
 	\label{fig:pseudo-inverse-ex1}
 \end{figure}
@@ -827,67 +827,67 @@ Pour cet exemple, un robot doit produire un force de 14 N sur un mur. Pour y par
 
 %%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-det(A) = det(U) = p_1 p_2 ... p_n
+	det(A) = det(U) = p_1 p_2 ... p_n
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Vecteurs et valeurs propres (eigen values/vectors)}
+\section{Vecteurs et valeurs propres (eigenvalues/eigenvectors)}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Pour les matrices carrées ($m=n$), une autre caractéristique utile est l'ensemble de ses vecteurs et valeurs propres. Un vecteur $\col{x}$ est un vecteur propre d'une matrice $A$ si le résultat $\col{y} = A \col{x}$ est parallèle à l'entrée $\col{x}$, autrement dit s'il existe un scalaire $\lambda$ (appelé valeur propre) tel que:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A \col{x} = \lambda  \col{x}
+	A \col{x} = \lambda  \col{x}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.85\textwidth]{linalgebra_eigen.png}
+	\includegraphics[width=0.85\textwidth]{linalgebra_eigen.png}
 	\caption{Vecteurs et valeurs propres}
 	\label{fig:eigen}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Une matrice $n \times n$ va avoir $n$ paires de vecteur et valeurs propres (qui peuvent être répété et aussi des nombres complexes). Si une ou plusieurs valeurs propres de la matrice est égale à zéro alors la matrice est singulière et les vecteurs propres associés forme une base du nullspace de la matrice. 
+Une matrice $n \times n$ va avoir $n$ paires de vecteurs et valeurs propres (qui peuvent être répétés et peuvent aussi être des nombres complexes). Si une ou plusieurs valeurs propres de la matrice sont égales à zéro alors la matrice est singulière et les vecteurs propres associés forment une base du nullspace de la matrice.
 
-La trace d'un matrice est égale à la somme des valeurs propres et le déterminant d'une matrice est égale à la multiplication de toutes les valeurs propres:
+La trace d'une matrice est égale à la somme des valeurs propres et le déterminant d'une matrice est égal à la multiplication de toutes les valeurs propres:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-trace(A) &= \sum_1^n{ \lambda_i } \\
-det(A)   &= \prod_1^n{ \lambda_i }
+	trace(A) &= \sum_1^n{ \lambda_i } \\
+	det(A)   &= \prod_1^n{ \lambda_i }
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Pour déterminer les valeurs et vecteurs propres d'une matrice, le problème est posé ainsi:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A \col{x} &= \lambda  \col{x} \\
-(A - \lambda I) \col{x} &= \col{0}
+	A \col{x} &= \lambda  \col{x} \\
+	(A - \lambda I) \col{x} &= \col{0}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-La matrice $(A - \lambda I)$ doit être singulière pour qu'il existe des solutions non-nulles à cette équation. Il est donc possible de trouver les valeurs propres $\lambda_i$ en solutionnant l'équation suivante:
+La matrice $(A - \lambda I)$ doit être singulière pour qu'il existe des solutions non-nulles à cette équation. Il est donc possible de trouver les valeurs propres $\lambda_i$ en résolvant l'équation suivante:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-det(A - \lambda I) = 0
+	det(A - \lambda I) = 0
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Pour chaque solution, i.e pour chaque valeur propre $\lambda_i$, il est possible de déterminer le vecteur propre associé $\col{v}_i$ en déterminant le nullspace de $(A - \lambda I)$:
+Pour chaque solution, c.-à-d. pour chaque valeur propre $\lambda_i$, il est possible de déterminer le vecteur propre associé $\col{v}_i$ en déterminant le nullspace de $(A - \lambda I)$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}_i \in nullspace(A - \lambda I)
+	\col{v}_i \in nullspace(A - \lambda I)
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est à noté que pour chaque valeur propre, le vecteur propre n'est pas unique, seule la direction l'est. Si $\col{v}_i$ est un vecteur propre alors tout multiple de lui même est aussi un vecteur propre. Donc autrement dit pour chaque valeur propre $\lambda_i$, on cherche en fait une base pour l'espace 1D associé aux vecteurs propres de cette valeur.
+Il est à noter que pour chaque valeur propre, le vecteur propre n'est pas unique, seule la direction l'est. Si $\col{v}_i$ est un vecteur propre, alors tout multiple de lui même est aussi un vecteur propre. Autrement dit, pour chaque valeur propre $\lambda_i$, on cherche en fait une base pour l'espace 1D associé aux vecteurs propres de cette valeur.
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.95\textwidth]{linalgebra_eigen_exemple.png}
+	\includegraphics[width=0.95\textwidth]{linalgebra_eigen_exemple.png}
 	\caption{Exemple de vecteurs et valeurs propres dans un contexte de transformations géométriques}
 	\label{fig:linalgebra_eigen_exemple}
 \end{figure}
@@ -900,31 +900,31 @@ Il est à noté que pour chaque valeur propre, le vecteur propre n'est pas uniqu
 Si une matrice a $n$ vecteurs propres indépendants, alors la matrice peut être diagonalisée, c'est à dire décomposée sous la forme:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A = V \Lambda V^{-1}
-\label{eq:diagmatrix}
+	A = V \Lambda V^{-1}
+	\label{eq:diagmatrix}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 où la matrice $V$ regroupe tous les vecteurs propres de $A$, et la matrice diagonale $\Lambda$ toutes les valeurs propres  de $A$:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-V = 
-\left[ \begin{array}{c@{}c@{}c}  
-\left[  \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \left[  \begin{array}{c} \\ \underline{v}_n \\ \\ \end{array} \right]
-\end{array} \right]
-\quad \quad
-\Lambda = 
-\left[ \begin{array}{c c c c}  
-\lambda_1 &  0          & 0 & 0 \\
-0         &  \lambda_2  & 0      & 0 \\
-0         &  0          &\ddots  & 0 \\
-0         &  0          & 0  & \lambda_n
-\end{array} \right]
+	V =
+	\left[ \begin{array}{c@{}c@{}c}
+			   \left[  \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \left[  \begin{array}{c} \\ \underline{v}_n \\ \\ \end{array} \right]
+	\end{array} \right]
+	\quad \quad
+	\Lambda =
+	\left[ \begin{array}{c c c c}
+			   \lambda_1 &  0          & 0 & 0 \\
+			   0         &  \lambda_2  & 0      & 0 \\
+			   0         &  0          &\ddots  & 0 \\
+			   0         &  0          & 0  & \lambda_n
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-Lorsqu'une matrice a plusieurs vecteur propres associés à la même valeur propre alors la matrice n'est pas diagonalisable. Il est toutefois possible de faire appelle à une méthode alternative appelée la réduction de Jordan. 
+Lorsqu'une matrice a plusieurs vecteurs propres associés à la même valeur propre alors la matrice n'est pas diagonalisable. Il est toutefois possible de faire appel à une méthode alternative appelée la réduction de Jordan.
 %
-La diagonalisation d'une matrice peut être interprété comme un changement de base, vers des coordonnées dites propres, pour lesquelles l'effet de la multiplication de cette matrice est indépendant pour chaque axes. 
+La diagonalisation d'une matrice peut être interprétée comme un changement de base, vers des coordonnées dites propres, pour lesquelles l'effet de la multiplication de cette matrice est indépendant pour chaque axe.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -936,32 +936,32 @@ Par définition, si les vecteurs propres $\col{v}_i$ sont multipliés leur matri
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A V = 
-\left[ \begin{array}{c@{}c@{}c}  
-A \left[   \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \; A \left[  \begin{array}{c} \\ \underline{v}_n \\ \\ \end{array} \right]
-\end{array} \right]
-= 
-\left[ \begin{array}{c@{}c@{}c}  
-\lambda_1 \left[   \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \;\lambda_n \left[  \begin{array}{c} \\  \underline{v}_n \\ \\ \end{array} \right]
-\end{array} \right]
-= V \Lambda
+	A V =
+	\left[ \begin{array}{c@{}c@{}c}
+			   A \left[   \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \; A \left[  \begin{array}{c} \\ \underline{v}_n \\ \\ \end{array} \right]
+	\end{array} \right]
+	=
+	\left[ \begin{array}{c@{}c@{}c}
+			   \lambda_1 \left[   \begin{array}{c}  \\ \underline{v}_1 \\ \\ \end{array} \right] &  \ldots & \;\lambda_n \left[  \begin{array}{c} \\  \underline{v}_n \\ \\ \end{array} \right]
+	\end{array} \right]
+	= V \Lambda
 \end{align}
 \label{eq:diagproof}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Ensuite, si la matrice $V$ est inversible (ce qui explique la condition d'indépendance des vecteurs propres pour que la matrice soit diagonalisable), il suffit de multiplier l'équation \eqref{eq:diagmatrix} par $V^{-1}$ par la droite pour obtenir l'équation \eqref{eq:diagmatrix}. 
+Ensuite, si la matrice $V$ est inversible (ce qui explique la condition d'indépendance des vecteurs propres pour que la matrice soit diagonalisable), il suffit de multiplier l'équation \eqref{eq:diagmatrix} par $V^{-1}$ par la droite pour obtenir l'équation \eqref{eq:diagmatrix}.
 
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Exemple de diagonalisation pour une dillatation en 2D}
+\subsection{Exemple de diagonalisation pour une dilatation en 2D}
 \label{sec:ExempleDeDiagonalisationPourUneDillatationEn2D}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.35\textwidth]{linalgebra_diag_exemple.png}
+	\includegraphics[width=0.35\textwidth]{linalgebra_diag_exemple.png}
 	\caption{Exemple de diagonalisation pour une transformation géométrique}
 	\label{fig:linalgebra_diag_exemple}
 \end{figure}
@@ -969,32 +969,32 @@ Ensuite, si la matrice $V$ est inversible (ce qui explique la condition d'indép
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A =
-\left[ \begin{array}{c c}  
-c\theta^2+1     & c\theta s\theta \\
-c\theta s\theta & s\theta^2+1
-\end{array} \right]
-=
-\underbrace{
-\left[ \begin{array}{c c}  
-c\theta & - s\theta \\ 
-s\theta &   c\theta 
-\end{array} \right]
-}_{V}
-\;
-\underbrace{
-\left[ \begin{array}{c c}  
-2 & 0 \\
-0 & 1 
-\end{array} \right]
-}_{\Lambda}
-\;
-\underbrace{
-\left[ \begin{array}{c c}  
-c\theta &   s\theta \\ 
-- s\theta &   c\theta 
-\end{array} \right]
-}_{V^{-1}}
+	A =
+	\left[ \begin{array}{c c}
+			   c\theta^2+1     & c\theta s\theta \\
+			   c\theta s\theta & s\theta^2+1
+	\end{array} \right]
+	=
+	\underbrace{
+		\left[ \begin{array}{c c}
+				   c\theta & - s\theta \\
+				   s\theta &   c\theta
+		\end{array} \right]
+	}_{V}
+	\;
+	\underbrace{
+		\left[ \begin{array}{c c}
+				   2 & 0 \\
+				   0 & 1
+		\end{array} \right]
+	}_{\Lambda}
+	\;
+	\underbrace{
+		\left[ \begin{array}{c c}
+				   c\theta &   s\theta \\
+				   - s\theta &   c\theta
+		\end{array} \right]
+	}_{V^{-1}}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1010,30 +1010,30 @@ c\theta &   s\theta \\
 \section{Puissance d'une matrice}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-La puissance $p$ d'une matrice est définie comme la multiplication répété de $p$ copie de cette matrice. Si la matrice est diagonalisable, la puissance de la matrice $A$ est égale à
+La puissance $p$ d'une matrice est définie comme la multiplication répétée de $p$ copie de cette matrice. Si la matrice est diagonalisable, la puissance de la matrice $A$ est égale à
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A^p = V \Lambda^p V^{-1}
-\label{eq:matrixpower}
+	A^p = V \Lambda^p V^{-1}
+	\label{eq:matrixpower}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 avec:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\Lambda^p = 
-\left[ \begin{array}{c c c c}  
-\lambda_1^p t &  0          & 0 & 0 \\
-0         &  \lambda_2^p  & 0      & 0 \\
-0         &  0          &\ddots  & 0 \\
-0         &  0          & 0  & \lambda_n^p
-\end{array} \right]
+	\Lambda^p =
+	\left[ \begin{array}{c c c c}
+			   \lambda_1^p t &  0          & 0 & 0 \\
+			   0         &  \lambda_2^p  & 0      & 0 \\
+			   0         &  0          &\ddots  & 0 \\
+			   0         &  0          & 0  & \lambda_n^p
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Cette propriété découle de la diagonalisation:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-A^p = A \; A \; \hdots \; A = V \Lambda V^{-1} \; V \Lambda V^{-1} \;  \hdots \; V \Lambda V^{-1} = V \Lambda \Lambda   \hdots \Lambda V^{-1} = V \Lambda^p V^{-1}
+	A^p = A \; A \; \hdots \; A = V \Lambda V^{-1} \; V \Lambda V^{-1} \;  \hdots \; V \Lambda V^{-1} = V \Lambda \Lambda   \hdots \Lambda V^{-1} = V \Lambda^p V^{-1}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1044,166 +1044,166 @@ A^p = A \; A \; \hdots \; A = V \Lambda V^{-1} \; V \Lambda V^{-1} \;  \hdots \;
 La suite de Fibonacci est définie par une séquence de chiffre pour lequel le prochain est la somme des deux précédents:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-0 \; 1\;1\;2\;3\;5\;8\;13\;21\;34\;55
+	0 \; 1\;1\;2\;3\;5\;8\;13\;21\;34\;55
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 Le chiffre suivant est calculé en fonction des deux précédents:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-f_{k+1} = f_{k} + f_{k-1}
+	f_{k+1} = f_{k} + f_{k-1}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-il faut donc un vecteur d'état $\col{x}$ de deux variable ($f_{k}$ et $f_{k-1}$ ) pour prédire le prochain chiffre. L'évolution du vecteur d'état peut être décrite par l'équation matricielle suivante:
+Il faut donc un vecteur d'état $\col{x}$ de deux variable ($f_{k}$ et $f_{k-1}$ ) pour prédire le prochain chiffre. L'évolution du vecteur d'état peut être décrite par l'équation matricielle suivante:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\underbrace{
-\left[ \begin{array}{c}  
-f_{k+1} \\ f_{k}
-\end{array} \right]
-}_{\col{x}_{k+1}}
-=
-\underbrace{
-\left[ \begin{array}{c c}  
-1 & 1 \\ 1 & 0 
-\end{array} \right]
-}_{A}
-\underbrace{
-\left[ \begin{array}{c}  
-f_{k} \\ f_{k-1}
-\end{array} \right]
-}_{\col{x}_{k}}
+	\underbrace{
+		\left[ \begin{array}{c}
+				   f_{k+1} \\ f_{k}
+		\end{array} \right]
+	}_{\col{x}_{k+1}}
+	=
+	\underbrace{
+		\left[ \begin{array}{c c}
+				   1 & 1 \\ 1 & 0
+		\end{array} \right]
+	}_{A}
+	\underbrace{
+		\left[ \begin{array}{c}
+				   f_{k} \\ f_{k-1}
+		\end{array} \right]
+	}_{\col{x}_{k}}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Il est possible de calculer la valeur future d'une évolution discrète comme celle-ci sans calculer toute la séquence grâce la propriété \eqref{eq:matrixpower}:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{x}_{k+1} &= A \col{x}_{k} \\
-\col{x}_{k+2} &= A \col{x}_{k+1} = A A \col{x}_{k} \\
-\col{x}_{k+3} &= A \col{x}_{k+2} = A A A \col{x}_{k} \\
-\col{x}_{k+p} &= A^p \col{x}_{k} = V \Lambda^p V^{-1} \col{x}_{k}
-\label{eq:discretevolutionpower}
+	\col{x}_{k+1} &= A \col{x}_{k} \\
+	\col{x}_{k+2} &= A \col{x}_{k+1} = A A \col{x}_{k} \\
+	\col{x}_{k+3} &= A \col{x}_{k+2} = A A A \col{x}_{k} \\
+	\col{x}_{k+p} &= A^p \col{x}_{k} = V \Lambda^p V^{-1} \col{x}_{k}
+	\label{eq:discretevolutionpower}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 Pour la suite de Fibonacci, la matrice $A$ qui décrit l'évolution peut être diagonalisée. Premièrement on détermine les valeurs propres:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-0
-=
-det(A - \lambda I) 
-=
-det\left(
-\left[ \begin{array}{c c}  
-1-\lambda & 1 \\ 1 & -\lambda  
-\end{array} \right]
-\right)
-= 
-\lambda^2 - \lambda -1 
+	0
+	=
+	det(A - \lambda I)
+	=
+	det\left(
+	\left[ \begin{array}{c c}
+			   1-\lambda & 1 \\ 1 & -\lambda
+	\end{array} \right]
+	\right)
+	=
+	\lambda^2 - \lambda -1
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 Il y a donc deux solutions:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\lambda_1 = \frac{1 + \sqrt{5}}{2} = 1.61803399 \quad\quad \lambda_2 = \frac{1 - \sqrt{5}}{2} = -0.61803399
+	\lambda_1 = \frac{1 + \sqrt{5}}{2} = 1.61803399 \quad\quad \lambda_2 = \frac{1 - \sqrt{5}}{2} = -0.61803399
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-ou la première valeur propre est égale au très fameux nombre d'or. Il est possible de déterminer les vecteurs propres associé en substituant dans l'équation $A \col{v} = \lambda \col{v}$, on trouve alors:
+où la première valeur propre est égale au très fameux nombre d'or. Il est possible de déterminer les vecteurs propres associés en substituant dans l'équation $A \col{v} = \lambda \col{v}$, on trouve alors:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{v}_1 = 
-\left[ \begin{array}{c}  
-\lambda_1 \\ 1
-\end{array} \right]
-\quad\quad 
-\col{v}_2 = 
-\left[ \begin{array}{c}  
-\lambda_2 \\ 1 
-\end{array} \right]
+	\col{v}_1 =
+	\left[ \begin{array}{c}
+			   \lambda_1 \\ 1
+	\end{array} \right]
+	\quad\quad
+	\col{v}_2 =
+	\left[ \begin{array}{c}
+			   \lambda_2 \\ 1
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-Il est donc maintenant possible de calculer n'importe quel position future dans la séquence directement grâce à l'équation \eqref{eq:discretevolutionpower}. Si on cherche la position $p=1E9$ à partir du début de la suite de Fibonacci:
+Il est donc maintenant possible de calculer n'importe quelle position future dans la séquence directement grâce à l'équation \eqref{eq:discretevolutionpower}. Si l'on cherche la position $p=1E9$ à partir du début de la suite de Fibonacci:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\col{x}_{p} &= V \Lambda^p V^{-1} \col{x}_{0} \\
-\left[ \begin{array}{c}  
-f_p \\ f_{p-1}
-\end{array} \right]
-&= 
-\left[ \begin{array}{c c }  
-\lambda_1 & \lambda_2 \\
-1         & 1 \\
-\end{array} \right]
-\left[ \begin{array}{c c }  
-\lambda_1^p & 0 \\
-0         & \lambda_2^p \\
-\end{array} \right]
-\left[ \begin{array}{c c }  
-\lambda_1 & \lambda_2 \\
-1         & 1 \\
-\end{array} \right]^{-1} 
-\left[ \begin{array}{c}  
-1 \\ 0
-\end{array} \right]
+	\col{x}_{p} &= V \Lambda^p V^{-1} \col{x}_{0} \\
+	\left[ \begin{array}{c}
+			   f_p \\ f_{p-1}
+	\end{array} \right]
+	&=
+	\left[ \begin{array}{c c }
+			   \lambda_1 & \lambda_2 \\
+			   1         & 1 \\
+	\end{array} \right]
+	\left[ \begin{array}{c c }
+			   \lambda_1^p & 0 \\
+			   0         & \lambda_2^p \\
+	\end{array} \right]
+	\left[ \begin{array}{c c }
+			   \lambda_1 & \lambda_2 \\
+			   1         & 1 \\
+	\end{array} \right]^{-1}
+	\left[ \begin{array}{c}
+			   1 \\ 0
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-lorsque $p$ est très grand il est possible de simplifier le calcul en négligeant la contribution $\lambda_2^p \approx 0$ puisque lorsque que la valeur absolue de la base est inférieur à l'unité, la puissance tend vers zéro lorsque $p$ tend vers l'infini. Il est donc possible de simplifier:
+lorsque $p$ est très grand il est possible de simplifier le calcul en négligeant la contribution $\lambda_2^p \approx 0$ puisque lorsque que la valeur absolue de la base est inférieure à l'unité, la puissance tend vers zéro lorsque $p$ tend vers l'infini. Il est donc possible de simplifier:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-\left[ \begin{array}{c}  
-f_p \\ f_{p-1}
-\end{array} \right]
-&= 
-\left[ \begin{array}{c c }  
-\lambda_1 & \lambda_2 \\
-1         & 1 \\
-\end{array} \right]
-\left[ \begin{array}{c c }  
-\lambda_1^p & 0 \\
-0         & 0 \\
-\end{array} \right]
-\frac{1}{\lambda_1 - \lambda_2}
-\left[ \begin{array}{c c }  
-1 & -\lambda_2 \\
--1         & \lambda_1 \\
-\end{array} \right] 
-\left[ \begin{array}{c}  
-1 \\ 0
-\end{array} \right]
-\\
-\left[ \begin{array}{c}  
-f_p \\ f_{p-1}
-\end{array} \right]
-&= 
-\left[ \begin{array}{c c}  
-\lambda_1^{p+1} & 0 \\
-\lambda_1^{p}  & 0\\
-\end{array} \right]
-\frac{1}{\lambda_1 - \lambda_2}
-\left[ \begin{array}{c }  
-1  \\
--1   \\
-\end{array} \right] 
-\\
-\left[ \begin{array}{c}  
-f_p \\ f_{p-1}
-\end{array} \right]
-&= 
-\frac{1}{\lambda_1 - \lambda_2}
-\left[ \begin{array}{c}  
-\lambda_1^{p+1}\\
-\lambda_1^{p} \\
-\end{array} \right] 
+	\left[ \begin{array}{c}
+			   f_p \\ f_{p-1}
+	\end{array} \right]
+	&=
+	\left[ \begin{array}{c c }
+			   \lambda_1 & \lambda_2 \\
+			   1         & 1 \\
+	\end{array} \right]
+	\left[ \begin{array}{c c }
+			   \lambda_1^p & 0 \\
+			   0         & 0 \\
+	\end{array} \right]
+	\frac{1}{\lambda_1 - \lambda_2}
+	\left[ \begin{array}{c c }
+			   1 & -\lambda_2 \\
+			   -1         & \lambda_1 \\
+	\end{array} \right]
+	\left[ \begin{array}{c}
+			   1 \\ 0
+	\end{array} \right]
+	\\
+	\left[ \begin{array}{c}
+			   f_p \\ f_{p-1}
+	\end{array} \right]
+	&=
+	\left[ \begin{array}{c c}
+			   \lambda_1^{p+1} & 0 \\
+			   \lambda_1^{p}  & 0\\
+	\end{array} \right]
+	\frac{1}{\lambda_1 - \lambda_2}
+	\left[ \begin{array}{c }
+			   1  \\
+			   -1   \\
+	\end{array} \right]
+	\\
+	\left[ \begin{array}{c}
+			   f_p \\ f_{p-1}
+	\end{array} \right]
+	&=
+	\frac{1}{\lambda_1 - \lambda_2}
+	\left[ \begin{array}{c}
+			   \lambda_1^{p+1}\\
+			   \lambda_1^{p} \\
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%% df
 Il est donc possible de calculer directement la valeur dans la suite pour une positon $p$ lorsque $p$ est très grand:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-f_p = \frac{\lambda_1^{p+1}}{\lambda_1 - \lambda_2} = \frac{1.618^{(p+1)}}{\sqrt{5}}
+	f_p = \frac{\lambda_1^{p+1}}{\lambda_1 - \lambda_2} = \frac{1.618^{(p+1)}}{\sqrt{5}}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Exponentiel de matrice}
+\section{Exponentielle d'une matrice}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 À venir!
@@ -1211,19 +1211,19 @@ f_p = \frac{\lambda_1^{p+1}}{\lambda_1 - \lambda_2} = \frac{1.618^{(p+1)}}{\sqrt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-e^{At} = V e^{\Lambda t} V^{-1}
+	e^{At} = V e^{\Lambda t} V^{-1}
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%    
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{align}
-e^{\Lambda t} = 
-\left[ \begin{array}{c c c c}  
-e^{\lambda_1 t} &  0          & 0 & 0 \\
-0         &  e^{\lambda_2 t}  & 0      & 0 \\
-0         &  0          &\ddots  & 0 \\
-0         &  0          & 0  & e^{\lambda_n t}
-\end{array} \right]
+	e^{\Lambda t} =
+	\left[ \begin{array}{c c c c}
+			   e^{\lambda_1 t} &  0          & 0 & 0 \\
+			   0         &  e^{\lambda_2 t}  & 0      & 0 \\
+			   0         &  0          &\ddots  & 0 \\
+			   0         &  0          & 0  & e^{\lambda_n t}
+	\end{array} \right]
 \end{align}
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1234,21 +1234,22 @@ e^{\lambda_1 t} &  0          & 0 & 0 \\
 
 \subsection{Moindres carrés pour estimer un ratio de transmission}
 
-La figure \ref{fig:exer_ls_gearbox} illustre un boiter de transmission et cinq paires de mesures angulaires à l'entrée et à la sortie. 
+La figure \ref{fig:exer_ls_gearbox} illustre un boitier de transmission et cinq paires de mesures angulaires à l'entrée et à la sortie.
 %%%%%%%%%%%%%%%%%%%%%
 \begin{figure}[H]
 	\centering
-		\includegraphics[width=0.50\textwidth]{exer_ls_gearbox.png}
+	\includegraphics[width=0.50\textwidth]{exer_ls_gearbox.png}
 	\caption{Moindres carrés pour estimer un ratio de transmission}
 	\label{fig:exer_ls_gearbox}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%
 
 \paragraph{A)}
-Construisez le un système d'équation linéaire qui relie ces mesures expérimentales.
+Construisez un système d'équations linéaire qui relie ces mesures expérimentales.
 
 \paragraph{B)}
 Écrivez l'équation matricielle à résoudre pour estimer le ratio de transmission.
 
 \paragraph{C)}
 Effectuer le calcul numérique pour estimer le ratio de transmission.
+


### PR DESCRIPTION
At some places, some additional TODOs were added where I still had some questions, or I couldn't complete on my own.

Additionnaly, the following choice of terms should be addressed in a future version.

* rang plein / plein rang ?
* vecteur colonne / vecteur-colonne -> On dirait que vecteur colonne existe, mais pas avec le tiret
* vecteur ligne / vecteur rangée / vecteur-rangée -> On dirait que c'est vecteur ligne le terme utilisé ailleurs
* Figure / figure -> Lors des références dans le texte
* éq/équation -> Lors des références dans le texte

Since all paragraphs were on one line, the git diff might not be useful to select each change, since there are multiple edits on a same line. If I reformatted the code completely, it would still have changed the complete file.